### PR TITLE
fix: log empty node types instead of claiming they're cached

### DIFF
--- a/packages/gatsby-source-nacelle/src/source-nodes/index.js
+++ b/packages/gatsby-source-nacelle/src/source-nodes/index.js
@@ -179,6 +179,10 @@ module.exports = async function ({
         console.info(
           `[gatsby-source-nacelle] created ${newNodeCount} new ${dataType} nodes`
         );
+      } else if (!formattedData.length) {
+        console.info(
+          `[gatsby-source-nacelle] no ${dataType} data present, skipping node creation`
+        );
       } else {
         console.info(
           `[gatsby-source-nacelle] using cached ${dataType} nodes from previous build`


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Fixes [ENG-5388](https://nacelle.atlassian.net/browse/ENG-5388) - Fixes the issue in Gatsby Source Nacelle where empty Nacelle Node types were being logged as cached. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

- If no nodes were added and the content is empty, logs that no nodes were created.

## How to Test

This is an abridged set of instructions adapted from #138

1. Checkout `mdarrik/ENG-5388-console-statements-mistakenly-claim-cached-nodes`
2. navigate to an existing gatsby repo using `gatsby-source-nacelle` or this repo's starter with a `.env` file that points to a space with empty types (navigation or contentCollection are commonly empty)
   1. For this repo's starter, make sure you run `npm run bootstrap` at the root of this repo first to install dependencies
3. Run a clean `npm run clean`
4. Run a build `npm run build` - should see a log with something like `info [gatsby-source-nacelle] no NavigationGroup data present, skipping node creation` & no cached nodes
5. Run a second build shortly/immediately after. Should see the same `info [gatsby-source-nacelle] no NavigationGroup data present, skipping node creation` & using cached nodes for other nodes