### PR TITLE
fix: make product provider compatible with warp2

### DIFF
--- a/packages/vue/__tests__/unit/productProvider.spec.js
+++ b/packages/vue/__tests__/unit/productProvider.spec.js
@@ -15,11 +15,11 @@ const InjectedComponent = {
     'setSelectedOptions',
     'setSelectedVariant'
   ],
-  render: h => h('div')
+  render: (h) => h('div')
 };
 
 const ProductProviderContainer = ({ props } = {}) => ({
-  render: h =>
+  render: (h) =>
     h(SpaceProvider, {}, [
       h(ProductProvider, { props }, [h(InjectedComponent)])
     ])
@@ -50,8 +50,8 @@ describe('Product Provider', () => {
     const injectedProductComponent = productProvider.findComponent({
       name: 'InjectedWithProduct'
     });
-    expect(injectedProductComponent.vm.product.value.handle).toEqual(
-      productData.handle
+    expect(injectedProductComponent.vm.product.value.content.handle).toEqual(
+      productData.content.handle
     );
   });
 
@@ -61,15 +61,15 @@ describe('Product Provider', () => {
     }));
     const productProvider = await mount(
       ProductProviderContainer({
-        props: { productHandle: productData.handle }
+        props: { productHandle: productData.content.handle }
       })
     );
     const injectedProductComponent = productProvider.findComponent({
       name: 'InjectedWithProduct'
     });
-    await new Promise(resolve => setTimeout(() => resolve(true)));
-    expect(injectedProductComponent.vm.product.value.handle).toEqual(
-      productData.handle
+    await new Promise((resolve) => setTimeout(() => resolve(true)));
+    expect(injectedProductComponent.vm.product.value.content.handle).toEqual(
+      productData.content.handle
     );
   });
 
@@ -81,8 +81,8 @@ describe('Product Provider', () => {
     jest.spyOn(injectedProductComponent.vm, 'setProduct');
     injectedProductComponent.vm.setProduct({ product: productData });
     expect(injectedProductComponent.vm.setProduct).toHaveBeenCalledTimes(1);
-    expect(injectedProductComponent.vm.product.value.handle).toEqual(
-      productData.handle
+    expect(injectedProductComponent.vm.product.value.content.handle).toEqual(
+      productData.content.handle
     );
   });
 
@@ -96,11 +96,11 @@ describe('Product Provider', () => {
     });
     jest.spyOn(injectedProductComponent.vm, 'setProduct');
     await injectedProductComponent.vm.setProduct({
-      handle: productData.handle
+      handle: productData.content.handle
     });
     expect(injectedProductComponent.vm.setProduct).toHaveBeenCalledTimes(1);
-    expect(injectedProductComponent.vm.product.value.handle).toEqual(
-      productData.handle
+    expect(injectedProductComponent.vm.product.value.content.handle).toEqual(
+      productData.content.handle
     );
   });
 
@@ -121,8 +121,8 @@ describe('Product Provider', () => {
     expect(injectedProductComponent.vm.product.value.selectedOptions).toEqual(
       productData.variants[0].selectedOptions
     );
-    expect(injectedProductComponent.vm.product.value.handle).toEqual(
-      productData.handle
+    expect(injectedProductComponent.vm.product.value.content.handle).toEqual(
+      productData.content.handle
     );
   });
 
@@ -141,8 +141,8 @@ describe('Product Provider', () => {
       injectedProductComponent.vm.setSelectedVariant
     ).toHaveBeenCalledTimes(1);
     expect(
-      injectedProductComponent.vm.product.value.selectedVariant.handle
-    ).toEqual(productData.variants[0].handle);
+      injectedProductComponent.vm.product.value.selectedVariant.productHandle
+    ).toEqual(productData.variants[0].productHandle);
   });
 
   it('it calls setSelectedVariant with variant id', () => {
@@ -154,13 +154,13 @@ describe('Product Provider', () => {
     });
     jest.spyOn(injectedProductComponent.vm, 'setSelectedVariant');
     injectedProductComponent.vm.setSelectedVariant({
-      id: productData.variants[0].id
+      sourceEntryId: productData.variants[0].sourceEntryId
     });
     expect(
       injectedProductComponent.vm.setSelectedVariant
     ).toHaveBeenCalledTimes(1);
     expect(
-      injectedProductComponent.vm.product.value.selectedVariant.handle
-    ).toEqual(productData.variants[0].handle);
+      injectedProductComponent.vm.product.value.selectedVariant.productHandle
+    ).toEqual(productData.variants[0].productHandle);
   });
 });

--- a/packages/vue/mocks/product.js
+++ b/packages/vue/mocks/product.js
@@ -1,23 +1,450 @@
 export default {
-  handle: 'shirt',
-  id: 'shirt-1',
-  options: [{ name: 'color', values: ['blue', 'red'] }],
+  availableForSale: true,
+  content: {
+    createdAt: null,
+    fields: null,
+    handle: 'aurora-high-tops',
+    locale: 'en-US',
+    nacelleEntryId:
+      'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9DT05URU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBMelE1TVRVMk5UUXpOakV5TWpNPS9lbi1VUw==',
+    published: true,
+    title: 'Aurora High Tops',
+    updatedAt: null,
+    indexedAt: 1637098847,
+    description:
+      '<p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts. Separated they live in Bookmarksgrove right at the coast of the Semantics, a large language ocean.</p>',
+    featuredMedia: {
+      altText: 'Aurora High Tops',
+      id: null,
+      mimeType: null,
+      src:
+        'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+      thumbnailSrc:
+        'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+      type: 'IMAGE'
+    },
+    media: [
+      {
+        altText: 'Aurora High Tops',
+        id: null,
+        mimeType: null,
+        src:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+        thumbnailSrc:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+        type: 'IMAGE'
+      },
+      {
+        altText: null,
+        id: null,
+        mimeType: null,
+        src:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/photo-1578116922645-3976907a7671.jpg?v=1603301445',
+        thumbnailSrc:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/photo-1578116922645-3976907a7671.jpg?v=1603301445&width=100',
+        type: 'IMAGE'
+      },
+      {
+        altText: null,
+        id: null,
+        mimeType: null,
+        src:
+          'https://cdn.shopify.com/videos/c/vp/5fa35f129ce3480fa015f96e9b7e632b/5fa35f129ce3480fa015f96e9b7e632b.SD-480p-1.5Mbps.mp4',
+        thumbnailSrc:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/5fa35f129ce3480fa015f96e9b7e632b.thumbnail.0000000.jpg?v=1597266642&width=100',
+        type: 'VIDEO'
+      },
+      {
+        altText: null,
+        id: null,
+        mimeType: null,
+        src: 'https://youtu.be/xTT7hpetEBk',
+        thumbnailSrc:
+          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/hqdefault.jpg?v=1603301428&width=100',
+        type: 'VIDEO'
+      }
+    ],
+    metafields: null,
+    options: [
+      {
+        name: 'Size',
+        values: ['7', '8', '9', '10', '11', '12']
+      }
+    ],
+    productEntryId:
+      'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+    sourceEntryId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzQ5MTU2NTQzNjEyMjM='
+  },
+  createdAt: 1587622,
+  indexedAt: 1637098847,
+  metafields: [],
+  nacelleEntryId:
+    'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+  productType: 'Shoes',
+  sourceEntryId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzQ5MTU2NTQzNjEyMjM=',
+  tags: ['footwear', 'men'],
+  updatedAt: null,
+  vendor: 'Prairie Wind Apparel',
   variants: [
     {
-      id: 'shirt-v-1',
-      name: 'blue-shirt',
-      selectedOptions: [
-        { name: 'color', value: 'blue' },
-        { name: 'size', value: 'large' }
-      ]
+      availableForSale: true,
+      compareAtPrice: null,
+      createdAt: null,
+      indexedAt: 1637098847,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZ3dPREF3Tnc9PS9lbi1VUw==',
+      price: 170,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '11223344',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTgwODAwNw==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRnd09EQXdOdz09L2VuLVVT',
+        indexedAt: 1637098847,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '7'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTgwODAwNw==',
+        swatchSrc: null,
+        title: '7',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZ3dPREF3Tnc9PS9lbi1VUw=='
+      }
     },
     {
-      id: 'shirt-v-2',
-      name: 'red-shirt',
-      selectedOptions: [
-        { name: 'color', value: 'red' },
-        { name: 'size', value: 'small' }
-      ]
+      availableForSale: false,
+      compareAtPrice: null,
+      createdAt: null,
+      indexedAt: 1637098847,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZzBNRGMzTlE9PS9lbi1VUw==',
+      price: 170,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '22334455',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTg0MDc3NQ==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRnME1EYzNOUT09L2VuLVVT',
+        indexedAt: 1637098847,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '8'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTg0MDc3NQ==',
+        swatchSrc: null,
+        title: '8',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZzBNRGMzTlE9PS9lbi1VUw=='
+      }
+    },
+    {
+      availableForSale: true,
+      compareAtPrice: 170,
+      createdAt: null,
+      indexedAt: 1637098847,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZzNNelUwTXc9PS9lbi1VUw==',
+      price: 160,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '33445566',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTg3MzU0Mw==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRnM016VTBNdz09L2VuLVVT',
+        indexedAt: 1637098848,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '9'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTg3MzU0Mw==',
+        swatchSrc: null,
+        title: '9',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UZzNNelUwTXc9PS9lbi1VUw=='
+      }
+    },
+    {
+      availableForSale: true,
+      compareAtPrice: null,
+      createdAt: null,
+      indexedAt: 1637098848,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5Ua3dOak14TVE9PS9lbi1VUw==',
+      price: 170,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '44556677',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTkwNjMxMQ==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRrd05qTXhNUT09L2VuLVVT',
+        indexedAt: 1637098848,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '10'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTkwNjMxMQ==',
+        swatchSrc: null,
+        title: '10',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5Ua3dOak14TVE9PS9lbi1VUw=='
+      }
+    },
+    {
+      availableForSale: true,
+      compareAtPrice: null,
+      createdAt: null,
+      indexedAt: 1637098848,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5Ua3pPVEEzT1E9PS9lbi1VUw==',
+      price: 170,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '55667788',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTkzOTA3OQ==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRrek9UQTNPUT09L2VuLVVT',
+        indexedAt: 1637098848,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '11'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTkzOTA3OQ==',
+        swatchSrc: null,
+        title: '11',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5Ua3pPVEEzT1E9PS9lbi1VUw=='
+      }
+    },
+    {
+      availableForSale: true,
+      compareAtPrice: null,
+      createdAt: null,
+      indexedAt: 1637098848,
+      metafields: [],
+      nacelleEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UazNNVGcwTnc9PS9lbi1VUw==',
+      price: 170,
+      priceCurrency: 'USD',
+      priceRules: [],
+      productEntryId:
+        'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+      productHandle: 'aurora-high-tops',
+      quantityAvailable: null,
+      sku: '66778899',
+      sourceEntryId:
+        'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTk3MTg0Nw==',
+      updatedAt: null,
+      weight: null,
+      weightUnit: null,
+      content: {
+        createdAt: null,
+        description: null,
+        featuredMedia: {
+          altText: 'Aurora High Tops',
+          id: null,
+          mimeType: null,
+          src:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579',
+          thumbnailSrc:
+            'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/black-hightop-LED-shoes.jpg?v=1587622579&width=100',
+          type: 'IMAGE'
+        },
+        fields: '{}',
+        nacelleEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UX0NPTlRFTlQvWjJsa09pOHZjMmh2Y0dsbWVTOVFjbTlrZFdOMFZtRnlhV0Z1ZEM4ek9UTTFORGs0TlRrM01UZzBOdz09L2VuLVVT',
+        indexedAt: 1637098849,
+        locale: 'en-US',
+        media: null,
+        metafields: [],
+        productEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVC9aMmxrT2k4dmMyaHZjR2xtZVM5UWNtOWtkV04wTHpRNU1UVTJOVFF6TmpFeU1qTT0vZW4tVVM=',
+        published: true,
+        selectedOptions: [
+          {
+            label: null,
+            name: 'Size',
+            value: '12'
+          }
+        ],
+        sourceEntryId:
+          'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zOTM1NDk4NTk3MTg0Nw==',
+        swatchSrc: null,
+        title: '12',
+        updatedAt: null,
+        variantEntryId:
+          'aWQ6Ly9DVVNUT00vY3VzdG9tL2RlZmF1bHQvUFJPRFVDVF9WQVJJQU5UL1oybGtPaTh2YzJodmNHbG1lUzlRY205a2RXTjBWbUZ5YVdGdWRDOHpPVE0xTkRrNE5UazNNVGcwTnc9PS9lbi1VUw=='
+      }
     }
   ]
 };

--- a/packages/vue/src/providers/ProductProvider.js
+++ b/packages/vue/src/providers/ProductProvider.js
@@ -99,18 +99,18 @@ export default {
      * @param {Object} variant Variant object selected
      * @param {String} id Variant id selected
      */
-    const setSelectedVariant = ({ variant, id }) => {
-      if (!variant && !id) {
+    const setSelectedVariant = ({ variant, sourceEntryId }) => {
+      if (!variant && !sourceEntryId) {
         console.warn(
-          "[nacelle] ProductProvider's `setSelectedVariant` method requires a `variant` or `id` parameter."
+          "[nacelle] ProductProvider's `setSelectedVariant` method requires a `variant` or `sourceEntryId` parameter."
         );
         return;
       }
       let selectedVariant = null;
       if (variant) selectedVariant = variant;
-      else if (id) {
+      else if (sourceEntryId) {
         selectedVariant = productProvided.value.variants?.find((variant) => {
-          return variant.id === id;
+          return variant.sourceEntryId === sourceEntryId;
         });
       }
       if (selectedVariant) {


### PR DESCRIPTION
**Ticket**

https://nacelle.atlassian.net/browse/LS-1212

**Changes**

make product provider, tests and mock compatible with warp2

**Testing**

- `git checkout LS-1213--warp2-product-provider`
- `cd packages/vue`
- `npm run test -- productProvider.spec.js`
