### PR TITLE
feat: sanitize user-supplied GraphQL fragments

### DIFF
--- a/packages/shopify-cart/src/utils/index.ts
+++ b/packages/shopify-cart/src/utils/index.ts
@@ -8,4 +8,5 @@
 export { default as cartFromGql } from './cartFromGql';
 export { default as createGqlClient } from './createGqlClient';
 export { default as handleShopifyError } from './handleShopifyError';
+export { default as sanitizeFragment } from './sanitizeFragment';
 // @endindex

--- a/packages/shopify-cart/src/utils/sanitizeFragment.spec.ts
+++ b/packages/shopify-cart/src/utils/sanitizeFragment.spec.ts
@@ -1,0 +1,27 @@
+import sanitizeFragment from './sanitizeFragment';
+
+describe('sanitizeFragment', () => {
+  it("changes the fragment name to the corresponding default fragment's name", () => {
+    const fragment = `
+      fragment Cost on MoneyV2 {
+        currencyCode
+        amount
+      }
+    `;
+    expect(sanitizeFragment(fragment, 'MONEY')).toMatch(
+      'fragment Money_money on MoneyV2'
+    );
+  });
+
+  it("throws an informative error when the provided GraphQL type doesn't match the expected GraphQL type", () => {
+    const fragment = `
+      fragment Money_money on Cash {
+        currencyCode
+        amount
+      }
+    `;
+    expect(() => sanitizeFragment(fragment, 'MONEY')).toThrow(
+      `MONEY fragment expected to be on GraphQL type 'MoneyV2', but received 'Cash'.`
+    );
+  });
+});

--- a/packages/shopify-cart/src/utils/sanitizeFragment.ts
+++ b/packages/shopify-cart/src/utils/sanitizeFragment.ts
@@ -1,0 +1,50 @@
+import fragments from '../graphql/fragments';
+
+/**
+ * Enforce that user-supplied fragments have predictable fragment names and use the expected GraphQL types.
+ * @param fragment user-supplied GraphQL fragment that could have an arbitrary fragment name.
+ * @param fragmentType the .
+ * @returns a modified version of the fragment, where the fragment's name is `fragmentName`.
+ * @example
+ * We need a user-supplied `MoneyV2` fragment to have a fragment name of `Money_money`, so that we can use it elsewhere.
+ * ```
+ * const moneyFragment = `
+ *  fragment Custom_money on MoneyV2 {
+ *    currencyCode
+ *    amount
+ *  }
+ * `;
+ *
+ * // Result: '\n  fragment Money_money on MoneyV2 {\n    currencyCode\n    amount\n  }\n'
+ * sanitizeFragment(moneyFragment, 'MONEY');
+ * ```
+ */
+export default function sanitizeFragment(
+  fragment: string,
+  fragmentType: keyof typeof fragments
+): string {
+  // In this regex, we use four capture groups:
+  // - `$1` captures `fragment `.
+  // - `$2` captures the fragment name.
+  // - `$3` captures ` on `.
+  // - `$4` captures the GraphQL type.
+  const regexp = /(fragment )(\w+)( on )(\w+)/;
+
+  // First, determine what the expected fragment name and GraphQL type are.
+  const defaultFragmentResult = regexp.exec(fragments[fragmentType]);
+  const expectedFragmentName = (defaultFragmentResult as RegExpExecArray)[2];
+  const expectedOnType = (defaultFragmentResult as RegExpExecArray)[4];
+
+  // Next, determine if there are any discrepancies between the supplied & expected GraphQL types.
+  const suppliedFragmentResult = regexp.exec(fragment);
+  const suppliedOnType = (suppliedFragmentResult as RegExpExecArray)[4];
+
+  if (suppliedOnType !== expectedOnType) {
+    throw new Error(
+      `${fragmentType} fragment expected to be on GraphQL type '${expectedOnType}', but received '${suppliedOnType}'.`
+    );
+  }
+
+  // Replace the supplied fragment name with our default fragment name.
+  return fragment.replace(regexp, `$1${expectedFragmentName}$3$4`);
+}


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-6849](https://nacelle.atlassian.net/browse/ENG-6849)

> Sanitize user-supplied fragments to ensure consistent fragment names and types

## What is this pull request doing?

This PR adds a new `sanitizeFragment` utility that ensures that user-supplied GraphQL fragments have the expected fragment name and GraphQL type. This will reduce opportunities for user-supplied GraphQL fragments to result in errors due to not adhering to our fragment naming conventions or using an unexpected GraphQL type for a given fragment.

## How to Test

1. Check out the `ENG-6849-sanitize-user-supplied-fragments` branch.
2. `npm run bootstrap` from the monorepo root, as needed.
3. `cd packages/shopify-cart`
4. `npm run test:ci -- utils/sanitizeFragment` - tests should pass with 100% coverage:

<img width="750" alt="ENG-6849-sanitize-user-supplied-fragments all tests passing" src="https://user-images.githubusercontent.com/5732000/186917477-f2ad8bdd-3e38-48dc-a500-465e440eed99.png">