### PR TITLE
fix: linting

### DIFF
--- a/examples/nuxt-3/README.md
+++ b/examples/nuxt-3/README.md
@@ -13,14 +13,15 @@ Example of a Nacelle powered storefront with similar functionality to the [Nuxt 
 
 - v1.x of the `@nacelle/storefront-sdk` currently exports esm as `esm.js`, which the [Nuxt 3 docs call out as an unsupported pattern](https://v3.nuxtjs.org/guide/going-further/esm#what-is-native-esm) for native Node.js ESM. In order to use the Storefront SDK in production builds, it needs to be transpiled by adding it to the [`build.transpile` key of the `nuxt.config.ts file`](./nuxt.config.ts). However, due to Vite quirks, this transpilation needs to be configured to only happen in production builds since the transpilation breaks Vite's ability to use the transpiled modules in development mode. You can use the `process.env.NODE_ENV` key to determine if it's dev or production and return the correct transpile array (`[]` for development and `[@nacelle/storefront-sdk]` for production).
 
-    ```js
-     build: {
+  ```js
+  build: {
     // need to transpile the storefront-sdk for Node to use as ESM
     // but only transpile in production because it breaks imports in local dev
-    transpile:
-      process.env.NODE_ENV === 'development' ? [] : ['@nacelle/storefront-sdk']
+    transpile: process.env.NODE_ENV === 'development'
+      ? []
+      : ['@nacelle/storefront-sdk'];
   }
-    ```
+  ```
 
 - Nuxt 3 currently doesn't support async keys in the config file. So currently the only way to pre-render routes using Nacelle data, is to use build hook which adds routes to the `prerender.routes` key of the nitro config. See [issue 4919](https://github.com/nuxt/framework/issues/4919) for progress on handling async routes and the current workaround. Also track this [RFC for the proposed hybrid mode](https://github.com/nuxt/framework/discussions/560) which will allow for a combination of static and generated routes. There's also a [github issue](https://github.com/nuxt/framework/issues/6411) for tracking the implementation of a full static mode closer to Nuxt 2's static mode.
 
@@ -33,7 +34,7 @@ Make sure to install the dependencies:
 npm install
 
 ## if in this monorepo, from the root:
-npm run bootstrap 
+npm run bootstrap
 ```
 
 Copy the `.env.example` to a file called `.env` and replace the values marked with `<>` with the values for your Nacelle space and Shopify storefront.

--- a/examples/nuxt-3/app.vue
+++ b/examples/nuxt-3/app.vue
@@ -1,21 +1,19 @@
 <template>
-  <div>
-    <header>
-      <nav class="site-nav">
-        <ul role="list">
-          <li><NuxtLink to="/">Home</NuxtLink></li>
-          <li>
-            <NuxtLink to="/cart" class="cart-link">
-              Cart<sup v-if="cartQuantity" class="cart__quantity">
-                {{ cartQuantity }}
-              </sup>
-            </NuxtLink>
-          </li>
-        </ul>
-      </nav>
-    </header>
-    <NuxtPage />
-  </div>
+  <header>
+    <nav class="site-nav">
+      <ul role="list">
+        <li><NuxtLink to="/">Home</NuxtLink></li>
+        <li>
+          <NuxtLink to="/cart" class="cart-link">
+            Cart<sup v-if="cartQuantity" class="cart__quantity">
+              {{ cartQuantity }}
+            </sup>
+          </NuxtLink>
+        </li>
+      </ul>
+    </nav>
+  </header>
+  <NuxtPage />
 </template>
 <script setup>
 // This is the site-wide meta configuration. Can override this on individual pages

--- a/examples/nuxt-3/app.vue
+++ b/examples/nuxt-3/app.vue
@@ -1,19 +1,21 @@
 <template>
-  <header>
-    <nav class="site-nav">
-      <ul role="list">
-        <li><NuxtLink to="/">Home</NuxtLink></li>
-        <li>
-          <NuxtLink to="/cart" class="cart-link">
-            Cart<sup v-if="cartQuantity" class="cart__quantity">
-              {{ cartQuantity }}
-            </sup>
-          </NuxtLink>
-        </li>
-      </ul>
-    </nav>
-  </header>
-  <NuxtPage />
+  <div>
+    <header>
+      <nav class="site-nav">
+        <ul role="list">
+          <li><NuxtLink to="/">Home</NuxtLink></li>
+          <li>
+            <NuxtLink to="/cart" class="cart-link">
+              Cart<sup v-if="cartQuantity" class="cart__quantity">
+                {{ cartQuantity }}
+              </sup>
+            </NuxtLink>
+          </li>
+        </ul>
+      </nav>
+    </header>
+    <NuxtPage />
+  </div>
 </template>
 <script setup>
 // This is the site-wide meta configuration. Can override this on individual pages

--- a/examples/nuxt-3/components/ProductCard.vue
+++ b/examples/nuxt-3/components/ProductCard.vue
@@ -2,8 +2,8 @@
   <div class="product-card">
     <div class="product-card__main">
       <h2
-        class="product-card__title"
         :id="`product-card-header-${product.content.handle}`"
+        class="product-card__title"
       >
         <NuxtLink :to="`/products/${product.content.handle}`">{{
           product.content.title
@@ -19,9 +19,9 @@
         <div class="product-card__price">${{ selectedVariant.price }}</div>
       </div>
       <div
-        class="product-card__option"
         v-for="option in options"
         :key="option.name"
+        class="product-card__option"
       >
         <label
           :for="`${option.name}-select-id`"
@@ -29,7 +29,7 @@
           >{{ option.name }}</label
         >
         <select :id="`${option.name}-select-id`" class="product-card__select">
-          <option v-for="value in option.values" :value="value" :key="value">
+          <option v-for="value in option.values" :key="value" :value="value">
             {{ value }}
           </option>
         </select>
@@ -58,11 +58,13 @@
 </template>
 
 <script setup>
-const props = defineProps({ product: Object });
+const props = defineProps({
+  product: {
+    type: Object,
+    default: () => ({})
+  }
+});
 const selectedVariant = ref(props.product?.variants?.[0] ?? null);
-const selectedOptions = ref(
-  selectedVariant?.value?.content?.selectedOptions ?? null
-);
 const options = computed(() =>
   props.product?.content?.options?.filter((option) => {
     return option.values.length > 1;
@@ -89,7 +91,7 @@ const cartButtonAccessibleLabel = computed(() => {
 });
 
 const addToCart = () => {
-  let cartVariant = transformProductForCart({
+  const cartVariant = transformProductForCart({
     product: props.product,
     variant: selectedVariant
   });

--- a/examples/nuxt-3/composables/cart/index.ts
+++ b/examples/nuxt-3/composables/cart/index.ts
@@ -1,6 +1,5 @@
 import { get, set } from 'idb-keyval';
 import { v4 as uuid } from 'uuid';
-import { reactive, unref, computed } from '#imports';
 import type { Ref, ComputedRef, DeepReadonly } from 'vue';
 import type {
   Media,
@@ -9,13 +8,7 @@ import type {
   Variant
 } from '@nacelle/storefront-sdk';
 import type { Metafield } from '@nacelle/shopify-checkout/dist/types/checkout-client.types';
-
-export interface LineItem {
-  id?: string;
-  metafields?: Metafield;
-  quantity: number;
-  variant: CartVariant;
-}
+import { reactive, unref, computed } from '#imports';
 
 export interface CartVariant {
   availableForSale?: boolean;
@@ -28,6 +21,13 @@ export interface CartVariant {
   title?: string;
   productHandle?: string;
   productTitle?: string;
+}
+
+export interface LineItem {
+  id?: string;
+  metafields?: Metafield;
+  quantity: number;
+  variant: CartVariant;
 }
 
 const cacheKey = 'cart';
@@ -97,7 +97,7 @@ export async function removeItemFromCart(lineItemId: string): Promise<boolean> {
 
 export async function updateItemInCart(item: LineItem): Promise<void> {
   const itemIndex = cartState.lineItems.findIndex(
-    (item) => item.id === item.id
+    (lineItem) => lineItem.id === item.id
   );
   if (itemIndex > -1) {
     cartState.lineItems[itemIndex] = {

--- a/examples/nuxt-3/nuxt.config.ts
+++ b/examples/nuxt-3/nuxt.config.ts
@@ -4,7 +4,7 @@ import { buildRoutes } from './utils/buildRoutes';
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   // Nuxt 3 will replace any runtimeConfig values with matching env
-  //values if they're prefixed with NUXT, as long as they have an initial value
+  // values if they're prefixed with NUXT, as long as they have an initial value
   // see https://v3.nuxtjs.org/guide/features/runtime-config/#environment-variables
   runtimeConfig: {
     public: {

--- a/examples/nuxt-3/pages/collections/[handle].vue
+++ b/examples/nuxt-3/pages/collections/[handle].vue
@@ -42,7 +42,7 @@ const { data: collectionPageData, error: pageFetchError } = await useAsyncData(
       const {
         productConnection: {
           pageInfo: productPaginationInfo,
-          productCount,
+          totalCount: productCount,
           edges: productEdges
         },
         ...productCollection

--- a/examples/nuxt-3/pages/collections/[handle].vue
+++ b/examples/nuxt-3/pages/collections/[handle].vue
@@ -42,17 +42,17 @@ const { data: collectionPageData, error: pageFetchError } = await useAsyncData(
       const {
         productConnection: {
           pageInfo: productPaginationInfo,
-          totalProductCount,
+          productCount,
           edges: productEdges
         },
-        ...collection
-      } = allProductCollections.edges[0]?.node;
-      const products = productEdges.map((edge) => edge.node);
+        ...productCollection
+      } = allProductCollections.edges[0].node;
+      const collectionProducts = productEdges.map((edge) => edge.node);
       return {
-        collection,
-        products,
+        collection: productCollection,
+        products: collectionProducts,
         productPaginationInfo,
-        totalProductCount
+        totalProductCount: productCount
       };
     }
     return {};
@@ -81,7 +81,7 @@ const loadMoreProducts = async () => {
   isFetchingProducts.value = true;
   const { productCollections } = await sdk.query({
     CollectionProductsQuery,
-    variables: { handle: handle, after: productPaginationCursor }
+    variables: { handle, after: productPaginationCursor }
   });
   const {
     productConnection: {

--- a/examples/nuxt-3/pages/products/[handle].vue
+++ b/examples/nuxt-3/pages/products/[handle].vue
@@ -138,9 +138,9 @@ const onOptionChanged = (option, $event) => {
   }
 };
 
-const addItem = async (e) => {
+const addItem = async () => {
   const cartVariant = transformProductForCart({
-    product: product,
+    product,
     variant: selectedVariant
   });
   if (cartVariant) {

--- a/examples/nuxt-3/queries/index.js
+++ b/examples/nuxt-3/queries/index.js
@@ -1,2 +1,5 @@
 export { default as ProductPageQuery } from './product-page-query';
-export { default as CollectionPageQuery, CollectionProductsQuery } from './collection-page-query';
+export {
+  default as CollectionPageQuery,
+  CollectionProductsQuery
+} from './collection-page-query';


### PR DESCRIPTION
## Why are these changes introduced?

To support #205.

## What is this pull request doing?

Currently, it doesn't seem possible to run Nuxt 2 and Nuxt 3 linting setups in the same monorepo. To do that, [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) would need to provide an option to define sub-projects that it runs in, [as Vetur does](https://vuejs.github.io/vetur/guide/setup.html#advanced).

With that in mind, it's challenging to run ESLint on the `examples/nuxt-3` project introduced in #205. We can do this locally, though, using an ESLint config setup [that closely mirrors this](https://github.com/nuxt/framework/discussions/2815#discussioncomment-2050408).

This PR fixes some issues highlighted by:
1. `'eslint:recommended'`
2. `'plugin:vue/vue3-essential'`
3. `'plugin:@typescript-eslint/recommended'`
4. `'@nuxtjs/eslint-config-typescript'`

Most of them are superficial (formatting, unused variables, default props, etc.). The more consequential fixes are:
- `examples/nuxt-3/composables/cart/index.ts` had a variable name collision that led to a problematic comparison: `item.id === item.id`
- In `examples/nuxt-3/pages/collections/[handle].vue`, there was a dangerous optional chaining that could result in a `TypeError`, if `allProductCollections.edges[0]` was `undefined`.