### PR TITLE
[starters/nuxt] Add global providers to layout

### DIFF
--- a/starters/nuxt/layouts/default.vue
+++ b/starters/nuxt/layouts/default.vue
@@ -4,16 +4,20 @@
     :space="initialSpace"
     :locale="$config.nacelle.locale"
   >
-    <nuxt />
+    <event-provider>
+      <cart-provider>
+        <nuxt />
+      </cart-provider>
+    </event-provider>
   </space-provider>
 </template>
 
 <script>
 import { inject } from '@nuxtjs/composition-api';
-import { SpaceProvider } from '@nacelle/vue';
+import { SpaceProvider, EventProvider, CartProvider } from '@nacelle/vue';
 
 export default {
-  components: { SpaceProvider },
+  components: { SpaceProvider, EventProvider, CartProvider },
   setup() {
     const initialSpace = inject('initialSpace');
     return { initialSpace };


### PR DESCRIPTION
**What This PR Does**
- Adds global providers to nuxt starter `layouts/default.vue`

**How To Test**
- Pull branch, and run `npm run dev`
- Open devtools and see that the app is wrapped in all 3 global providers: `SpaceProvider`, `EventProvider`, `CartProvider`
