### PR TITLE
chore: close search autocomplete on enter

### DIFF
--- a/reference-stores/nuxt/components/search/SearchInput.vue
+++ b/reference-stores/nuxt/components/search/SearchInput.vue
@@ -110,6 +110,7 @@ export default {
       });
     },
     handleEnter(event) {
+      this.isFocussed = false;
       this.$router.push({ path: `/search?q=${this.query}` });
       event.target.blur();
     }


### PR DESCRIPTION
**What This PR Does**
Ensures the search autocomplete dropdown closes on enter keypress.  

**How To Test**
Spin up this branch.  Enter some search terms in search input and hit enter.  The autocomplete dropdown should close