### PR TITLE
fix: toggleActiveFilters

### DIFF
--- a/packages/vue/src/providers/RefinementProvider.js
+++ b/packages/vue/src/providers/RefinementProvider.js
@@ -297,6 +297,7 @@ export default {
               const index = activeFilter.values.findIndex(
                 (index) => index === value
               );
+
               if (index >= 0) {
                 activeFilter.values.splice(index, 1);
               } else {


### PR DESCRIPTION
While making the PLP for the reference store I found a bug in the refinement provider that removed all filters in array after the targeted filter to remove

