### PR TITLE
fix: conform search provider to warp2 schema

### DIFF
--- a/packages/vue/__tests__/unit/searchProvider.spec.js
+++ b/packages/vue/__tests__/unit/searchProvider.spec.js
@@ -3,21 +3,21 @@ import Fuse from 'fuse.js';
 describe('Simulate & test what the search provider does', () => {
   it('searches through searchData', () => {
     const searchData = [
-      { id: 1, title: 'one' },
-      { id: 2, title: 'two' },
-      { id: 3, title: 'onetwo' }
+      { id: 1, content: { title: 'one' } },
+      { id: 2, content: { title: 'two' } },
+      { id: 3, content: { title: 'onetwo' } }
     ];
     const searchOptions = {
       relevanceThreshold: 0.5,
-      keys: ['title']
+      keys: ['content.title']
     };
     const results = new Fuse(searchData, searchOptions)
       .search(String('one'))
       .filter((result) => typeof result.item !== 'undefined')
       .map((result) => result.item);
     expect(results).toEqual([
-      { id: 1, title: 'one' },
-      { id: 3, title: 'onetwo' }
+      { id: 1, content: { title: 'one' } },
+      { id: 3, content: { title: 'onetwo' } }
     ]);
   });
 });

--- a/packages/vue/src/providers/SearchProvider.js
+++ b/packages/vue/src/providers/SearchProvider.js
@@ -11,7 +11,7 @@ export default {
       type: Object,
       default: () => ({
         relevanceThreshold: 0.5,
-        keys: ['title']
+        keys: ['content.title']
       })
     }
   },


### PR DESCRIPTION
**Ticket**

[LS-1213](https://nacelle.atlassian.net/browse/LS-1213)

**Changes**

conform search provider + testing to warp2 schema

**Testing**

- `git checkout LS-1213--warp2-search-provider`
- `cd packages/vue`
- `npm run test -- searchProvider.spec.js`