### PR TITLE
chore: adds typecheck for string

### DIFF
--- a/packages/shopify-checkout/src/utils/metafieldsToCustomAttributes.ts
+++ b/packages/shopify-checkout/src/utils/metafieldsToCustomAttributes.ts
@@ -17,7 +17,9 @@ export default function metafieldsToCustomAttributes({
   }
 
   const customAttributes: Attribute[] = metafields?.reduce((fields, m) => {
-    fields.push({ key: m.key, value: m.value });
+    if (typeof m.value === 'string') {
+      fields.push({ key: m.key, value: m.value });
+    }
 
     return fields;
   }, [] as Attribute[]);

--- a/packages/shopify-checkout/src/utils/metafieldsToCustomAttributes.ts
+++ b/packages/shopify-checkout/src/utils/metafieldsToCustomAttributes.ts
@@ -19,6 +19,10 @@ export default function metafieldsToCustomAttributes({
   const customAttributes: Attribute[] = metafields?.reduce((fields, m) => {
     if (typeof m.value === 'string') {
       fields.push({ key: m.key, value: m.value });
+    } else {
+      console.warn(
+        `Omitting custom attribute "${m.key}" because it has a non-string value.`
+      );
     }
 
     return fields;


### PR DESCRIPTION
**What This PR Does**
- ensures shopifyCheckout package only passes through `checkoutAttributes` with values that are strings

**Testing**
- `npm run test:ci`

**Notes**
- the `Attribute` and `Metafield` types were left unchanged intentionally so that typescript users would still get type errors if the values passed weren't strings.  The caveat is that there is no test against passing in other values.  Another approach where types are updated can be seen on this branch: 
https://github.com/getnacelle/nacelle-js/tree/LS-1306--null-checkout-attrs