### PR TITLE
feat(gatsby-source-nacelle): stringify rich text nodes

### DIFF
--- a/packages/gatsby-source-nacelle/src/utils/linkNestedContentReferences.js
+++ b/packages/gatsby-source-nacelle/src/utils/linkNestedContentReferences.js
@@ -9,8 +9,11 @@ function findNestedReferences(contentObject = {}, parent = null, key) {
       // delete the contentObject from the parent so that it doesn't conflict
       // with the node link
       delete parent[key];
+    } else if (contentObject[0]?._type === 'block') {
+      // if the array's entry type is block, it's a Sanity Portable (Rich) Text block, so stringify it to JSON so it's easy to fetch
+      parent[key] = JSON.stringify(contentObject);
     } else {
-      // if not a reference, look for references in each part of the array instead
+      // if not a reference & not Sanity rich text, look for references in each part of the array instead
       Object.entries(contentObject).map(([key, value]) =>
         findNestedReferences(value, contentObject, key)
       );
@@ -22,6 +25,9 @@ function findNestedReferences(contentObject = {}, parent = null, key) {
         `${key}___NODE`
       ] = `NacelleContent-${contentObject.nacelleEntryId}`;
       delete parent[key];
+      // if we've stringified  the rich text, don't keep traversing the object since it's now a string
+    } else if (contentObject.nodeType === 'document') {
+      parent[key] = JSON.stringify(contentObject);
     } else {
       // otherwise keep traversing, looking for more references
       Object.entries(contentObject).map(([key, value]) =>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-5390](https://nacelle.atlassian.net/browse/ENG-5390) - Improves Rich Text handling in Gatsby Source Nacelle 9.0 <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Adds checks for Sanity & Contentful Rich Text during nested content linking & stringifies the rich text data. This makes it easier to query for rich text without needing to rewrite the queries when content changes. 

Note that this currently only applies to Rich text in `NacelleContent` since we're not currently traversing/linking other Nacelle Entry Types.


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## How to Test

1. Checkout this branch (`mdarrik/ENG-5390-gatsby-source-nacelle-rich-text-fields` or run `gh pr checkout 158` if using [GH CLI](https://cli.github.com))
2. Install deps if you haven't already using `npm run lerna bootstrap`
3. Navigate to `starters/gatsby` and fill the `.env` info with a Nacelle Contentful space that has Rich Text
4. Run `npm run develop` in that folder, and use the Gatsby GraphiQL package to query for your rich text content, should be a string entry with a JSON representation of the rich text
5. Replace the env values with a Nacelle Sanity space and repeat step 4 above. (Note that if your space has ingested images, you might need to do some editing to this plugin to replace `.` with '' in Node names - ask @me if you get stuck and I can send you the fix, it's just out of scope for this PR). 