### PR TITLE
small tweak to allow overriding the injected sdk via props

### DIFF
--- a/packages/vue/src/providers/CollectionProvider.js
+++ b/packages/vue/src/providers/CollectionProvider.js
@@ -35,7 +35,7 @@ export default {
      Use sdk from injection or config prop
      */
     let { nacelleSdk } = useSpaceProvider();
-    if (!nacelleSdk || Object.keys(config).length) {
+    if (Object.keys(config).length) {
       nacelleSdk = useSdk({ config });
     }
 
@@ -137,7 +137,7 @@ export default {
      */
     watch(
       collectionProvided,
-      value => {
+      (value) => {
         context.emit('input', value);
       },
       { immediate: true }
@@ -146,10 +146,10 @@ export default {
     /**
      Update provider with collection or collectionHandle props
      */
-    watch(collection, value => {
+    watch(collection, (value) => {
       setCollection({ collection: value });
     });
-    watch(collectionHandle, value => {
+    watch(collectionHandle, (value) => {
       setCollection({ handle: value });
     });
 

--- a/packages/vue/src/providers/ProductProvider.js
+++ b/packages/vue/src/providers/ProductProvider.js
@@ -32,7 +32,7 @@ export default {
      Use sdk from injection or config prop
      */
     let { nacelleSdk } = useSpaceProvider();
-    if (!nacelleSdk || Object.keys(config).length) {
+    if (Object.keys(config).length) {
       nacelleSdk = useSdk({ config });
     }
 
@@ -109,7 +109,7 @@ export default {
       let selectedVariant = null;
       if (variant) selectedVariant = variant;
       else if (id) {
-        selectedVariant = productProvided.value.variants?.find(variant => {
+        selectedVariant = productProvided.value.variants?.find((variant) => {
           return variant.id === id;
         });
       }
@@ -136,7 +136,7 @@ export default {
      */
     watch(
       productProvided,
-      value => {
+      (value) => {
         context.emit('input', value);
       },
       { immediate: true }
@@ -145,10 +145,10 @@ export default {
     /**
      Update provider with product or productHandle props
      */
-    watch(product, value => {
+    watch(product, (value) => {
       setProduct({ product: value });
     });
-    watch(productHandle, value => {
+    watch(productHandle, (value) => {
       setProduct({ handle: value });
     });
 


### PR DESCRIPTION
**What This PR Does**
- Currently the product & collection providers initialize the sdk as follows
```
const config = props.config;

let { nacelleSdk } = useSpaceProvider();
if (!nacelleSdk || Object.keys(config).length) {
  nacelleSdk = useSdk({ config });
}
```
This provides no way to override the sdk via props.  This adjustment ensures if props are present they trump the injected sdk.
```
const config = props.config;

let { nacelleSdk } = useSpaceProvider();
if (Object.keys(config).length) {
  nacelleSdk = useSdk({ config });
}
```