### PR TITLE
feat: shopify checkout custom query

### DIFF
--- a/packages/shopify-checkout/README.md
+++ b/packages/shopify-checkout/README.md
@@ -188,17 +188,17 @@ const checkout = await checkoutClient.discountRemove({
 });
 ```
 
-##### Making custom query to Shopify Checkout API
+##### Making custom checkout queries to the Shopify Storefront API
 
-| Parameter | [Type](#common-types)     | Required? | Description                                               |
-| --------- | ------------------------- | --------- | --------------------------------------------------------- |
-| `query`   | `string`                  | ✅        | A valid Shopify API query or mutation                     |
-| `input`   | `Record<string, unknown>` | ✅        | A valid variable objects for a Shopify query or mutations |
+| Parameter   | [Type](#common-types) | Required? | Description                                           |
+| ----------- | --------------------- | --------- | ----------------------------------------------------- |
+| `query`     | `string`              | ✅        | A Shopify Storefront API query/mutation               |
+| `variables` | `object`              | ✅        | Variables for a Shopify Storefront API query/mutation |
 
 ##### Example
 
 ```js
-// Allows for end user to send any query/mutation to Shopify API
+// Send any query/mutation to the Shopify Storefront API
 const checkout = await checkoutClient.query({
   query: `
     mutation checkoutShippingAddressUpdateV2($checkoutId: ID!, $shippingAddress: MailingAddressInput!) {
@@ -215,7 +215,7 @@ const checkout = await checkoutClient.query({
       }
     }
     `,
-  input: {
+  variables: {
     checkoutId: checkoutData.id,
     shippingAddress: {
       address1: '123 smith street',
@@ -230,8 +230,8 @@ const checkout = await checkoutClient.query({
 
 Other example mutations from Shopify docs:
 
-- [checkoutShippingAddressUpdateV2](https://shopify.dev/api/storefront/2022-07/mutations/checkoutShippingAddressUpdateV2)
-- [checkoutCustomerAssociateV2](https://shopify.dev/api/storefront/2022-07/mutations/checkoutCustomerAssociateV2)
+[checkoutshippingaddressupdatev2]: https://shopify.dev/api/storefront/2022-07/mutations/checkoutShippingAddressUpdateV2
+[checkoutcustomerassociatev2]: https://shopify.dev/api/storefront/2022-07/mutations/checkoutCustomerAssociateV2
 
 ### Advanced Usage
 

--- a/packages/shopify-checkout/README.md
+++ b/packages/shopify-checkout/README.md
@@ -188,6 +188,51 @@ const checkout = await checkoutClient.discountRemove({
 });
 ```
 
+##### Making custom query to Shopify Checkout API
+
+| Parameter | [Type](#common-types)     | Required? | Description                                               |
+| --------- | ------------------------- | --------- | --------------------------------------------------------- |
+| `query`   | `string`                  | ✅        | A valid Shopify API query or mutation                     |
+| `input`   | `Record<string, unknown>` | ✅        | A valid variable objects for a Shopify query or mutations |
+
+##### Example
+
+```js
+// Allows for end user to send any query/mutation to Shopify API
+const checkout = await checkoutClient.query({
+  query: `
+    mutation checkoutShippingAddressUpdateV2($checkoutId: ID!, $shippingAddress: MailingAddressInput!) {
+      checkoutShippingAddressUpdateV2(checkoutId: $checkoutId, shippingAddress: $shippingAddress) {
+        checkout {
+          id
+          webUrl
+        }
+        checkoutUserErrors {
+          code
+          fields
+          message
+        }
+      }
+    }
+    `,
+  input: {
+    checkoutId: checkoutData.id,
+    shippingAddress: {
+      address1: '123 smith street',
+      city: 'Smith',
+      country: 'USA',
+      firstName: 'John',
+      lastName: 'John'
+    }
+  }
+});
+```
+
+Other example mutations from Shopify docs:
+
+- [checkoutShippingAddressUpdateV2](https://shopify.dev/api/storefront/2022-07/mutations/checkoutShippingAddressUpdateV2)
+- [checkoutCustomerAssociateV2](https://shopify.dev/api/storefront/2022-07/mutations/checkoutCustomerAssociateV2)
+
 ### Advanced Usage
 
 #### Using a custom `fetchClient`

--- a/packages/shopify-checkout/__tests__/mocks/index.ts
+++ b/packages/shopify-checkout/__tests__/mocks/index.ts
@@ -15,7 +15,7 @@ export const clientSettings = {
   myshopifyDomain: 'nacelle-swag-store'
 };
 
-export const graphqlEndpoint = `https://${clientSettings.myshopifyDomain}.myshopify.com/api/2022-01/graphql`;
+export const graphqlEndpoint = `https://${clientSettings.myshopifyDomain}.myshopify.com/api/2022-07/graphql`;
 
 const checkoutUuids = {
   beginsWithLetter: 'a9b8c7?key=123123',
@@ -74,6 +74,7 @@ interface Checkouts {
   checkoutCreate: ShopifyResponse<mutations.CheckoutCreateData>;
   applyDiscount: ShopifyResponse<mutations.CheckoutDiscountCodeApplyV2Data>;
   removeDiscount: ShopifyResponse<mutations.CheckoutDiscountCodeRemoveData>;
+  shippingAddressUpdate: ShopifyResponse<unknown>;
   checkoutUpdate(
     params: CheckoutUpdateVariables
   ): ShopifyResponse<mutations.CheckoutAttributesUpdateData>;
@@ -123,6 +124,17 @@ export const checkouts: Checkouts = {
       checkoutDiscountCodeRemove: {
         checkout: {
           ...emptyCheckout
+        },
+        checkoutUserErrors: []
+      }
+    }
+  },
+  shippingAddressUpdate: {
+    data: {
+      checkoutShippingAddressUpdateV2: {
+        checkout: {
+          id: checkoutIds.beginsWithLetter,
+          webUrl
         },
         checkoutUserErrors: []
       }
@@ -274,5 +286,36 @@ export const shopifyErrors = {
         }
       }
     }
+  }
+};
+
+export const mockCustomQuery = `  
+mutation checkoutShippingAddressUpdateV2($checkoutId: ID!, $shippingAddress: MailingAddressInput!) {
+  checkoutShippingAddressUpdateV2(checkoutId: $checkoutId, shippingAddress: $shippingAddress) {
+    checkout {
+      id
+      webUrl
+    }
+    checkoutUserErrors {
+      code
+      message
+    }
+  }
+}            
+`;
+
+export const mockCustomQueryinput = {
+  checkoutId: 'testId',
+  shippingAddress: {
+    address1: 'testA1',
+    address2: 'testA2',
+    city: 'testCity',
+    company: 'testCo',
+    country: 'USA',
+    firstName: 'testFN',
+    lastName: 'testLN',
+    phone: 'testPhone',
+    province: 'NY',
+    zip: 'testZip'
   }
 };

--- a/packages/shopify-checkout/__tests__/mocks/index.ts
+++ b/packages/shopify-checkout/__tests__/mocks/index.ts
@@ -304,7 +304,7 @@ mutation checkoutShippingAddressUpdateV2($checkoutId: ID!, $shippingAddress: Mai
 }            
 `;
 
-export const mockCustomQueryinput = {
+export const mockCustomQueryvariables = {
   checkoutId: 'testId',
   shippingAddress: {
     address1: 'testA1',

--- a/packages/shopify-checkout/package-lock.json
+++ b/packages/shopify-checkout/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@nacelle/shopify-checkout",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-typescript": "^7.15.0",

--- a/packages/shopify-checkout/src/client/actions/index.ts
+++ b/packages/shopify-checkout/src/client/actions/index.ts
@@ -5,11 +5,12 @@
 
 // EXPORT CLIENT ACTIONS
 // @index('./!(*.spec).ts', (f, _) => `export { default as ${_.camelCase(f.name)} } from '${f.path}';`)
+export { default as applyDiscount } from './applyDiscount';
 export { default as checkoutAttributesUpdate } from './checkoutAttributesUpdate';
 export { default as checkoutCreate } from './checkoutCreate';
 export { default as checkoutLineItemsReplace } from './checkoutLineItemsReplace';
 export { default as findCheckout } from './findCheckout';
 export { default as putCheckout } from './putCheckout';
-export { default as applyDiscount } from './applyDiscount';
+export { default as queryCheckout } from './queryCheckout';
 export { default as removeDiscount } from './removeDiscount';
 // @endindex

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import fetchClient from 'cross-fetch';
+import { mocked } from 'ts-jest/utils';
+import { queryCheckout } from '../../client/actions';
+import { createGqlClient } from '../../utils';
+import { mockJsonResponse } from '../../../__tests__/utils';
+import {
+  clientSettings,
+  checkouts,
+  graphqlEndpoint,
+  headers,
+  mockCustomQuery,
+  mockCustomQueryinput
+} from '../../../__tests__/mocks';
+
+jest.mock('cross-fetch');
+const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
+
+describe('custom query', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('makes the expected request when sending custom query', async () => {
+    mocked(fetchClient).mockImplementationOnce(
+      (): Promise<any> =>
+        mockJsonResponse<unknown>(checkouts.shippingAddressUpdate)
+    );
+
+    await expect(
+      queryCheckout({
+        gqlClient,
+        query: mockCustomQuery,
+        input: mockCustomQueryinput
+      }).then((response) => response)
+    ).resolves.toMatchObject(checkouts.shippingAddressUpdate);
+
+    expect(fetchClient).toHaveBeenCalledTimes(1);
+    expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: mockCustomQuery,
+        variables: mockCustomQueryinput
+      })
+    });
+  });
+});

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.spec.ts
@@ -10,7 +10,7 @@ import {
   graphqlEndpoint,
   headers,
   mockCustomQuery,
-  mockCustomQueryinput
+  mockCustomQueryvariables
 } from '../../../__tests__/mocks';
 
 jest.mock('cross-fetch');
@@ -31,7 +31,7 @@ describe('custom query', () => {
       queryCheckout({
         gqlClient,
         query: mockCustomQuery,
-        input: mockCustomQueryinput
+        variables: mockCustomQueryvariables
       }).then((response) => response)
     ).resolves.toMatchObject(checkouts.shippingAddressUpdate);
 
@@ -41,7 +41,7 @@ describe('custom query', () => {
       headers,
       body: JSON.stringify({
         query: mockCustomQuery,
-        variables: mockCustomQueryinput
+        variables: mockCustomQueryvariables
       })
     });
   });

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.ts
@@ -9,7 +9,9 @@ export default function queryCheckout({
   gqlClient,
   query,
   variables
-}: CheckoutQueryParams): Promise<ShopifyResponse<Record<string, unknown>>> {
+}: CheckoutQueryParams): Promise<ShopifyResponse<
+  Record<string, unknown>
+> | void> {
   return gqlClient<typeof variables, ShopifyResponse<Record<string, unknown>>>({
     query,
     variables

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.ts
@@ -9,9 +9,7 @@ export default function queryCheckout({
   gqlClient,
   query,
   variables
-}: CheckoutQueryParams): Promise<ShopifyResponse<
-  Record<string, unknown>
-> | void> {
+}: CheckoutQueryParams): Promise<ShopifyResponse<Record<string, unknown>>> {
   return gqlClient<typeof variables, ShopifyResponse<Record<string, unknown>>>({
     query,
     variables

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.ts
@@ -3,34 +3,17 @@ import { GqlClient, ShopifyResponse } from '../../checkout-client.types';
 export interface CheckoutQueryParams {
   gqlClient: GqlClient;
   query: string;
-  input?: Record<string, unknown>;
-  queueToken?: string;
+  variables: Record<string, unknown>;
 }
-
-export default async function queryCheckout({
+export default function queryCheckout({
   gqlClient,
   query,
-  input,
-  queueToken
-}: CheckoutQueryParams): Promise<ShopifyResponse<unknown> | void> {
-  const variables = {
-    ...input,
-    queueToken
-  };
-
-  try {
-    const shopifyResponse = await gqlClient<
-      Pick<CheckoutQueryParams, 'input' | 'queueToken'>,
-      ShopifyResponse<unknown>
-    >({
-      query,
-      variables
-    }).catch((err) => {
-      throw new Error(err);
-    });
-
-    return shopifyResponse;
-  } catch (err) {
-    throw new Error(String(err));
-  }
+  variables
+}: CheckoutQueryParams): Promise<ShopifyResponse<
+  Record<string, unknown>
+> | void> {
+  return gqlClient<typeof variables, ShopifyResponse<Record<string, unknown>>>({
+    query,
+    variables
+  });
 }

--- a/packages/shopify-checkout/src/client/actions/queryCheckout.ts
+++ b/packages/shopify-checkout/src/client/actions/queryCheckout.ts
@@ -1,0 +1,36 @@
+import { GqlClient, ShopifyResponse } from '../../checkout-client.types';
+
+export interface CheckoutQueryParams {
+  gqlClient: GqlClient;
+  query: string;
+  input?: Record<string, unknown>;
+  queueToken?: string;
+}
+
+export default async function queryCheckout({
+  gqlClient,
+  query,
+  input,
+  queueToken
+}: CheckoutQueryParams): Promise<ShopifyResponse<unknown> | void> {
+  const variables = {
+    ...input,
+    queueToken
+  };
+
+  try {
+    const shopifyResponse = await gqlClient<
+      Pick<CheckoutQueryParams, 'input' | 'queueToken'>,
+      ShopifyResponse<unknown>
+    >({
+      query,
+      variables
+    }).catch((err) => {
+      throw new Error(err);
+    });
+
+    return shopifyResponse;
+  } catch (err) {
+    throw new Error(String(err));
+  }
+}

--- a/packages/shopify-checkout/src/client/client-dom.spec.ts
+++ b/packages/shopify-checkout/src/client/client-dom.spec.ts
@@ -14,7 +14,9 @@ import {
   checkoutIds,
   graphqlEndpoint,
   headers,
-  webUrl
+  webUrl,
+  mockCustomQuery,
+  mockCustomQueryinput
 } from '../../__tests__/mocks';
 
 jest.mock('cross-fetch');
@@ -347,5 +349,33 @@ describe('createShopifyCheckoutClient', () => {
         }
       })
     });
+  });
+});
+
+it('makes the expected request when sending custom query', async () => {
+  const checkoutClient = createShopifyCheckoutClient({
+    ...clientSettings,
+    fetchClient
+  });
+
+  mocked(fetchClient).mockImplementationOnce(
+    (): Promise<any> =>
+      mockJsonResponse<unknown>(checkouts.shippingAddressUpdate)
+  );
+
+  await expect(
+    checkoutClient.query({
+      query: mockCustomQuery,
+      input: mockCustomQueryinput
+    })
+  ).resolves.toMatchObject(checkouts.shippingAddressUpdate);
+  expect(fetchClient).toHaveBeenCalledTimes(1);
+  expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      query: mockCustomQuery,
+      variables: mockCustomQueryinput
+    })
   });
 });

--- a/packages/shopify-checkout/src/client/client-dom.spec.ts
+++ b/packages/shopify-checkout/src/client/client-dom.spec.ts
@@ -16,7 +16,7 @@ import {
   headers,
   webUrl,
   mockCustomQuery,
-  mockCustomQueryinput
+  mockCustomQueryvariables
 } from '../../__tests__/mocks';
 
 jest.mock('cross-fetch');
@@ -366,7 +366,7 @@ it('makes the expected request when sending custom query', async () => {
   await expect(
     checkoutClient.query({
       query: mockCustomQuery,
-      input: mockCustomQueryinput
+      variables: mockCustomQueryvariables
     })
   ).resolves.toMatchObject(checkouts.shippingAddressUpdate);
   expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -375,7 +375,7 @@ it('makes the expected request when sending custom query', async () => {
     headers,
     body: JSON.stringify({
       query: mockCustomQuery,
-      variables: mockCustomQueryinput
+      variables: mockCustomQueryvariables
     })
   });
 });

--- a/packages/shopify-checkout/src/client/index.ts
+++ b/packages/shopify-checkout/src/client/index.ts
@@ -79,7 +79,7 @@ export interface CheckoutClient {
    */
   discountRemove: RemoveDiscount;
   /**
-   * Allows for end user to send any query/mutation to Shopify API
+   * Send any query/mutation to the Shopify Storefront API
    */
   query: QueryCheckout;
 }
@@ -153,10 +153,11 @@ export default function createShopifyCheckoutClient({
 
   async function query({
     query,
-    input,
-    queueToken
-  }: CustomQueryParams): Promise<ShopifyResponse<unknown> | void> {
-    return await queryCheckout({ gqlClient, query, input, queueToken });
+    variables
+  }: CustomQueryParams): Promise<ShopifyResponse<
+    Record<string, unknown>
+  > | void> {
+    return await queryCheckout({ gqlClient, query, variables });
   }
 
   return {

--- a/packages/shopify-checkout/src/client/index.ts
+++ b/packages/shopify-checkout/src/client/index.ts
@@ -154,7 +154,9 @@ export default function createShopifyCheckoutClient({
   async function query({
     query,
     variables
-  }: CustomQueryParams): Promise<ShopifyResponse<Record<string, unknown>>> {
+  }: CustomQueryParams): Promise<ShopifyResponse<
+    Record<string, unknown>
+  > | void> {
     return await queryCheckout({ gqlClient, query, variables });
   }
 

--- a/packages/shopify-checkout/src/client/index.ts
+++ b/packages/shopify-checkout/src/client/index.ts
@@ -154,9 +154,7 @@ export default function createShopifyCheckoutClient({
   async function query({
     query,
     variables
-  }: CustomQueryParams): Promise<ShopifyResponse<
-    Record<string, unknown>
-  > | void> {
+  }: CustomQueryParams): Promise<ShopifyResponse<Record<string, unknown>>> {
     return await queryCheckout({ gqlClient, query, variables });
   }
 

--- a/packages/shopify-checkout/src/utils/createGqlClient.ts
+++ b/packages/shopify-checkout/src/utils/createGqlClient.ts
@@ -55,7 +55,7 @@ export default function createGqlClient({
         throw new Error(missingParametersErrorMessage);
       }
       const domain = sanitizeShopifyDomain(myshopifyDomain || '');
-      endpoint = `https://${domain}.myshopify.com/api/2022-01/graphql`;
+      endpoint = `https://${domain}.myshopify.com/api/2022-07/graphql`;
     }
 
     let fetcher = fetchClient;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [[ENG-6125](https://nacelle.atlassian.net/browse/ENG-6125)] <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

- add Shopify checkout custom query method
- update Shopify API version to 2022-07

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

🖥 [Local development instructions](#link-to-repo-readme)
🗒 [General testing guidelines](#link-to-testing-guidelines)
📄 [Changelog guidelines](#link-to-changelog-guidelines)

- `npm run test` everything should pass

For end to end testing
- there is a branch of the [shopify-checkout-react-discounts-testing](https://github.com/getnacelle/shopify-checkout-react-discounts-testing/tree/ENG-6125--shopify-custom-query) that is made to test this feature
- for me `npm run build && npm run preview` worked better than `npm run dev` for some reason
- click "Process Checkout" and look at the request in the network tab, make sure that the endpoint uses the `2022-07` version rather than the `2022-01`
- click on the "Custom Query" button and look in the inspector, make sure that the object returned is the appropriate object
- navigate to the returned checkout `webUrl` and make sure that the checkout has been updated appropriately

### Testing checklist

* [ ] Tested on mobile
* [ ] Tested on multiple browsers
* [ ] Tested for accessibility
* [x] Updated the `README.md` with documentation changes
* [ ] Updated public facing documentation