### PR TITLE
fix(gatsby-source-nacelle): replace field key

### DIFF
--- a/packages/gatsby-source-nacelle/src/type-defs/index.js
+++ b/packages/gatsby-source-nacelle/src/type-defs/index.js
@@ -3,7 +3,7 @@ type CollectionContent @dontInfer {
   collectionEntryId: ID!
   createdAt: Int
   description: String
-  fields: JSON
+  remoteFields: JSON
   handle: String
   indexedAt: Int
   locale: String
@@ -133,7 +133,7 @@ type ProductContent @dontInfer {
   createdAt: Int
   description: String
   featuredMedia: Media
-  fields: JSON
+  remoteFields: JSON
   handle: String
   indexedAt: Int
   locale: String
@@ -204,7 +204,7 @@ type VariantContent @dontInfer {
   createdAt: Int
   description: String
   featuredMedia: Media
-  fields: JSON
+  remoteFields: JSON
   indexedAt: Int
   locale: String
   media: [Media!]

--- a/packages/gatsby-source-nacelle/src/utils/replaceKey.js
+++ b/packages/gatsby-source-nacelle/src/utils/replaceKey.js
@@ -6,15 +6,29 @@
  * @param {string} keyMappings[].newKey - the property to replace with
  * @returns {Object} New object with updated properties
  */
-module.exports = function (obj, keyMappings) {
+function replaceKey(obj, keyMappings) {
   const o = { ...obj };
   try {
     for (const { oldKey, newKey } of keyMappings) {
       delete Object.assign(o, { [newKey]: o[oldKey] })[oldKey];
     }
 
+    for (const [key, value] of Object.entries(o)) {
+      if (value && Array.isArray(value)) {
+        value.forEach((item, index) => {
+          if (item && typeof item === 'object') {
+            o[key][index] = replaceKey(o[key][index], keyMappings);
+          }
+        });
+      } else if (value && typeof value === 'object') {
+        o[key] = replaceKey(o[key], keyMappings);
+      }
+    }
+
     return o;
   } catch (err) {
     throw new Error(err);
   }
-};
+}
+
+module.exports = replaceKey;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[LS-1583](https://nacelle.atlassian.net/browse/LS-1583)] <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

- Renames `fields` to `remoteFields` for `CollectionContent`, `ProductContent`, and `VariantContent` types.
- Updates `replaceKey` to recursively search for keys.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

Easiest way to test would probably be with the Gatsby Starter.
- In `starters/gatsby` add a `.env` file with the following (This space has content fields set up for Product, Variant, and Collection content. However, do to an [issue](https://nacelle.atlassian.net/browse/ENG-4140), this will be returned as stringified JSON): 
```
# Nacelle
GATSBY_NACELLE_STOREFRONT_TOKEN=979f5597-6b7d-46df-8429-b8ac474eb9d2
GATSBY_NACELLE_STOREFRONT_ENDPOINT=https://storefront.api.development.nacelle.com/graphql/v1/spaces/ckyaffo3m1654353oyzztyzelhh
GATSBY_NACELLE_STOREFRONT_LOCALE="en-US"

# Shopify Checkout (for details, see: https://www.npmjs.com/package/@nacelle/shopify-checkout)
GATSBY_MYSHOPIFY_DOMAIN=pepper-wood-apparel
GATSBY_SHOPIFY_STOREFRONT_CHECKOUT_TOKEN=477e3f771eb126e58db487428cd34948
GATSBY_SHOPIFY_STOREFRONT_API_VERSION=2021-10
``` 
- Run `npm run develop`
- Open the Graphiql provided by Gatsby, typically at `http://localhost:8000/___graphql` and query for the `remoteFields` on `NacelleProduct` (plus variants) and `NacelleProduct` collection. 
- Alternative method: Utilize the Storefront SDK `.after` method to provide `content.fields` data. For example, in `starters/gatsby/gatsby-config.js`:
```js
const client = new NacelleClient({
  storefrontEndpoint: process.env.GATSBY_NACELLE_STOREFRONT_ENDPOINT,
  token: process.env.GATSBY_NACELLE_STOREFRONT_TOKEN
});

client.after('products', (products) => {
  return products.map((product) => ({
    ...product,
    content: {
      ...product.content,
      fields: { productTest: 'true' }
    },
    variants: product.variants.map((variant, index) => {
      return {
        ...variant,
        content: {
          ...variant.content,
          fields: { variantIndex: `${index}` }
        }
      };
    })
  }));
});
```