### PR TITLE
fix(starters/gatsby): remove duplicate layout component

### DIFF
--- a/starters/gatsby/gatsby-browser.js
+++ b/starters/gatsby/gatsby-browser.js
@@ -17,7 +17,7 @@ export const wrapPageElement = ({ element, props }) => (
 export const wrapRootElement = ({ element }) => (
   <CartProvider>
     <CheckoutProvider checkoutClient={checkoutClient}>
-      <Layout>{element}</Layout>
+      {element}
     </CheckoutProvider>
   </CartProvider>
 );


### PR DESCRIPTION
**What This PR Does**
- removes `Layout` component from `wrapRootElement` so it doesn't render twice