### PR TITLE
[packages/*] Add `repository.directory` to package.json

### DIFF
--- a/packages/shopify-checkout/package.json
+++ b/packages/shopify-checkout/package.json
@@ -34,7 +34,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/getnacelle/nacelle-js.git"
+    "url": "git+https://github.com/getnacelle/nacelle-js.git",
+    "directory": "packages/shopify-checkout"
   },
   "scripts": {
     "build": "vite build && tsc && mv dist/src dist/types",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,8 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/getnacelle/nacelle-js.git"
+    "url": "git+https://github.com/getnacelle/nacelle-js.git",
+    "directory": "packages/vue"
   },
   "bugs": {
     "url": "https://github.com/getnacelle/nacelle-js/issues"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Addresses [LD-1189](https://nacelle.atlassian.net/browse/LD-1189)

> Add "repository.directory" to package.json of nacelle-js packages

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR adds [`repository.directory`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository) information to the `package.json` of `packages/*`.

<img width="600" alt="From the npm docs, 'If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives.'" src="https://user-images.githubusercontent.com/5732000/136224662-0e7ba5ea-cea7-4d8e-a136-81e3ff2bdb74.png">

This should make it easier for developers to find the package's code via the GitHub link on npm, bundlephobia, etc., rather than being taken to the monorepo root.
