### PR TITLE
fix(shopify-checkout): accept checkout IDs that start with letter

### DIFF
--- a/packages/shopify-checkout/__tests__/mocks/index.ts
+++ b/packages/shopify-checkout/__tests__/mocks/index.ts
@@ -17,14 +17,22 @@ export const clientSettings = {
 
 export const graphqlEndpoint = `https://${clientSettings.myshopifyDomain}.myshopify.com/api/2022-01/graphql`;
 
-const checkoutUuidWithKey = '998877?key=123123';
-export const checkoutId = Buffer.from(
-  'gid://shopify/Checkout/' + checkoutUuidWithKey
-).toString('base64');
+const checkoutUuids = {
+  beginsWithLetter: 'a9b8c7?key=123123',
+  beginsWithNumber: '998877?key=123123'
+};
+export const checkoutIds = {
+  beginsWithLetter: Buffer.from(
+    'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter
+  ).toString('base64'),
+  beginsWithNumber: Buffer.from(
+    'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
+  ).toString('base64')
+};
 
 export const webUrl =
   'https://nacelle-swag-store.myshopify.com/112233/checkouts/' +
-  checkoutUuidWithKey;
+  checkoutUuids.beginsWithLetter;
 
 export const discountCode = 'BFCM2020';
 
@@ -75,7 +83,7 @@ interface Checkouts {
 }
 
 export const emptyCheckout: ShopifyCheckoutResponseProperties = {
-  id: checkoutId,
+  id: checkoutIds.beginsWithLetter,
   webUrl,
   completedAt: null,
   lineItems: { edges: [] },

--- a/packages/shopify-checkout/src/client/actions/discount.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/discount.spec.ts
@@ -7,7 +7,7 @@ import * as mutations from '../../graphql/mutations';
 import { mockJsonResponse } from '../../../__tests__/utils';
 import {
   clientSettings,
-  checkoutId,
+  checkoutIds,
   checkouts,
   discountCode,
   shopifyErrors,
@@ -35,7 +35,7 @@ describe('discount', () => {
     await expect(
       applyDiscount({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         discountCode
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
@@ -58,7 +58,7 @@ describe('discount', () => {
     await expect(
       removeDiscount({
         gqlClient,
-        id: checkoutId
+        id: checkoutIds.beginsWithLetter
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
       buildCheckout(
@@ -77,14 +77,14 @@ describe('discount', () => {
     expect.assertions(2);
 
     // [1/2] `applyDiscount`
-    await expect(applyDiscount({ gqlClient, id: checkoutId })).rejects.toThrow(
-      networkErrorMessage
-    );
+    await expect(
+      applyDiscount({ gqlClient, id: checkoutIds.beginsWithLetter })
+    ).rejects.toThrow(networkErrorMessage);
 
     // [2/2] `removeDiscount`
-    await expect(removeDiscount({ gqlClient, id: checkoutId })).rejects.toThrow(
-      networkErrorMessage
-    );
+    await expect(
+      removeDiscount({ gqlClient, id: checkoutIds.beginsWithLetter })
+    ).rejects.toThrow(networkErrorMessage);
   });
 
   it('throws an error if an invalid `id` is provided', async () => {
@@ -128,7 +128,7 @@ describe('discount', () => {
 
     applyDiscount({
       gqlClient,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       discountCode
     }).catch((e) =>
       expect(String(e).includes(checkoutDoesNotExistError.message)).toBe(true)
@@ -144,7 +144,7 @@ describe('discount', () => {
 
     removeDiscount({
       gqlClient,
-      id: checkoutId
+      id: checkoutIds.beginsWithLetter
     }).catch((e) =>
       expect(String(e).includes(checkoutDoesNotExistError.message)).toBe(true)
     );

--- a/packages/shopify-checkout/src/client/actions/findCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/findCheckout.spec.ts
@@ -2,12 +2,13 @@
 import fetchClient from 'cross-fetch';
 import { mocked } from 'ts-jest/utils';
 import { findCheckout } from '../../client/actions';
+import { ShopifyCheckout } from '../../checkout-client.types';
 import { createGqlClient } from '../../utils';
 import * as queries from '../../graphql/queries';
 import { mockJsonResponse } from '../../../__tests__/utils';
 import {
   clientSettings,
-  checkoutId,
+  checkoutIds,
   checkouts,
   webUrl,
   graphqlEndpoint,
@@ -30,9 +31,11 @@ describe('findCheckout', () => {
     );
 
     await expect(
-      findCheckout({ gqlClient, id: checkoutId }).then((checkout) => checkout)
+      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
+        (checkout) => checkout
+      )
     ).resolves.toMatchObject({
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -44,7 +47,7 @@ describe('findCheckout', () => {
       headers,
       body: JSON.stringify({
         query: queries.getCheckout,
-        variables: { id: checkoutId }
+        variables: { id: checkoutIds.beginsWithLetter }
       })
     });
   });
@@ -61,8 +64,8 @@ describe('findCheckout', () => {
     );
 
     await expect(
-      findCheckout({ gqlClient, id: checkoutId }).then(
-        (checkout) => checkout?.completed
+      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
+        (checkout) => (checkout as ShopifyCheckout)?.completed
       )
     ).resolves.toBe(false);
   });
@@ -78,8 +81,8 @@ describe('findCheckout', () => {
         mockJsonResponse<queries.GetCheckoutData>(checkoutResponse)
     );
     await expect(
-      findCheckout({ gqlClient, id: checkoutId }).then(
-        (checkout) => checkout?.completed
+      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
+        (checkout) => (checkout as ShopifyCheckout)?.completed
       )
     ).resolves.toBe(true);
   });
@@ -92,9 +95,9 @@ describe('findCheckout', () => {
     );
 
     expect.assertions(1);
-    await expect(findCheckout({ gqlClient, id: checkoutId })).rejects.toThrow(
-      networkErrorMessage
-    );
+    await expect(
+      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter })
+    ).rejects.toThrow(networkErrorMessage);
   });
 
   it("throws an error if the checkout can't be found", async () => {
@@ -108,10 +111,11 @@ describe('findCheckout', () => {
     );
 
     expect.assertions(1);
-    await findCheckout({ gqlClient, id: checkoutId }).catch((e) =>
-      expect(
-        String(e).includes('[findCheckout] Checkout response has no data')
-      ).toBe(true)
+    await findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).catch(
+      (e) =>
+        expect(
+          String(e).includes('[findCheckout] Checkout response has no data')
+        ).toBe(true)
     );
   });
 
@@ -130,8 +134,8 @@ describe('findCheckout', () => {
     );
 
     expect.assertions(1);
-    await findCheckout({ gqlClient, id: checkoutId }).catch((e) =>
-      expect(String(e).includes(problemMessage)).toBe(true)
+    await findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).catch(
+      (e) => expect(String(e).includes(problemMessage)).toBe(true)
     );
   });
 });

--- a/packages/shopify-checkout/src/client/actions/putCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/putCheckout.spec.ts
@@ -13,7 +13,7 @@ import { mockJsonResponse } from '../../../__tests__/utils';
 import {
   cartItems,
   clientSettings,
-  checkoutId,
+  checkoutIds,
   checkouts,
   graphqlEndpoint,
   headers,
@@ -148,7 +148,7 @@ describe('putCheckout', () => {
     const note = 'Happy Birthday!';
 
     const checkoutUpdate = checkouts.checkoutUpdate({
-      checkoutId,
+      checkoutId: checkoutIds.beginsWithLetter,
       input: { customAttributes, note }
     });
 
@@ -167,7 +167,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         customAttributes,
         note
       }).then((checkout) => checkout)
@@ -182,7 +182,7 @@ describe('putCheckout', () => {
       body: JSON.stringify({
         query: mutations.checkoutAttributesUpdate,
         variables: {
-          checkoutId,
+          checkoutId: checkoutIds.beginsWithLetter,
           input: {
             customAttributes,
             note
@@ -194,7 +194,7 @@ describe('putCheckout', () => {
 
   it("updates an existing checkout's line items", async () => {
     const checkoutLineItemsReplace = checkouts.checkoutLineItemsReplace({
-      checkoutId,
+      checkoutId: checkoutIds.beginsWithLetter,
       lineItems: newCartItems
     });
 
@@ -212,7 +212,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         lineItems: newCartItems
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
@@ -228,7 +228,7 @@ describe('putCheckout', () => {
       body: JSON.stringify({
         query: mutations.checkoutLineItemsReplace,
         variables: {
-          checkoutId,
+          checkoutId: checkoutIds.beginsWithLetter,
           lineItems: newCartItems
         }
       })
@@ -258,7 +258,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         note: 'Happy Birthday!'
       })
     ).rejects.toThrow(networkErrorMessage);
@@ -267,7 +267,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         lineItems: newCartItems
       })
     ).rejects.toThrow(networkErrorMessage);
@@ -359,7 +359,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         note: 'Happy Birthday!'
       }).catch((e) =>
         expect(String(e).includes(doesNotExistMessage)).toBe(true)
@@ -377,7 +377,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         lineItems: newCartItems
       }).catch((e) =>
         expect(String(e).includes(doesNotExistMessage)).toBe(true)
@@ -406,7 +406,7 @@ describe('putCheckout', () => {
 
     await putCheckout({
       gqlClient,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       note: 'Happy Birthday!'
     }).catch((e) => expect(String(e).includes(problemMessage)).toBe(true));
 
@@ -420,7 +420,7 @@ describe('putCheckout', () => {
 
     await putCheckout({
       gqlClient,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       lineItems: newCartItems
     }).catch((e) => expect(String(e).includes(problemMessage)).toBe(true));
   });

--- a/packages/shopify-checkout/src/client/client-dom.spec.ts
+++ b/packages/shopify-checkout/src/client/client-dom.spec.ts
@@ -11,7 +11,7 @@ import {
   cartItems,
   checkouts,
   clientSettings,
-  checkoutId,
+  checkoutIds,
   graphqlEndpoint,
   headers,
   webUrl
@@ -78,7 +78,7 @@ describe('createShopifyCheckoutClient', () => {
         mockJsonResponse<queries.GetCheckoutData>({
           data: {
             node: {
-              id: checkoutId,
+              id: checkoutIds.beginsWithLetter,
               webUrl,
               completedAt: null,
               lineItems: { edges: [] },
@@ -92,7 +92,7 @@ describe('createShopifyCheckoutClient', () => {
       checkoutClient.get({ id: '998877' }).then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -120,7 +120,7 @@ describe('createShopifyCheckoutClient', () => {
         mockJsonResponse<queries.GetCheckoutData>({
           data: {
             node: {
-              id: checkoutId,
+              id: checkoutIds.beginsWithLetter,
               webUrl: customEndointCheckoutUrl,
               completedAt: null,
               lineItems: { edges: [] },
@@ -134,7 +134,7 @@ describe('createShopifyCheckoutClient', () => {
       checkoutClient.get({ id: '998877' }).then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: customEndointCheckoutUrl,
       lines: [],
       discounts: []
@@ -168,7 +168,7 @@ describe('createShopifyCheckoutClient', () => {
         .then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -197,7 +197,7 @@ describe('createShopifyCheckoutClient', () => {
 
     // providing `cartItems` without `metafields` or `note` should only run `checkoutLineItemsReplace`
     const checkoutLineItemsReplace = checkouts.checkoutLineItemsReplace({
-      checkoutId,
+      checkoutId: checkoutIds.beginsWithLetter,
       lineItems: cartItemsToCheckoutItems({ cartItems })
     });
 
@@ -207,7 +207,10 @@ describe('createShopifyCheckoutClient', () => {
           checkoutLineItemsReplace
         )
     );
-    await checkoutClient.process({ id: checkoutId, cartItems });
+    await checkoutClient.process({
+      id: checkoutIds.beginsWithLetter,
+      cartItems
+    });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
     expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
@@ -216,7 +219,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutLineItemsReplace,
         variables: {
-          checkoutId,
+          checkoutId: checkoutIds.beginsWithLetter,
           lineItems: cartItemsToCheckoutItems({ cartItems })
         }
       })
@@ -238,7 +241,7 @@ describe('createShopifyCheckoutClient', () => {
     ];
     const note = 'Many thanks!';
     const checkoutUpdate = checkouts.checkoutUpdate({
-      checkoutId,
+      checkoutId: checkoutIds.beginsWithLetter,
       input: { customAttributes: checkoutAttributes, note }
     });
 
@@ -248,7 +251,7 @@ describe('createShopifyCheckoutClient', () => {
     );
 
     await checkoutClient.process({
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       metafields: checkoutAttributes,
       note
     });
@@ -260,7 +263,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutAttributesUpdate,
         variables: {
-          checkoutId,
+          checkoutId: checkoutIds.beginsWithLetter,
           input: {
             customAttributes: checkoutAttributes,
             note
@@ -285,12 +288,12 @@ describe('createShopifyCheckoutClient', () => {
 
     await expect(
       checkoutClient.discountApply({
-        id: checkoutId,
+        id: checkoutIds.beginsWithLetter,
         discountCode: 'BFCM2020'
       })
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -303,7 +306,7 @@ describe('createShopifyCheckoutClient', () => {
         query: mutations.checkoutDiscountCodeApplyV2,
         variables: {
           input: {
-            checkoutId,
+            checkoutId: checkoutIds.beginsWithLetter,
             discountCode: 'BFCM2020'
           }
         }
@@ -326,11 +329,11 @@ describe('createShopifyCheckoutClient', () => {
 
     await expect(
       checkoutClient.discountRemove({
-        id: checkoutId
+        id: checkoutIds.beginsWithLetter
       })
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutId,
+      id: checkoutIds.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -343,7 +346,7 @@ describe('createShopifyCheckoutClient', () => {
         query: mutations.checkoutDiscountCodeRemove,
         variables: {
           input: {
-            checkoutId
+            checkoutId: checkoutIds.beginsWithLetter
           }
         }
       })

--- a/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.spec.ts
+++ b/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.spec.ts
@@ -1,20 +1,21 @@
 import { isVerifiedCheckoutId } from '../utils';
-import { checkoutId } from '../../__tests__/mocks';
+import { checkoutIds } from '../../__tests__/mocks';
 
 describe('handleShopifyError', () => {
   it('returns `true` when provided a valid Shopify checkout ID', async () => {
-    expect(isVerifiedCheckoutId(checkoutId)).toBe(true);
+    expect(isVerifiedCheckoutId(checkoutIds.beginsWithLetter)).toBe(true);
+    expect(isVerifiedCheckoutId(checkoutIds.beginsWithNumber)).toBe(true);
   });
 
   it('returns `false` when provided a non-base64 Shopify checkout ID', async () => {
     expect(
-      isVerifiedCheckoutId('gid://shopify/Checkout/998877?key=123123')
+      isVerifiedCheckoutId('gid://shopify/Checkout/a9b8c7?key=123123')
     ).toBe(false);
   });
 
   it("returns `false` when provided a base64 string that doesn't correspond to a Shopify checkout ID", async () => {
     const invalidId = Buffer.from(
-      'gid://definitely-not-shopify/Checkout/998877?key=123123'
+      'gid://definitely-not-shopify/Checkout/a9b8c7?key=123123'
     ).toString('base64');
 
     expect(isVerifiedCheckoutId(invalidId)).toBe(false);

--- a/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts
+++ b/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts
@@ -1,9 +1,9 @@
 export default function isVerifiedCheckoutId(id: string): boolean {
   // Shopify CheckoutIds are Base64-encoded urls formatted like:
-  // 'gid://shopify/Checkout/<id>' and therefore must include 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC8'
+  // 'gid://shopify/Checkout/<id>' and therefore must include 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC'
   if (!id?.length) {
     return false;
   }
 
-  return id.includes('Z2lkOi8vc2hvcGlmeS9DaGVja291dC8') && id !== '';
+  return id.includes('Z2lkOi8vc2hvcGlmeS9DaGVja291dC') && id !== '';
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [ENG-4354](https://nacelle.atlassian.net/browse/ENG-4354)

> @nacelle/shopify-checkout is erroneously reporting checkout ids as invalid

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

Our validation of Shopify checkout IDs in `packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts` was not accounting for an aspect of Base64 encoding.

Notice how in the following example, when the Checkout ID starts with a letter, the Base64-encoded string has a trailing `1dC9`, whereas the absence of a Checkout ID or a Checkout ID that starts with a number has a trailing `1dC8`:

<img width="455" alt="base64 encoding shopify checkout example" src="https://user-images.githubusercontent.com/5732000/158489113-3ae371b3-539e-4776-979e-3ed5a7f48a84.png">

Because we used `'Z2lkOi8vc2hvcGlmeS9DaGVja291dC8'` as a comparison string, the `isVerifiedCheckoutId` utility was incorrectly returning `false` when a Checkout ID began with a letter.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR changes `isVerifiedCheckoutId`'s comparison string to `'Z2lkOi8vc2hvcGlmeS9DaGVja291dC'` (it removes the trailing `8`), so that Checkout IDs that start with either letters or numbers are returned as `true`. It also add and updates the appropriate tests to account for both cases.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

- Check out the `fix/ENG-4354--nacelle-shopify-checkout-isVerifiedCheckoutId` branch
- `cd packages/shopify-checkout`
- `npm run test:ci` (all tests should pass)
<img width="700" alt="nacelle-js fix:ENG-4354--nacelle-shopify-checkout-isVerifiedCheckoutId all tests passing" src="https://user-images.githubusercontent.com/5732000/158490000-01f48685-a2ac-4842-bb62-83309cffc152.png">

- `npm run build` (it should build all outputs without errors)
<img width="700" alt="nacelle-js fix:ENG-4354--nacelle-shopify-checkout-isVerifiedCheckoutId build outputs" src="https://user-images.githubusercontent.com/5732000/158490010-b477204b-3e2c-41cf-97fe-95cda4db858e.png">

