### PR TITLE
feat(gatsby-source-nacelle): adds pagination to product collections query

### DIFF
--- a/packages/gatsby-source-nacelle/gatsby-node.js
+++ b/packages/gatsby-source-nacelle/gatsby-node.js
@@ -1,5 +1,10 @@
 const sourceNodes = require('./src/source-nodes');
 const typeDefs = require('./src/type-defs');
+const {
+  allProductCollectionsEntriesQuery,
+  allProductCollectionsQuery
+} = require('./src/queries');
+const { paginateEntries, paginateQuery } = require('./src/utils');
 
 exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
@@ -29,7 +34,22 @@ exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
     client.spaceProperties(),
     client.navigation(),
     client.products(),
-    client.productCollections(),
+    client
+      .query({
+        query: allProductCollectionsQuery
+      })
+      .then((response) => {
+        return paginateQuery(
+          client,
+          allProductCollectionsQuery,
+          response.allProductCollections
+        );
+      })
+      .then((response) => {
+        return Promise.all(
+          paginateEntries(client, allProductCollectionsEntriesQuery, response)
+        );
+      }),
     client.content(),
     client.contentCollections()
   ]).catch((err) => {
@@ -61,7 +81,12 @@ exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
     sourceNodes({
       gatsbyApi,
       pluginOptions,
-      data: productCollectionData,
+      data: productCollectionData.map((collection) => ({
+        ...collection,
+        products: collection.productConnection.edges.map(
+          (product) => product.node
+        )
+      })),
       dataType: 'ProductCollection'
     }),
     sourceNodes({

--- a/packages/gatsby-source-nacelle/src/queries/index.js
+++ b/packages/gatsby-source-nacelle/src/queries/index.js
@@ -1,0 +1,2 @@
+exports.allProductCollectionsQuery = require('./product-collections');
+exports.allProductCollectionsEntriesQuery = require('./product-collections-entries');

--- a/packages/gatsby-source-nacelle/src/queries/product-collections-entries.js
+++ b/packages/gatsby-source-nacelle/src/queries/product-collections-entries.js
@@ -1,0 +1,23 @@
+module.exports = `query allProductCollections(
+  $filter: ProductCollectionFilterInput
+  $after: String
+) {
+  allProductCollections(filter: $filter) {
+    edges {
+      node {
+        nacelleEntryId
+        productConnection(after: $after) {
+          edges {
+            node {
+              nacelleEntryId
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+}`;

--- a/packages/gatsby-source-nacelle/src/queries/product-collections.js
+++ b/packages/gatsby-source-nacelle/src/queries/product-collections.js
@@ -1,0 +1,66 @@
+module.exports = `query allProductCollections(
+  $filter: ProductCollectionFilterInput
+) {
+  allProductCollections(filter: $filter) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        createdAt
+        indexedAt
+        metafields {
+          id
+          key
+          namespace
+          value
+        }
+        nacelleEntryId
+        sourceEntryId
+        sourceId
+        tags
+        updatedAt
+        content {
+          collectionEntryId
+          createdAt
+          description
+          featuredMedia {
+            altText
+            id
+            mimeType
+            src
+            thumbnailSrc
+            type
+          }
+          fields
+          handle
+          indexedAt
+          locale
+          metafields {
+            id
+            key
+            namespace
+            value
+          }
+          nacelleEntryId
+          sourceEntryId
+          sourceId
+          title
+          updatedAt
+        }
+        productConnection {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          edges {
+            node {
+              nacelleEntryId
+            }
+          }
+        }
+      }
+    }
+  }
+}`;

--- a/packages/gatsby-source-nacelle/src/utils/index.js
+++ b/packages/gatsby-source-nacelle/src/utils/index.js
@@ -2,4 +2,6 @@ exports.cacheIsInvalid = require('./cacheIsInvalid');
 exports.cmsPreviewEnabled = require('./cmsPreviewEnabled');
 exports.createRemoteImageFileNode = require('./createRemoteImageFileNode');
 exports.hasBeenIndexedSinceLastBuild = require('./checkIndexTimestamp');
+exports.paginateQuery = require('./paginateQuery');
+exports.paginateEntries = require('./paginateEntries');
 exports.replaceKey = require('./replaceKey');

--- a/packages/gatsby-source-nacelle/src/utils/paginateEntries.js
+++ b/packages/gatsby-source-nacelle/src/utils/paginateEntries.js
@@ -1,0 +1,33 @@
+module.exports = function (client, query, collections) {
+  return collections.map(async (collection) => {
+    const key = Object.keys(collection.node).find((key) => {
+      return collection.node[key]?.edges;
+    });
+    let edges = collection.node[key].edges;
+    let hasNextPage = collection.node[key].pageInfo.hasNextPage;
+    let endCursor = collection.node[key].pageInfo.endCursor;
+
+    while (hasNextPage) {
+      const response = await client.query({
+        query,
+        variables: JSON.stringify({
+          filter: {
+            nacelleEntryIds: [collection.node.nacelleEntryId]
+          },
+          after: endCursor
+        })
+      });
+
+      const paginatedCollection = Object.values(response)[0].edges[0];
+      edges = edges.concat(paginatedCollection.node[key].edges);
+      hasNextPage = paginatedCollection.node[key].pageInfo.hasNextPage;
+      endCursor = paginatedCollection.node[key].pageInfo.endCursor;
+    }
+
+    collection.node[key] = {
+      edges
+    };
+
+    return collection.node;
+  });
+};

--- a/packages/gatsby-source-nacelle/src/utils/paginateQuery.js
+++ b/packages/gatsby-source-nacelle/src/utils/paginateQuery.js
@@ -1,0 +1,22 @@
+module.exports = async function (client, query, data) {
+  let edges = data.edges;
+  let hasNextPage = data.pageInfo.hasNextPage;
+  let endCursor = data.pageInfo.endCursor;
+
+  while (hasNextPage) {
+    const response = await client.query({
+      query,
+      variables: JSON.stringify({
+        filter: {
+          after: endCursor
+        }
+      })
+    });
+    const responseData = Object.values(response)[0];
+    hasNextPage = responseData.pageInfo.hasNextPage;
+    endCursor = responseData.pageInfo.endCursor;
+    edges = edges.concat(responseData.edges);
+  }
+
+  return edges;
+};


### PR DESCRIPTION
Fixes [[ENG-4723](https://nacelle.atlassian.net/browse/ENG-4723)] <!-- link to Jira or Github issue if one exists -->

- Collection queries were not returning all products assigned to collections.

### WHAT is this pull request doing?

- Replaces the use of the `productCollections` SDK method with a custom query using the `query` SDK method.
- Requests more collections if there are more to be fetched.
- Requests more collection products if there are more to be fetched.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

- Run `npm run bootstrap` in the root directory.
- Update the `.env` file in `starters/gatsby` OR use your own Gatsby project (will require `npm link`ing the `gatsby-source-nacelle` package).
- To test with project that experienced this issue, see the ticket above for credentials, otherwise provide one of our reference stores.