### PR TITLE
chore: dependabot build fix

### DIFF
--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - edited
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   pull-request-health-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -8,7 +8,7 @@ on:
       - edited
 
 permissions:
-  issues: write
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -1,7 +1,7 @@
 name: pull-request-health-checks
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🩺 Perform Pull Request Health Checks
+        if: github.actor != 'dependabot-bot'
         uses: aslafy-z/conventional-pr-title-action@v2.2.5
         with:
           success-state: Title follows the specification.

--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -1,15 +1,11 @@
 name: pull-request-health-checks
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - edited
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   pull-request-health-checks:


### PR DESCRIPTION
## What This PR Does

Adds a conditional to `pr-health-checks` to not run if the PR was opened by dependabot.  This should fix the failing workflows on dependabot PRs

## How To Test

This line of code has been added to a failing [dependabot PR](https://github.com/getnacelle/nacelle-js/pull/130).  The `pr-health-checks` job is no longer running.  You can ignore the other failing job, it is resolved in future PRs.

<img width="815" alt="Screen Shot 2022-05-12 at 10 26 03 AM" src="https://user-images.githubusercontent.com/24395931/168098633-dae18f56-f939-4068-b3e7-23f4548357db.png">
