### PR TITLE
fix(shopify-checkout): correctly include checkoutUserErrors in error handling on checkoutCreate

### DIFF
--- a/packages/shopify-checkout/src/client/actions/checkoutCreate.ts
+++ b/packages/shopify-checkout/src/client/actions/checkoutCreate.ts
@@ -49,7 +49,7 @@ export default async function createCheckout({
     const errs = errors || data?.checkoutCreate.checkoutUserErrors;
 
     if (errs?.length) {
-      handleShopifyError(errors, { caller: 'checkoutCreate' });
+      handleShopifyError(errs, { caller: 'checkoutCreate' });
     }
 
     if (data?.checkoutCreate.checkout) {


### PR DESCRIPTION


<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Fixes [ENG-5496](https://nacelle.atlassian.net/browse/ENG-5496) - bug where `checkoutCreate`'s checkoutUserErrors were not getting passed to the error handling. This caused the error message to not include why the error was thrown. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Fixes the bug where `checkoutUserErrors` weren't getting passed to the handleShopifyError logic in `checkoutCreate`
2. Adds tests to put checkout for handling a generic `errors` response, and a generic mutation-specific error (which is a child of `data` in the response) for each of the possible mutations triggered by `putCheckout`. 
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## How to Test

1. Run `npm run test:ci` in the `packages/shopify-checkout` folder. All tests should pass.
