### PR TITLE
chore: new graphql fragments

### DIFF
--- a/packages/shopify-checkout/src/graphql/fragments/index.ts
+++ b/packages/shopify-checkout/src/graphql/fragments/index.ts
@@ -1,0 +1,82 @@
+import { gql } from '../../utils';
+
+const lineItem = gql`
+  fragment CheckoutLineItem_lineItem on CheckoutLineItem {
+    customAttributes {
+      key
+      value
+    }
+    discountAllocations {
+      allocatedAmount {
+        amount
+        currencyCode
+      }
+    }
+    id
+    quantity
+    title
+    unitPrice {
+      amount
+      currencyCode
+    }
+    variant {
+      id
+    }
+  }
+`;
+
+const discountApplication = gql`
+  fragment DiscountApplication_discountApplication on DiscountApplication {
+    allocationMethod
+    targetSelection
+    targetType
+    ... on ScriptDiscountApplication {
+      title
+    }
+    value {
+      ... on MoneyV2 {
+        amount
+        currencyCode
+      }
+      ... on PricingPercentageValue {
+        percentage
+      }
+    }
+  }
+`;
+
+const checkout = gql`
+  fragment Checkout_checkout on Checkout {
+    id
+    webUrl
+    lineItems(first: 100) {
+      edges {
+        node {
+          ...CheckoutLineItem_lineItem
+        }
+      }
+    }
+    discountApplications(first: 100) {
+      edges {
+        node {
+          ...DiscountApplication_discountApplication
+        }
+      }
+    }
+  }
+  ${lineItem}
+  ${discountApplication}
+`;
+
+const userErrors = gql`
+  fragment CheckoutUserError_checkoutUserErrors on CheckoutUserError {
+    code
+    field
+    message
+  }
+`;
+
+export default {
+  CHECKOUT: checkout,
+  USER_ERRORS: userErrors
+};

--- a/packages/shopify-checkout/src/graphql/fragments/index.ts
+++ b/packages/shopify-checkout/src/graphql/fragments/index.ts
@@ -68,8 +68,8 @@ const checkout = gql`
   ${discountApplication}
 `;
 
-const userErrors = gql`
-  fragment CheckoutUserError_checkoutUserErrors on CheckoutUserError {
+const userError = gql`
+  fragment CheckoutUserError_checkoutUserError on CheckoutUserError {
     code
     field
     message
@@ -78,5 +78,5 @@ const userErrors = gql`
 
 export default {
   CHECKOUT: checkout,
-  USER_ERRORS: userErrors
+  USER_ERROR: userError
 };

--- a/packages/shopify-checkout/src/graphql/mutations/index.ts
+++ b/packages/shopify-checkout/src/graphql/mutations/index.ts
@@ -19,12 +19,12 @@ export const checkoutCreate = gql`
         ...Checkout_checkout
       }
       checkoutUserErrors {
-        ...CheckoutUserError_checkoutUserErrors
+        ...CheckoutUserError_checkoutUserError
       }
     }
   }
   ${fragments.CHECKOUT}
-  ${fragments.USER_ERRORS}
+  ${fragments.USER_ERROR}
 `;
 
 export interface CheckoutLineItemsReplaceData {
@@ -44,12 +44,12 @@ export const checkoutLineItemsReplace = gql`
         ...Checkout_checkout
       }
       userErrors {
-        ...CheckoutUserError_checkoutUserErrors
+        ...CheckoutUserError_checkoutUserError
       }
     }
   }
   ${fragments.CHECKOUT}
-  ${fragments.USER_ERRORS}
+  ${fragments.USER_ERROR}
 `;
 
 export interface CheckoutAttributesUpdateData {
@@ -69,12 +69,12 @@ export const checkoutAttributesUpdate = gql`
         ...Checkout_checkout
       }
       checkoutUserErrors {
-        ...CheckoutUserError_checkoutUserErrors
+        ...CheckoutUserError_checkoutUserError
       }
     }
   }
   ${fragments.CHECKOUT}
-  ${fragments.USER_ERRORS}
+  ${fragments.USER_ERROR}
 `;
 
 export const checkoutDiscountCodeApplyV2 = gql`
@@ -90,12 +90,12 @@ export const checkoutDiscountCodeApplyV2 = gql`
         ...Checkout_checkout
       }
       checkoutUserErrors {
-        ...CheckoutUserError_checkoutUserErrors
+        ...CheckoutUserError_checkoutUserError
       }
     }
   }
   ${fragments.CHECKOUT}
-  ${fragments.USER_ERRORS}
+  ${fragments.USER_ERROR}
 `;
 
 export interface CheckoutDiscountCodeApplyV2Data {
@@ -112,12 +112,12 @@ export const checkoutDiscountCodeRemove = gql`
         ...Checkout_checkout
       }
       checkoutUserErrors {
-        ...CheckoutUserError_checkoutUserErrors
+        ...CheckoutUserError_checkoutUserError
       }
     }
   }
   ${fragments.CHECKOUT}
-  ${fragments.USER_ERRORS}
+  ${fragments.USER_ERROR}
 `;
 
 export interface CheckoutDiscountCodeRemoveData {

--- a/packages/shopify-checkout/src/graphql/mutations/index.ts
+++ b/packages/shopify-checkout/src/graphql/mutations/index.ts
@@ -3,6 +3,7 @@ import {
   ShopifyCheckoutUserError,
   ShopifyCheckoutResponseProperties
 } from '../../checkout-client.types';
+import fragments from '../fragments';
 
 export interface CheckoutCreateData {
   checkoutCreate: {
@@ -15,16 +16,15 @@ export const checkoutCreate = gql`
   mutation checkoutCreate($input: CheckoutCreateInput!) {
     checkoutCreate(input: $input) {
       checkout {
-        id
-        webUrl
+        ...Checkout_checkout
       }
       checkoutUserErrors {
-        code
-        field
-        message
+        ...CheckoutUserError_checkoutUserErrors
       }
     }
   }
+  ${fragments.CHECKOUT}
+  ${fragments.USER_ERRORS}
 `;
 
 export interface CheckoutLineItemsReplaceData {
@@ -41,16 +41,15 @@ export const checkoutLineItemsReplace = gql`
   ) {
     checkoutLineItemsReplace(lineItems: $lineItems, checkoutId: $checkoutId) {
       checkout {
-        id
-        webUrl
+        ...Checkout_checkout
       }
       userErrors {
-        code
-        field
-        message
+        ...CheckoutUserError_checkoutUserErrors
       }
     }
   }
+  ${fragments.CHECKOUT}
+  ${fragments.USER_ERRORS}
 `;
 
 export interface CheckoutAttributesUpdateData {
@@ -67,16 +66,15 @@ export const checkoutAttributesUpdate = gql`
   ) {
     checkoutAttributesUpdateV2(checkoutId: $checkoutId, input: $input) {
       checkout {
-        id
-        webUrl
+        ...Checkout_checkout
       }
       checkoutUserErrors {
-        code
-        field
-        message
+        ...CheckoutUserError_checkoutUserErrors
       }
     }
   }
+  ${fragments.CHECKOUT}
+  ${fragments.USER_ERRORS}
 `;
 
 export const checkoutDiscountCodeApplyV2 = gql`
@@ -89,16 +87,15 @@ export const checkoutDiscountCodeApplyV2 = gql`
       discountCode: $discountCode
     ) {
       checkout {
-        id
-        webUrl
+        ...Checkout_checkout
       }
       checkoutUserErrors {
-        code
-        field
-        message
+        ...CheckoutUserError_checkoutUserErrors
       }
     }
   }
+  ${fragments.CHECKOUT}
+  ${fragments.USER_ERRORS}
 `;
 
 export interface CheckoutDiscountCodeApplyV2Data {
@@ -112,16 +109,15 @@ export const checkoutDiscountCodeRemove = gql`
   mutation checkoutDiscountCodeRemove($checkoutId: ID!) {
     checkoutDiscountCodeRemove(checkoutId: $checkoutId) {
       checkout {
-        id
-        webUrl
+        ...Checkout_checkout
       }
       checkoutUserErrors {
-        code
-        field
-        message
+        ...CheckoutUserError_checkoutUserErrors
       }
     }
   }
+  ${fragments.CHECKOUT}
+  ${fragments.USER_ERRORS}
 `;
 
 export interface CheckoutDiscountCodeRemoveData {

--- a/packages/shopify-checkout/src/graphql/queries/index.ts
+++ b/packages/shopify-checkout/src/graphql/queries/index.ts
@@ -1,5 +1,6 @@
 import { gql } from '../../utils';
 import { GqlStringField } from '../../checkout-client.types';
+import fragments from '../fragments';
 
 export interface CheckoutNode {
   id: GqlStringField;
@@ -15,10 +16,9 @@ export const getCheckout = gql`
   query getCheckout($id: ID!) {
     node(id: $id) {
       ... on Checkout {
-        id
-        webUrl
-        completedAt
+        ...Checkout_checkout
       }
     }
   }
+  ${fragments.CHECKOUT}
 `;


### PR DESCRIPTION
**What this PR does**
- ticket: [LS-1547](https://nacelle.atlassian.net/browse/LS-1547)
- adds new gql fragments for `lineItem`, `discountApplication`, `checkout`, `userError`
- uses fragments to queries and mutations

**Notes**
I think this is what was intended by ticket.  If not happy to make updates.  This ticket was simply to get the fragments in repo.  It is not intended to be the full update.  That is handled by: [LS-1548](https://nacelle.atlassian.net/browse/LS-1548)