### PR TITLE
[packages/vue] Fixes bug in product provider get options

### DIFF
--- a/packages/vue/src/providers/ProductProvider.js
+++ b/packages/vue/src/providers/ProductProvider.js
@@ -62,7 +62,7 @@ export default {
           productProvided.value = {
             selectedOptions: null,
             selectedVariant: null,
-            options: getProductOptions({ productObject }),
+            options: getProductOptions({ product: productObject }),
             ...productObject
           };
         }
@@ -109,7 +109,7 @@ export default {
       let selectedVariant = null;
       if (variant) selectedVariant = variant;
       else if (id) {
-        selectedVariant = productProvided.value.variants?.find((variant) => {
+        selectedVariant = productProvided.value.variants?.find(variant => {
           return variant.id === id;
         });
       }
@@ -136,7 +136,7 @@ export default {
      */
     watch(
       productProvided,
-      (value) => {
+      value => {
         context.emit('input', value);
       },
       { immediate: true }
@@ -145,10 +145,10 @@ export default {
     /**
      Update provider with product or productHandle props
      */
-    watch(product, (value) => {
+    watch(product, value => {
       setProduct({ product: value });
     });
-    watch(productHandle, (value) => {
+    watch(productHandle, value => {
       setProduct({ handle: value });
     });
 


### PR DESCRIPTION
**What This PR Does**
- Adds a quick patch `getProductOptions({ productObject })` becomes `getProductOptions({ product: productObject })`
- Minor formatting adjustments on save