### PR TITLE
[packages/*] Change build target to es2015 for portability

### DIFF
--- a/packages/shopify-checkout/vite.config.js
+++ b/packages/shopify-checkout/vite.config.js
@@ -15,7 +15,7 @@ export const config = {
       treeshake: 'smallest'
     },
     sourcemap: true,
-    target: 'esnext'
+    target: 'es2015'
   },
   plugins: [
     transformTaggedTemplate({

--- a/packages/vue/vite.config.js
+++ b/packages/vue/vite.config.js
@@ -11,11 +11,10 @@ export const config = {
     }
   },
   build: {
-    target: 'esnext',
     lib: {
       entry: path.resolve(__dirname, 'src/index.js'),
       name: 'NacelleVue',
-      fileName: format => `nacelle-vue.${format}.js`,
+      fileName: (format) => `nacelle-vue.${format}.js`,
       formats: ['es', 'umd', 'iife']
     },
     rollupOptions: {
@@ -31,7 +30,8 @@ export const config = {
           '@nacelle/client-js-sdk': 'NacelleClient'
         }
       }
-    }
+    },
+    target: 'es2015'
   }
 };
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Addresses [LD-1187](https://nacelle.atlassian.net/browse/LD-1187)

> As a merchant developer, I want nacelle-js packages to ship es2015-friendly code, so that my frontend framework doesn't need to transpile modules

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR switches `packages/vue` and `packages/shopify-checkout` from `esnext` to `es2015` build outputs.

#### Pros

Eliminates the requirement for frontend projects to transpile `@nacelle/vue` and `@nacelle/shopify-checkout`.

#### Cons

Increases size of most build outputs by ~20%, with the exception of `@nacelle/vue`'s ESM output, which decreases in size:

##### `@nacelle/vue`
<img width="550" alt="nacelle-vue-esnext-es2015" src="https://user-images.githubusercontent.com/5732000/136115254-a9cd1285-fc94-4443-9f71-976c63679c61.png">

##### `@nacelle/shopify-checkout`
<img width="700" alt="nacelle-shopify-checkout-esnext-es2015" src="https://user-images.githubusercontent.com/5732000/136115263-b67fbe15-9b88-47fa-be8b-5013c9ac2dc6.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

1. `npm run boostrap && npm run build` from the monorepo root
2. use either `@nacelle/vue` or `@nacelle/shopify-checkout` in a project
  a. For example, in `starters/nuxt`, use either of these packages without adding the packages to the `build.transpile` array in `nuxt.config.js`.
