### PR TITLE
chore: update API & types

### DIFF
--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -246,9 +246,9 @@ const cart = await cartClient.cartNoteUpdate({
 <!-- LINKS -->
 
 [shopify-access-scopes]: https://shopify.dev/api/usage/access-scopes#unauthenticated-access-scopes
-[shopify-cart-object]: https://shopify.dev/api/storefront/2022-04/objects/Cart#top
-[shopify-attributes-input]: https://shopify.dev/api/storefront/2022-04/input-objects/AttributeInput
-[shopify-buyer-identity-input]: https://shopify.dev/api/storefront/2022-04/input-objects/CartBuyerIdentityInput
-[shopify-cart-input]: https://shopify.dev/api/storefront/2022-04/input-objects/CartInput
-[shopify-cart-line-input]: https://shopify.dev/api/storefront/2022-04/input-objects/CartLineInput
-[shopify-cart-line-update-input]: https://shopify.dev/api/storefront/2022-04/input-objects/CartLineUpdateInput
+[shopify-cart-object]: https://shopify.dev/api/storefront/2022-07/objects/Cart#top
+[shopify-attributes-input]: https://shopify.dev/api/storefront/2022-07/input-objects/AttributeInput
+[shopify-buyer-identity-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartBuyerIdentityInput
+[shopify-cart-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartInput
+[shopify-cart-line-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartLineInput
+[shopify-cart-line-update-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartLineUpdateInput

--- a/packages/shopify-cart/__tests__/mocks/index.ts
+++ b/packages/shopify-cart/__tests__/mocks/index.ts
@@ -21,7 +21,7 @@ export const clientSettings = {
 };
 import { ShopifyError } from '../../src/types/errors.type';
 
-export const graphqlEndpoint = `https://${clientSettings.shopifyShopId}.myshopify.com/api/2022-04/graphql`;
+export const graphqlEndpoint = `https://${clientSettings.shopifyShopId}.myshopify.com/api/2022-07/graphql`;
 export const cartId = Buffer.from('gid://shopify/Cart/112233').toString(
   'base64'
 );
@@ -73,8 +73,8 @@ interface CartResponse {
 
 export const cartWithoutLine: Cart_CartFragment = {
   id: cartId,
-  createdAt: '2022-04-01T00:00:00Z',
-  updatedAt: '2022-04-01T00:00:00Z',
+  createdAt: '2022-07-01T00:00:00Z',
+  updatedAt: '2022-07-01T00:00:00Z',
   checkoutUrl,
   buyerIdentity: {
     countryCode: null,
@@ -108,8 +108,8 @@ export const cartWithoutLine: Cart_CartFragment = {
 
 export const cartWithLine: Cart_CartFragment = {
   id: cartId,
-  createdAt: '2022-04-01T00:00:00Z',
-  updatedAt: '2022-04-01T00:00:00Z',
+  createdAt: '2022-07-01T00:00:00Z',
+  updatedAt: '2022-07-01T00:00:00Z',
   checkoutUrl,
   buyerIdentity: {
     countryCode: null,

--- a/packages/shopify-cart/codegen.yml
+++ b/packages/shopify-cart/codegen.yml
@@ -1,6 +1,6 @@
 overwrite: true
 schema:
-  - https://${SHOPIFY_SHOP_ID}.myshopify.com/api/2022-04/graphql:
+  - https://${SHOPIFY_SHOP_ID}.myshopify.com/api/2022-07/graphql:
       headers:
         X-Shopify-Storefront-Access-Token: ${SHOPIFY_STOREFRONT_ACCESS_TOKEN}
 documents: 'src/graphql/**/*.ts'

--- a/packages/shopify-cart/src/types/shopify.type.ts
+++ b/packages/shopify-cart/src/types/shopify.type.ts
@@ -10,55 +10,11 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /**
-   * Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
-   * For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
-   * represented as `"2019-09-07T15:50:00Z`".
-   *
-   */
   DateTime: any;
-  /**
-   * A signed decimal number, which supports arbitrary precision and is serialized as a string.
-   *
-   * Example values: `"29.99"`, `"29.999"`.
-   *
-   */
   Decimal: any;
-  /**
-   * A string containing HTML code. Refer to the [HTML spec](https://html.spec.whatwg.org/#elements-3) for a
-   * complete list of HTML elements.
-   *
-   * Example value: `"<p>Grey cotton knit sweater.</p>"`.
-   *
-   */
   HTML: any;
-  /**
-   * A [JSON](https://www.json.org/json-en.html) object.
-   *
-   * Example value:
-   * `{
-   *   "product": {
-   *     "id": "gid://shopify/Product/1346443542550",
-   *     "title": "White T-shirt",
-   *     "options": [{
-   *       "name": "Size",
-   *       "values": ["M", "L"]
-   *     }]
-   *   }
-   * }`
-   *
-   */
   JSON: any;
-  /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
   Money: any;
-  /**
-   * Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
-   * [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
-   *
-   * For example, `"https://johns-apparel.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
-   * (`johns-apparel.myshopify.com`).
-   *
-   */
   URL: any;
 };
 
@@ -136,11 +92,10 @@ export type Article = HasMetafields & Node & OnlineStorePublishable & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The URL used for viewing the resource on the shop's Online Store. Returns `null` if the resource is currently not published to the Online Store sales channel. */
   onlineStoreUrl?: Maybe<Scalars['URL']>;
   /** The date and time when the article was published. */
@@ -185,12 +140,7 @@ export type ArticleMetafieldArgs = {
 
 /** An article in an online store blog. */
 export type ArticleMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 /** The author of an article. */
@@ -324,11 +274,10 @@ export type Blog = HasMetafields & Node & OnlineStorePublishable & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The URL used for viewing the resource on the shop's Online Store. Returns `null` if the resource is currently not published to the Online Store sales channel. */
   onlineStoreUrl?: Maybe<Scalars['URL']>;
   /** The blog's SEO information. */
@@ -365,12 +314,7 @@ export type BlogMetafieldArgs = {
 
 /** An online store blog. */
 export type BlogMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 /**
@@ -434,16 +378,22 @@ export enum CardBrand {
 /** A cart represents the merchandise that a buyer intends to purchase, and the estimated cost associated with the cart. To learn how to interact with a cart during a customer's session, refer to [Manage a cart with the Storefront API](https://shopify.dev/api/examples/cart). */
 export type Cart = Node & {
   __typename?: 'Cart';
+  /** An attribute associated with the cart. */
+  attribute?: Maybe<Attribute>;
   /** The attributes associated with the cart. Attributes are represented as key-value pairs. */
   attributes: Array<Attribute>;
   /** Information about the buyer that is interacting with the cart. */
   buyerIdentity: CartBuyerIdentity;
   /** The URL of the checkout for the cart. */
   checkoutUrl: Scalars['URL'];
+  /** The estimated costs that the buyer will pay at checkout. The costs are subject to change and changes will be reflected at checkout. The `cost` field uses the `buyerIdentity` field to determine [international pricing](https://shopify.dev/api/examples/international-pricing#create-a-cart). */
+  cost: CartCost;
   /** The date and time when the cart was created. */
   createdAt: Scalars['DateTime'];
   /** The delivery groups available for the cart, based on the default address of the logged-in customer. */
   deliveryGroups: CartDeliveryGroupConnection;
+  /** The discounts that have been applied to the entire cart. */
+  discountAllocations: Array<CartDiscountAllocation>;
   /**
    * The case-insensitive discount codes that the customer added at checkout.
    *
@@ -460,8 +410,16 @@ export type Cart = Node & {
   lines: CartLineConnection;
   /** A note that is associated with the cart. For example, the note can be a personalized message to the buyer. */
   note?: Maybe<Scalars['String']>;
+  /** The total number of items in the cart. */
+  totalQuantity: Scalars['Int'];
   /** The date and time when the cart was updated. */
   updatedAt: Scalars['DateTime'];
+};
+
+
+/** A cart represents the merchandise that a buyer intends to purchase, and the estimated cost associated with the cart. To learn how to interact with a cart during a customer's session, refer to [Manage a cart with the Storefront API](https://shopify.dev/api/examples/cart). */
+export type CartAttributeArgs = {
+  key: Scalars['String'];
 };
 
 
@@ -551,6 +509,34 @@ export type CartCodeDiscountAllocation = CartDiscountAllocation & {
   discountedAmount: MoneyV2;
 };
 
+/**
+ * The costs that the buyer will pay at checkout.
+ * It uses [`CartBuyerIdentity`](https://shopify.dev/api/storefront/reference/cart/cartbuyeridentity) to determine
+ * [international pricing](https://shopify.dev/api/examples/international-pricing#create-a-cart).
+ *
+ */
+export type CartCost = {
+  __typename?: 'CartCost';
+  /** The estimated amount, before taxes and discounts, for the customer to pay at checkout. The checkout charge amount doesn't include any deferred payments that'll be paid at a later date. If the cart has no deferred payments, then the checkout charge amount is equivalent to `subtotalAmount`. */
+  checkoutChargeAmount: MoneyV2;
+  /** The amount, before taxes and cart-level discounts, for the customer to pay. */
+  subtotalAmount: MoneyV2;
+  /** Whether the subtotal amount is estimated. */
+  subtotalAmountEstimated: Scalars['Boolean'];
+  /** The total amount for the customer to pay. */
+  totalAmount: MoneyV2;
+  /** Whether the total amount is estimated. */
+  totalAmountEstimated: Scalars['Boolean'];
+  /** The duty amount for the customer to pay at checkout. */
+  totalDutyAmount?: Maybe<MoneyV2>;
+  /** Whether the total duty amount is estimated. */
+  totalDutyAmountEstimated: Scalars['Boolean'];
+  /** The tax amount for the customer to pay at checkout. */
+  totalTaxAmount?: Maybe<MoneyV2>;
+  /** Whether the total tax amount is estimated. */
+  totalTaxAmountEstimated: Scalars['Boolean'];
+};
+
 /** Return type for `cartCreate` mutation. */
 export type CartCreatePayload = {
   __typename?: 'CartCreatePayload';
@@ -558,6 +544,15 @@ export type CartCreatePayload = {
   cart?: Maybe<Cart>;
   /** The list of errors that occurred from executing the mutation. */
   userErrors: Array<CartUserError>;
+};
+
+/** The discounts automatically applied to the cart line based on prerequisites that have been met. */
+export type CartCustomDiscountAllocation = CartDiscountAllocation & {
+  __typename?: 'CartCustomDiscountAllocation';
+  /** The discounted amount that has been applied to the cart line. */
+  discountedAmount: MoneyV2;
+  /** The title of the allocated discount. */
+  title: Scalars['String'];
 };
 
 /** Information about the options available for one or more line items to be delivered to a specific address. */
@@ -670,6 +665,8 @@ export enum CartErrorCode {
  */
 export type CartEstimatedCost = {
   __typename?: 'CartEstimatedCost';
+  /** The estimated amount, before taxes and discounts, for the customer to pay at checkout. The checkout charge amount doesn't include any deferred payments that'll be paid at a later date. If the cart has no deferred payments, then the checkout charge amount is equivalent to`subtotal_amount`. */
+  checkoutChargeAmount: MoneyV2;
   /** The estimated amount, before taxes and discounts, for the customer to pay. */
   subtotalAmount: MoneyV2;
   /** The estimated total amount for the customer to pay. */
@@ -700,8 +697,12 @@ export type CartInput = {
 /** Represents information about the merchandise in the cart. */
 export type CartLine = Node & {
   __typename?: 'CartLine';
+  /** An attribute associated with the cart line. */
+  attribute?: Maybe<Attribute>;
   /** The attributes associated with the cart line. Attributes are represented as key-value pairs. */
   attributes: Array<Attribute>;
+  /** The cost of the merchandise that the buyer will pay for at checkout. The costs are subject to change and changes will be reflected at checkout. */
+  cost: CartLineCost;
   /** The discounts that have been applied to the cart line. */
   discountAllocations: Array<CartDiscountAllocation>;
   /**
@@ -719,6 +720,12 @@ export type CartLine = Node & {
   sellingPlanAllocation?: Maybe<SellingPlanAllocation>;
 };
 
+
+/** Represents information about the merchandise in the cart. */
+export type CartLineAttributeArgs = {
+  key: Scalars['String'];
+};
+
 /**
  * An auto-generated type for paginating through multiple CartLines.
  *
@@ -731,6 +738,19 @@ export type CartLineConnection = {
   nodes: Array<CartLine>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
+};
+
+/** The cost of the merchandise line that the buyer will pay at checkout. */
+export type CartLineCost = {
+  __typename?: 'CartLineCost';
+  /** The amount of the merchandise line. */
+  amountPerQuantity: MoneyV2;
+  /** The compare at amount of the merchandise line. */
+  compareAtAmountPerQuantity?: Maybe<MoneyV2>;
+  /** The cost of the merchandise line before line-level discounts. */
+  subtotalAmount: MoneyV2;
+  /** The total cost of the merchandise line. */
+  totalAmount: MoneyV2;
 };
 
 /**
@@ -748,6 +768,10 @@ export type CartLineEdge = {
 /** The estimated cost of the merchandise line that the buyer will pay at checkout. */
 export type CartLineEstimatedCost = {
   __typename?: 'CartLineEstimatedCost';
+  /** The amount of the merchandise line. */
+  amount: MoneyV2;
+  /** The compare at amount of the merchandise line. */
+  compareAtAmount?: Maybe<MoneyV2>;
   /** The estimated cost of the merchandise line before discounts. */
   subtotalAmount: MoneyV2;
   /** The estimated total cost of the merchandise line. */
@@ -870,7 +894,7 @@ export type Checkout = Node & {
    * @deprecated Use `paymentDueV2` instead
    */
   paymentDue: Scalars['Money'];
-  /** The amount left to be paid. This is equal to the cost of the line items, duties, taxes and shipping minus discounts and gift cards. */
+  /** The amount left to be paid. This is equal to the cost of the line items, duties, taxes, and shipping, minus discounts and gift cards. */
   paymentDueV2: MoneyV2;
   /**
    * Whether or not the Checkout is ready and can be completed. Checkouts may
@@ -896,7 +920,7 @@ export type Checkout = Node & {
    * @deprecated Use `subtotalPriceV2` instead
    */
   subtotalPrice: Scalars['Money'];
-  /** Price of the checkout before duties, shipping and taxes. */
+  /** The price at checkout before duties, shipping, and taxes. */
   subtotalPriceV2: MoneyV2;
   /** Whether the checkout is tax exempt. */
   taxExempt: Scalars['Boolean'];
@@ -909,7 +933,7 @@ export type Checkout = Node & {
    * @deprecated Use `totalPriceV2` instead
    */
   totalPrice: Scalars['Money'];
-  /** The sum of all the prices of all the items in the checkout, duties, taxes and discounts included. */
+  /** The sum of all the prices of all the items in the checkout, including duties, taxes, and discounts. */
   totalPriceV2: MoneyV2;
   /**
    * The sum of all the taxes applied to the line items and shipping lines in the checkout.
@@ -942,36 +966,6 @@ export type CheckoutLineItemsArgs = {
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
   reverse?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** Specifies the fields required to update a checkout's attributes. */
-export type CheckoutAttributesUpdateInput = {
-  /**
-   * Allows setting partial addresses on a Checkout, skipping the full validation of attributes.
-   * The required attributes are city, province, and country.
-   * Full validation of the addresses is still done at completion time. Defaults to `false` with
-   * each operation.
-   *
-   */
-  allowPartialAddresses?: InputMaybe<Scalars['Boolean']>;
-  /** A list of extra information that is added to the checkout. */
-  customAttributes?: InputMaybe<Array<AttributeInput>>;
-  /** The text of an optional note that a shop owner can attach to the checkout. */
-  note?: InputMaybe<Scalars['String']>;
-};
-
-/** Return type for `checkoutAttributesUpdate` mutation. */
-export type CheckoutAttributesUpdatePayload = {
-  __typename?: 'CheckoutAttributesUpdatePayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
 };
 
 /** Specifies the fields required to update a checkout's attributes. */
@@ -1036,57 +1030,9 @@ export type CheckoutCompleteFreePayload = {
   userErrors: Array<UserError>;
 };
 
-/** Return type for `checkoutCompleteWithCreditCard` mutation. */
-export type CheckoutCompleteWithCreditCardPayload = {
-  __typename?: 'CheckoutCompleteWithCreditCardPayload';
-  /** The checkout on which the payment was applied. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /** A representation of the attempted payment. */
-  payment?: Maybe<Payment>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
 /** Return type for `checkoutCompleteWithCreditCardV2` mutation. */
 export type CheckoutCompleteWithCreditCardV2Payload = {
   __typename?: 'CheckoutCompleteWithCreditCardV2Payload';
-  /** The checkout on which the payment was applied. */
-  checkout?: Maybe<Checkout>;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /** A representation of the attempted payment. */
-  payment?: Maybe<Payment>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
-/** Return type for `checkoutCompleteWithTokenizedPayment` mutation. */
-export type CheckoutCompleteWithTokenizedPaymentPayload = {
-  __typename?: 'CheckoutCompleteWithTokenizedPaymentPayload';
-  /** The checkout on which the payment was applied. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /** A representation of the attempted payment. */
-  payment?: Maybe<Payment>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
-/** Return type for `checkoutCompleteWithTokenizedPaymentV2` mutation. */
-export type CheckoutCompleteWithTokenizedPaymentV2Payload = {
-  __typename?: 'CheckoutCompleteWithTokenizedPaymentV2Payload';
   /** The checkout on which the payment was applied. */
   checkout?: Maybe<Checkout>;
   /** The list of errors that occurred from executing the mutation. */
@@ -1135,13 +1081,6 @@ export type CheckoutCreateInput = {
   lineItems?: InputMaybe<Array<CheckoutLineItemInput>>;
   /** The text of an optional note that a shop owner can attach to the checkout. */
   note?: InputMaybe<Scalars['String']>;
-  /**
-   * The three-letter currency code of one of the shop's enabled presentment currencies.
-   * Including this field creates a checkout in the specified currency. By default, new
-   * checkouts are created in the shop's primary currency.
-   *  This argument is deprecated: Use `country` field instead.
-   */
-  presentmentCurrencyCode?: InputMaybe<CurrencyCode>;
   /** The shipping address to where the line items will be shipped. */
   shippingAddress?: InputMaybe<MailingAddressInput>;
 };
@@ -1162,17 +1101,6 @@ export type CheckoutCreatePayload = {
   userErrors: Array<UserError>;
 };
 
-/** Return type for `checkoutCustomerAssociate` mutation. */
-export type CheckoutCustomerAssociatePayload = {
-  __typename?: 'CheckoutCustomerAssociatePayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The associated customer object. */
-  customer?: Maybe<Customer>;
-  /** The list of errors that occurred from executing the mutation. */
-  userErrors: Array<UserError>;
-};
-
 /** Return type for `checkoutCustomerAssociateV2` mutation. */
 export type CheckoutCustomerAssociateV2Payload = {
   __typename?: 'CheckoutCustomerAssociateV2Payload';
@@ -1189,39 +1117,11 @@ export type CheckoutCustomerAssociateV2Payload = {
   userErrors: Array<UserError>;
 };
 
-/** Return type for `checkoutCustomerDisassociate` mutation. */
-export type CheckoutCustomerDisassociatePayload = {
-  __typename?: 'CheckoutCustomerDisassociatePayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
 /** Return type for `checkoutCustomerDisassociateV2` mutation. */
 export type CheckoutCustomerDisassociateV2Payload = {
   __typename?: 'CheckoutCustomerDisassociateV2Payload';
   /** The updated checkout object. */
   checkout?: Maybe<Checkout>;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
-/** Return type for `checkoutDiscountCodeApply` mutation. */
-export type CheckoutDiscountCodeApplyPayload = {
-  __typename?: 'CheckoutDiscountCodeApplyPayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
   /** The list of errors that occurred from executing the mutation. */
   checkoutUserErrors: Array<CheckoutUserError>;
   /**
@@ -1250,20 +1150,6 @@ export type CheckoutDiscountCodeRemovePayload = {
   __typename?: 'CheckoutDiscountCodeRemovePayload';
   /** The updated checkout object. */
   checkout?: Maybe<Checkout>;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
-/** Return type for `checkoutEmailUpdate` mutation. */
-export type CheckoutEmailUpdatePayload = {
-  __typename?: 'CheckoutEmailUpdatePayload';
-  /** The checkout object with the updated email. */
-  checkout: Checkout;
   /** The list of errors that occurred from executing the mutation. */
   checkoutUserErrors: Array<CheckoutUserError>;
   /**
@@ -1331,6 +1217,8 @@ export enum CheckoutErrorCode {
   GiftCardUnusable = 'GIFT_CARD_UNUSABLE',
   /** The input value should be greater than or equal to the minimum value allowed. */
   GreaterThanOrEqualTo = 'GREATER_THAN_OR_EQUAL_TO',
+  /** Higher value discount applied. */
+  HigherValueDiscountApplied = 'HIGHER_VALUE_DISCOUNT_APPLIED',
   /** The input value is invalid. */
   Invalid = 'INVALID',
   /** Cannot specify country and presentment currency code. */
@@ -1355,6 +1243,8 @@ export enum CheckoutErrorCode {
   LineItemNotFound = 'LINE_ITEM_NOT_FOUND',
   /** Checkout is locked. */
   Locked = 'LOCKED',
+  /** Maximum number of discount codes limit reached. */
+  MaximumDiscountCodeLimitReached = 'MAXIMUM_DISCOUNT_CODE_LIMIT_REACHED',
   /** Missing payment input. */
   MissingPaymentInput = 'MISSING_PAYMENT_INPUT',
   /** Not enough in stock. */
@@ -1374,34 +1264,6 @@ export enum CheckoutErrorCode {
   /** Unable to apply discount. */
   UnableToApply = 'UNABLE_TO_APPLY'
 }
-
-/** Return type for `checkoutGiftCardApply` mutation. */
-export type CheckoutGiftCardApplyPayload = {
-  __typename?: 'CheckoutGiftCardApplyPayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
-/** Return type for `checkoutGiftCardRemove` mutation. */
-export type CheckoutGiftCardRemovePayload = {
-  __typename?: 'CheckoutGiftCardRemovePayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
 
 /** Return type for `checkoutGiftCardRemoveV2` mutation. */
 export type CheckoutGiftCardRemoveV2Payload = {
@@ -1549,20 +1411,6 @@ export type CheckoutLineItemsUpdatePayload = {
   userErrors: Array<UserError>;
 };
 
-/** Return type for `checkoutShippingAddressUpdate` mutation. */
-export type CheckoutShippingAddressUpdatePayload = {
-  __typename?: 'CheckoutShippingAddressUpdatePayload';
-  /** The updated checkout object. */
-  checkout: Checkout;
-  /** The list of errors that occurred from executing the mutation. */
-  checkoutUserErrors: Array<CheckoutUserError>;
-  /**
-   * The list of errors that occurred from executing the mutation.
-   * @deprecated Use `checkoutUserErrors` instead
-   */
-  userErrors: Array<UserError>;
-};
-
 /** Return type for `checkoutShippingAddressUpdateV2` mutation. */
 export type CheckoutShippingAddressUpdateV2Payload = {
   __typename?: 'CheckoutShippingAddressUpdateV2Payload';
@@ -1622,11 +1470,10 @@ export type Collection = HasMetafields & Node & OnlineStorePublishable & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The URL used for viewing the resource on the shop's Online Store. Returns `null` if the resource is currently not published to the Online Store sales channel. */
   onlineStoreUrl?: Maybe<Scalars['URL']>;
   /** List of products in the collection. */
@@ -1655,12 +1502,7 @@ export type CollectionMetafieldArgs = {
 
 /** A collection represents a grouping of products that a shop owner can create to organize them or make their shops easier to browse. */
 export type CollectionMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 
@@ -1788,7 +1630,7 @@ export type Country = {
 
 /**
  * The code designating a country/region, which generally follows ISO 3166-1 alpha-2 guidelines.
- * If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision
+ * If a territory doesn't have a country code value in the `CountryCode` enum, then it might be considered a subdivision
  * of another country. For example, the territories associated with Spain are represented by the country code `ES`,
  * and the territories associated with the United States of America are represented by the country code `US`.
  *
@@ -2312,24 +2154,6 @@ export type CreditCard = {
  * a Shopify vaulted credit card payment.
  *
  */
-export type CreditCardPaymentInput = {
-  /** The amount of the payment. */
-  amount: Scalars['Money'];
-  /** The billing address for the payment. */
-  billingAddress: MailingAddressInput;
-  /** A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one. For more information, refer to [Idempotent requests](https://shopify.dev/api/usage/idempotent-requests). */
-  idempotencyKey: Scalars['String'];
-  /** Executes the payment in test mode if possible. Defaults to `false`. */
-  test?: InputMaybe<Scalars['Boolean']>;
-  /** The ID returned by Shopify's Card Vault. */
-  vaultId: Scalars['String'];
-};
-
-/**
- * Specifies the fields required to complete a checkout with
- * a Shopify vaulted credit card payment.
- *
- */
 export type CreditCardPaymentInputV2 = {
   /** The billing address for the payment. */
   billingAddress: MailingAddressInput;
@@ -2422,7 +2246,10 @@ export enum CurrencyCode {
   Bwp = 'BWP',
   /** Belarusian Ruble (BYN). */
   Byn = 'BYN',
-  /** Belarusian Ruble (BYR). */
+  /**
+   * Belarusian Ruble (BYR).
+   * @deprecated `BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.
+   */
   Byr = 'BYR',
   /** Belize Dollar (BZD). */
   Bzd = 'BZD',
@@ -2632,8 +2459,13 @@ export enum CurrencyCode {
   Srd = 'SRD',
   /** South Sudanese Pound (SSP). */
   Ssp = 'SSP',
-  /** Sao Tome And Principe Dobra (STD). */
+  /**
+   * Sao Tome And Principe Dobra (STD).
+   * @deprecated `STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.
+   */
   Std = 'STD',
+  /** Sao Tome And Principe Dobra (STN). */
+  Stn = 'STN',
   /** Syrian Pound (SYP). */
   Syp = 'SYP',
   /** Swazi Lilangeni (SZL). */
@@ -2666,7 +2498,12 @@ export enum CurrencyCode {
   Uyu = 'UYU',
   /** Uzbekistan som (UZS). */
   Uzs = 'UZS',
-  /** Venezuelan Bolivares (VEF). */
+  /** Venezuelan Bolivares (VED). */
+  Ved = 'VED',
+  /**
+   * Venezuelan Bolivares (VEF).
+   * @deprecated `VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.
+   */
   Vef = 'VEF',
   /** Venezuelan Bolivares (VES). */
   Ves = 'VES',
@@ -2720,11 +2557,10 @@ export type Customer = HasMetafields & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The orders associated with the customer. */
   orders: OrderConnection;
   /** The customer’s phone number. */
@@ -2759,12 +2595,7 @@ export type CustomerMetafieldArgs = {
 
 /** A customer represents a customer account with the shop. Customer accounts store contact information for the customer, saving logged-in customers the trouble of having to provide it at every checkout. */
 export type CustomerMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 
@@ -3165,7 +2996,10 @@ export enum DiscountApplicationAllocationMethod {
   Across = 'ACROSS',
   /** The value is applied onto every entitled line. */
   Each = 'EACH',
-  /** The value is specifically applied onto a particular line. */
+  /**
+   * The value is specifically applied onto a particular line.
+   * @deprecated Use ACROSS instead.
+   */
   One = 'ONE'
 }
 
@@ -3438,11 +3272,10 @@ export type HasMetafields = {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
 };
 
 
@@ -3455,12 +3288,15 @@ export type HasMetafieldsMetafieldArgs = {
 
 /** Represents information about the metafields associated to the specified resource. */
 export type HasMetafieldsMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
+};
+
+/** Identifies a metafield on an owner resource by namespace and key. */
+export type HasMetafieldsIdentifier = {
+  /** The identifier for the metafield. */
+  key: Scalars['String'];
+  /** A container for a set of metafields. */
+  namespace: Scalars['String'];
 };
 
 /** Represents an image resource. */
@@ -3564,16 +3400,16 @@ export type ImageEdge = {
 /**
  * The available options for transforming an image.
  *
- * All transformation options are considered "best-effort". Any transformation that the original image type doesn't support will be ignored.
+ * All transformation options are considered best effort. Any transformation that the original image type doesn't support will be ignored.
  *
  */
 export type ImageTransformInput = {
   /**
-   * Region of the image to remain after cropping.
-   * Must be used in conjunction with maxWidth and/or maxHeight fields where the maxWidth / maxHeight are not equal.
-   * The crop parameter should coincide with the smaller value (i.e. smaller maxWidth indicates a LEFT / RIGHT crop, while
-   * smaller maxHeight indicates a TOP / BOTTOM crop). For example, { maxWidth: 5, maxHeight: 10, crop: LEFT } will result
-   * in an image with width 5 and height 10, where the right side of the image is removed.
+   * The region of the image to remain after cropping.
+   * Must be used in conjunction with the `maxWidth` and/or `maxHeight` fields, where the `maxWidth` and `maxHeight` aren't equal.
+   * The `crop` argument should coincide with the smaller value. A smaller `maxWidth` indicates a `LEFT` or `RIGHT` crop, while
+   * a smaller `maxHeight` indicates a `TOP` or `BOTTOM` crop. For example, `{ maxWidth: 5, maxHeight: 10, crop: LEFT }` will result
+   * in an image with a width of 5 and height of 10, where the right side of the image is removed.
    *
    */
   crop?: InputMaybe<CropRegion>;
@@ -3757,7 +3593,7 @@ export enum LanguageCode {
   Lv = 'LV',
   /** Malagasy. */
   Mg = 'MG',
-  /** Maori. */
+  /** Māori. */
   Mi = 'MI',
   /** Macedonian. */
   Mk = 'MK',
@@ -4333,32 +4169,6 @@ export type Metafield = Node & {
 };
 
 /**
- * An auto-generated type for paginating through multiple Metafields.
- *
- */
-export type MetafieldConnection = {
-  __typename?: 'MetafieldConnection';
-  /** A list of edges. */
-  edges: Array<MetafieldEdge>;
-  /** A list of the nodes contained in MetafieldEdge. */
-  nodes: Array<Metafield>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-};
-
-/**
- * An auto-generated type which holds one Metafield and a cursor during pagination.
- *
- */
-export type MetafieldEdge = {
-  __typename?: 'MetafieldEdge';
-  /** A cursor for use in pagination. */
-  cursor: Scalars['String'];
-  /** The item at the end of MetafieldEdge. */
-  node: Metafield;
-};
-
-/**
  * A filter used to view a subset of products in a collection matching a specific metafield value.
  *
  * Only the following metafield types are currently supported:
@@ -4459,76 +4269,26 @@ export type Mutation = {
   cartLinesUpdate?: Maybe<CartLinesUpdatePayload>;
   /** Updates the note on the cart. */
   cartNoteUpdate?: Maybe<CartNoteUpdatePayload>;
-  /**
-   * Updates the attributes of a checkout if `allowPartialAddresses` is `true`.
-   * @deprecated Use `checkoutAttributesUpdateV2` instead
-   */
-  checkoutAttributesUpdate?: Maybe<CheckoutAttributesUpdatePayload>;
   /** Updates the attributes of a checkout if `allowPartialAddresses` is `true`. */
   checkoutAttributesUpdateV2?: Maybe<CheckoutAttributesUpdateV2Payload>;
   /** Completes a checkout without providing payment information. You can use this mutation for free items or items whose purchase price is covered by a gift card. */
   checkoutCompleteFree?: Maybe<CheckoutCompleteFreePayload>;
-  /**
-   * Completes a checkout using a credit card token from Shopify's Vault.
-   * @deprecated Use `checkoutCompleteWithCreditCardV2` instead
-   */
-  checkoutCompleteWithCreditCard?: Maybe<CheckoutCompleteWithCreditCardPayload>;
   /** Completes a checkout using a credit card token from Shopify's card vault. Before you can complete checkouts using CheckoutCompleteWithCreditCardV2, you need to  [_request payment processing_](https://shopify.dev/apps/channels/getting-started#request-payment-processing). */
   checkoutCompleteWithCreditCardV2?: Maybe<CheckoutCompleteWithCreditCardV2Payload>;
-  /**
-   * Completes a checkout with a tokenized payment.
-   * @deprecated Use `checkoutCompleteWithTokenizedPaymentV2` instead
-   */
-  checkoutCompleteWithTokenizedPayment?: Maybe<CheckoutCompleteWithTokenizedPaymentPayload>;
-  /**
-   * Completes a checkout with a tokenized payment.
-   * @deprecated Use `checkoutCompleteWithTokenizedPaymentV3` instead
-   */
-  checkoutCompleteWithTokenizedPaymentV2?: Maybe<CheckoutCompleteWithTokenizedPaymentV2Payload>;
   /** Completes a checkout with a tokenized payment. */
   checkoutCompleteWithTokenizedPaymentV3?: Maybe<CheckoutCompleteWithTokenizedPaymentV3Payload>;
   /** Creates a new checkout. */
   checkoutCreate?: Maybe<CheckoutCreatePayload>;
-  /**
-   * Associates a customer to the checkout.
-   * @deprecated Use `checkoutCustomerAssociateV2` instead
-   */
-  checkoutCustomerAssociate?: Maybe<CheckoutCustomerAssociatePayload>;
   /** Associates a customer to the checkout. */
   checkoutCustomerAssociateV2?: Maybe<CheckoutCustomerAssociateV2Payload>;
-  /**
-   * Disassociates the current checkout customer from the checkout.
-   * @deprecated Use `checkoutCustomerDisassociateV2` instead
-   */
-  checkoutCustomerDisassociate?: Maybe<CheckoutCustomerDisassociatePayload>;
   /** Disassociates the current checkout customer from the checkout. */
   checkoutCustomerDisassociateV2?: Maybe<CheckoutCustomerDisassociateV2Payload>;
-  /**
-   * Applies a discount to an existing checkout using a discount code.
-   * @deprecated Use `checkoutDiscountCodeApplyV2` instead
-   */
-  checkoutDiscountCodeApply?: Maybe<CheckoutDiscountCodeApplyPayload>;
   /** Applies a discount to an existing checkout using a discount code. */
   checkoutDiscountCodeApplyV2?: Maybe<CheckoutDiscountCodeApplyV2Payload>;
   /** Removes the applied discounts from an existing checkout. */
   checkoutDiscountCodeRemove?: Maybe<CheckoutDiscountCodeRemovePayload>;
-  /**
-   * Updates the email on an existing checkout.
-   * @deprecated Use `checkoutEmailUpdateV2` instead
-   */
-  checkoutEmailUpdate?: Maybe<CheckoutEmailUpdatePayload>;
   /** Updates the email on an existing checkout. */
   checkoutEmailUpdateV2?: Maybe<CheckoutEmailUpdateV2Payload>;
-  /**
-   * Applies a gift card to an existing checkout using a gift card code. This will replace all currently applied gift cards.
-   * @deprecated Use `checkoutGiftCardsAppend` instead
-   */
-  checkoutGiftCardApply?: Maybe<CheckoutGiftCardApplyPayload>;
-  /**
-   * Removes an applied gift card from the checkout.
-   * @deprecated Use `checkoutGiftCardRemoveV2` instead
-   */
-  checkoutGiftCardRemove?: Maybe<CheckoutGiftCardRemovePayload>;
   /** Removes an applied gift card from the checkout. */
   checkoutGiftCardRemoveV2?: Maybe<CheckoutGiftCardRemoveV2Payload>;
   /** Appends gift cards to an existing checkout. */
@@ -4541,11 +4301,6 @@ export type Mutation = {
   checkoutLineItemsReplace?: Maybe<CheckoutLineItemsReplacePayload>;
   /** Updates line items on a checkout. */
   checkoutLineItemsUpdate?: Maybe<CheckoutLineItemsUpdatePayload>;
-  /**
-   * Updates the shipping address of an existing checkout.
-   * @deprecated Use `checkoutShippingAddressUpdateV2` instead
-   */
-  checkoutShippingAddressUpdate?: Maybe<CheckoutShippingAddressUpdatePayload>;
   /** Updates the shipping address of an existing checkout. */
   checkoutShippingAddressUpdateV2?: Maybe<CheckoutShippingAddressUpdateV2Payload>;
   /** Updates the shipping lines on an existing checkout. */
@@ -4557,9 +4312,10 @@ export type Mutation = {
    */
   customerAccessTokenCreate?: Maybe<CustomerAccessTokenCreatePayload>;
   /**
-   * Creates a customer access token using a multipass token instead of email and password.
-   * A customer record is created if customer does not exist. If a customer record already
-   * exists but the record is disabled, then it's enabled.
+   * Creates a customer access token using a
+   * [multipass token](https://shopify.dev/api/multipass) instead of email and
+   * password. A customer record is created if the customer doesn't exist. If a customer
+   * record already exists but the record is disabled, then the customer record is enabled.
    *
    */
   customerAccessTokenCreateWithMultipass?: Maybe<CustomerAccessTokenCreateWithMultipassPayload>;
@@ -4587,11 +4343,20 @@ export type Mutation = {
   customerCreate?: Maybe<CustomerCreatePayload>;
   /** Updates the default address of an existing customer. */
   customerDefaultAddressUpdate?: Maybe<CustomerDefaultAddressUpdatePayload>;
-  /** Sends a reset password email to the customer, as the first step in the reset password process. */
+  /**
+   * "Sends a reset password email to the customer. The reset password email contains a reset password URL and token that you can pass to the [`customerResetByUrl`](https://shopify.dev/api/storefront/latest/mutations/customerResetByUrl) or [`customerReset`](https://shopify.dev/api/storefront/latest/mutations/customerReset) mutation to reset the customer password."
+   *
+   */
   customerRecover?: Maybe<CustomerRecoverPayload>;
-  /** Resets a customer’s password with a token received from `CustomerRecover`. */
+  /**
+   * "Resets a customer’s password with the token received from a reset password email. You can send a reset password email with the [`customerRecover`](https://shopify.dev/api/storefront/latest/mutations/customerRecover) mutation."
+   *
+   */
   customerReset?: Maybe<CustomerResetPayload>;
-  /** Resets a customer’s password with the reset password url received from `CustomerRecover`. */
+  /**
+   * "Resets a customer’s password with the reset password URL received from a reset password email. You can send a reset password email with the [`customerRecover`](https://shopify.dev/api/storefront/latest/mutations/customerRecover) mutation."
+   *
+   */
   customerResetByUrl?: Maybe<CustomerResetByUrlPayload>;
   /** Updates an existing customer. */
   customerUpdate?: Maybe<CustomerUpdatePayload>;
@@ -4654,13 +4419,6 @@ export type MutationCartNoteUpdateArgs = {
 
 
 /** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutAttributesUpdateArgs = {
-  checkoutId: Scalars['ID'];
-  input: CheckoutAttributesUpdateInput;
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
 export type MutationCheckoutAttributesUpdateV2Args = {
   checkoutId: Scalars['ID'];
   input: CheckoutAttributesUpdateV2Input;
@@ -4674,30 +4432,9 @@ export type MutationCheckoutCompleteFreeArgs = {
 
 
 /** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutCompleteWithCreditCardArgs = {
-  checkoutId: Scalars['ID'];
-  payment: CreditCardPaymentInput;
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
 export type MutationCheckoutCompleteWithCreditCardV2Args = {
   checkoutId: Scalars['ID'];
   payment: CreditCardPaymentInputV2;
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutCompleteWithTokenizedPaymentArgs = {
-  checkoutId: Scalars['ID'];
-  payment: TokenizedPaymentInput;
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutCompleteWithTokenizedPaymentV2Args = {
-  checkoutId: Scalars['ID'];
-  payment: TokenizedPaymentInputV2;
 };
 
 
@@ -4716,13 +4453,6 @@ export type MutationCheckoutCreateArgs = {
 
 
 /** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutCustomerAssociateArgs = {
-  checkoutId: Scalars['ID'];
-  customerAccessToken: Scalars['String'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
 export type MutationCheckoutCustomerAssociateV2Args = {
   checkoutId: Scalars['ID'];
   customerAccessToken: Scalars['String'];
@@ -4730,21 +4460,8 @@ export type MutationCheckoutCustomerAssociateV2Args = {
 
 
 /** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutCustomerDisassociateArgs = {
-  checkoutId: Scalars['ID'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
 export type MutationCheckoutCustomerDisassociateV2Args = {
   checkoutId: Scalars['ID'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutDiscountCodeApplyArgs = {
-  checkoutId: Scalars['ID'];
-  discountCode: Scalars['String'];
 };
 
 
@@ -4762,30 +4479,9 @@ export type MutationCheckoutDiscountCodeRemoveArgs = {
 
 
 /** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutEmailUpdateArgs = {
-  checkoutId: Scalars['ID'];
-  email: Scalars['String'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
 export type MutationCheckoutEmailUpdateV2Args = {
   checkoutId: Scalars['ID'];
   email: Scalars['String'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutGiftCardApplyArgs = {
-  checkoutId: Scalars['ID'];
-  giftCardCode: Scalars['String'];
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutGiftCardRemoveArgs = {
-  appliedGiftCardId: Scalars['ID'];
-  checkoutId: Scalars['ID'];
 };
 
 
@@ -4828,13 +4524,6 @@ export type MutationCheckoutLineItemsReplaceArgs = {
 export type MutationCheckoutLineItemsUpdateArgs = {
   checkoutId: Scalars['ID'];
   lineItems: Array<CheckoutLineItemUpdateInput>;
-};
-
-
-/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
-export type MutationCheckoutShippingAddressUpdateArgs = {
-  checkoutId: Scalars['ID'];
-  shippingAddress: MailingAddressInput;
 };
 
 
@@ -5007,11 +4696,10 @@ export type Order = HasMetafields & Node & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /**
    * Unique identifier for the order that appears on the order.
    * For example, _#1000_ or _Store1001.
@@ -5111,12 +4799,7 @@ export type OrderMetafieldArgs = {
 
 /** An order is a customer’s completed request to purchase one or more products from a shop. An order is created when a customer completes the checkout process, during which time they provides an email address, billing address and payment information. */
 export type OrderMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 
@@ -5284,11 +4967,10 @@ export type Page = HasMetafields & Node & OnlineStorePublishable & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The URL used for viewing the resource on the shop's Online Store. Returns `null` if the resource is currently not published to the Online Store sales channel. */
   onlineStoreUrl?: Maybe<Scalars['URL']>;
   /** The page's SEO information. */
@@ -5309,12 +4991,7 @@ export type PageMetafieldArgs = {
 
 /** Shopify merchants can create pages to hold static HTML content. Each Page object represents a custom page on the online store. */
 export type PageMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 /**
@@ -5405,7 +5082,7 @@ export type Payment = Node & {
   idempotencyKey?: Maybe<Scalars['String']>;
   /** The URL where the customer needs to be redirected so they can complete the 3D Secure payment flow. */
   nextActionUrl?: Maybe<Scalars['URL']>;
-  /** Whether or not the payment is still processing asynchronously. */
+  /** Whether the payment is still processing asynchronously. */
   ready: Scalars['Boolean'];
   /** A flag to indicate if the payment is to be done in test mode for gateways that support it. */
   test: Scalars['Boolean'];
@@ -5504,11 +5181,10 @@ export type Product = HasMetafields & Node & OnlineStorePublishable & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** The URL used for viewing the resource on the shop's Online Store. Returns `null` if the resource is currently not published to the Online Store sales channel. */
   onlineStoreUrl?: Maybe<Scalars['URL']>;
   /** List of product options. */
@@ -5622,12 +5298,7 @@ export type ProductMetafieldArgs = {
  * For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty).
  */
 export type ProductMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 
@@ -5852,11 +5523,10 @@ export type ProductVariant = HasMetafields & Node & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /**
    * The product variant’s price.
    * @deprecated Use `priceV2` instead
@@ -5900,12 +5570,7 @@ export type ProductVariantMetafieldArgs = {
 
 /** A product variant represents a different version of a product, such as differing sizes or differing colors. */
 export type ProductVariantMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 
@@ -5986,7 +5651,7 @@ export type QueryRoot = {
   blogByHandle?: Maybe<Blog>;
   /** List of the shop's blogs. */
   blogs: BlogConnection;
-  /** Find a cart by its ID. */
+  /** Retrieve a cart by its ID. For more information, refer to [Manage a cart with the Storefront API](https://shopify.dev/api/examples/cart). */
   cart?: Maybe<Cart>;
   /** Fetch a specific `Collection` by one of its unique attributes. */
   collection?: Maybe<Collection>;
@@ -6051,6 +5716,8 @@ export type QueryRoot = {
   publicApiVersions: Array<ApiVersion>;
   /** The shop associated with the storefront access token. */
   shop: Shop;
+  /** A list of redirects for a shop. */
+  urlRedirects: UrlRedirectConnection;
 };
 
 
@@ -6225,6 +5892,16 @@ export type QueryRootProductsArgs = {
   sortKey?: InputMaybe<ProductSortKeys>;
 };
 
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootUrlRedirectsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  reverse?: InputMaybe<Scalars['Boolean']>;
+};
+
 /** SEO information. */
 export type Seo = {
   __typename?: 'SEO';
@@ -6277,13 +5954,15 @@ export type SelectedOptionInput = {
 /** Represents how products and variants can be sold and purchased. */
 export type SellingPlan = {
   __typename?: 'SellingPlan';
+  /** The initial payment due for the purchase. */
+  checkoutCharge: SellingPlanCheckoutCharge;
   /** The description of the selling plan. */
   description?: Maybe<Scalars['String']>;
   /** A globally-unique identifier. */
   id: Scalars['ID'];
   /** The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'. */
   name: Scalars['String'];
-  /** The selling plan options available in the drop-down list in the storefront. For example, 'Delivery every week' or 'Delivery every 2 weeks' specifies the delivery frequency options for the product. */
+  /** The selling plan options available in the drop-down list in the storefront. For example, 'Delivery every week' or 'Delivery every 2 weeks' specifies the delivery frequency options for the product. Individual selling plans contribute their options to the associated selling plan group. For example, a selling plan group might have an option called `option1: Delivery every`. One selling plan in that group could contribute `option1: 2 weeks` with the pricing for that option, and another selling plan could contribute `option1: 4 weeks`, with different pricing. */
   options: Array<SellingPlanOption>;
   /** The price adjustments that a selling plan makes when a variant is purchased with a selling plan. */
   priceAdjustments: Array<SellingPlanPriceAdjustment>;
@@ -6294,8 +5973,12 @@ export type SellingPlan = {
 /** Represents an association between a variant and a selling plan. Selling plan allocations describe the options offered for each variant, and the price of the variant when purchased with a selling plan. */
 export type SellingPlanAllocation = {
   __typename?: 'SellingPlanAllocation';
+  /** The checkout charge amount due for the purchase. */
+  checkoutChargeAmount: MoneyV2;
   /** A list of price adjustments, with a maximum of two. When there are two, the first price adjustment goes into effect at the time of purchase, while the second one starts after a certain number of orders. A price adjustment represents how a selling plan affects pricing when a variant is purchased with a selling plan. Prices display in the customer's currency if the shop is configured for it. */
   priceAdjustments: Array<SellingPlanAllocationPriceAdjustment>;
+  /** The remaining balance charge amount due for the purchase. */
+  remainingBalanceChargeAmount: MoneyV2;
   /** A representation of how products and variants can be sold and purchased. For example, an individual selling plan could be '6 weeks of prepaid granola, delivered weekly'. */
   sellingPlan: SellingPlan;
 };
@@ -6338,6 +6021,33 @@ export type SellingPlanAllocationPriceAdjustment = {
   /** The resulting price per unit for the variant associated with the selling plan. If the variant isn't sold by quantity or measurement, then this field returns `null`. */
   unitPrice?: Maybe<MoneyV2>;
 };
+
+/** The initial payment due for the purchase. */
+export type SellingPlanCheckoutCharge = {
+  __typename?: 'SellingPlanCheckoutCharge';
+  /** The charge type for the checkout charge. */
+  type: SellingPlanCheckoutChargeType;
+  /** The charge value for the checkout charge. */
+  value: SellingPlanCheckoutChargeValue;
+};
+
+/** The percentage value of the price used for checkout charge. */
+export type SellingPlanCheckoutChargePercentageValue = {
+  __typename?: 'SellingPlanCheckoutChargePercentageValue';
+  /** The percentage value of the price used for checkout charge. */
+  percentage: Scalars['Float'];
+};
+
+/** The checkout charge when the full amount isn't charged at checkout. */
+export enum SellingPlanCheckoutChargeType {
+  /** The checkout charge is a percentage of the product or variant price. */
+  Percentage = 'PERCENTAGE',
+  /** The checkout charge is a fixed price amount. */
+  Price = 'PRICE'
+}
+
+/** The portion of the price to be charged at checkout. */
+export type SellingPlanCheckoutChargeValue = MoneyV2 | SellingPlanCheckoutChargePercentageValue;
 
 /**
  * An auto-generated type for paginating through multiple SellingPlans.
@@ -6428,7 +6138,11 @@ export type SellingPlanGroupEdge = {
   node: SellingPlanGroup;
 };
 
-/** Represents an option on a selling plan group that's available in the drop-down list in the storefront. */
+/**
+ * Represents an option on a selling plan group that's available in the drop-down list in the storefront.
+ *
+ * Individual selling plans contribute their options to the associated selling plan group. For example, a selling plan group might have an option called `option1: Delivery every`. One selling plan in that group could contribute `option1: 2 weeks` with the pricing for that option, and another selling plan could contribute `option1: 4 weeks`, with different pricing.
+ */
 export type SellingPlanGroupOption = {
   __typename?: 'SellingPlanGroupOption';
   /** The name of the option. For example, 'Delivery every'. */
@@ -6453,12 +6167,12 @@ export type SellingPlanPercentagePriceAdjustment = {
   adjustmentPercentage: Scalars['Int'];
 };
 
-/** Represents by how much the price of a variant associated with a selling plan is adjusted. Each variant can have up to two price adjustments. */
+/** Represents by how much the price of a variant associated with a selling plan is adjusted. Each variant can have up to two price adjustments. If a variant has multiple price adjustments, then the first price adjustment applies when the variant is initially purchased. The second price adjustment applies after a certain number of orders (specified by the `orderCount` field) are made. If a selling plan doesn't have any price adjustments, then the unadjusted price of the variant is the effective price. */
 export type SellingPlanPriceAdjustment = {
   __typename?: 'SellingPlanPriceAdjustment';
   /** The type of price adjustment. An adjustment value can have one of three types: percentage, amount off, or a new price. */
   adjustmentValue: SellingPlanPriceAdjustmentValue;
-  /** The number of orders that the price adjustment applies to If the price adjustment always applies, then this field is `null`. */
+  /** The number of orders that the price adjustment applies to. If the price adjustment always applies, then this field is `null`. */
   orderCount?: Maybe<Scalars['Int']>;
 };
 
@@ -6491,18 +6205,17 @@ export type Shop = HasMetafields & Node & {
   /** Returns a metafield found by namespace and key. */
   metafield?: Maybe<Metafield>;
   /**
-   * A paginated list of metafields associated with the resource.
-   * @deprecated As of 2022-07, the paginated `metafields` field has been repurposed to require a list of metafield identifiers.
+   * The metafields associated with the resource matching the supplied list of namespaces and keys.
    *
    */
-  metafields: MetafieldConnection;
+  metafields: Array<Maybe<Metafield>>;
   /** A string representing the way currency is formatted when the currency isn’t specified. */
   moneyFormat: Scalars['String'];
   /** The shop’s name. */
   name: Scalars['String'];
   /** Settings related to payments. */
   paymentSettings: PaymentSettings;
-  /** The shop’s primary domain. */
+  /** The primary domain of the shop’s Online Store. */
   primaryDomain: Domain;
   /** The shop’s privacy policy. */
   privacyPolicy?: Maybe<ShopPolicy>;
@@ -6528,12 +6241,7 @@ export type ShopMetafieldArgs = {
 
 /** Shop represents a collection of the general settings and information about the shop. */
 export type ShopMetafieldsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  namespace?: InputMaybe<Scalars['String']>;
-  reverse?: InputMaybe<Scalars['Boolean']>;
+  identifiers: Array<HasMetafieldsIdentifier>;
 };
 
 /** Policy that a merchant has configured for their store, such as their refund or privacy policy. */
@@ -6578,7 +6286,7 @@ export type ShopPolicyWithDefault = {
  */
 export type StoreAvailability = {
   __typename?: 'StoreAvailability';
-  /** Whether or not this product variant is in-stock at this location. */
+  /** Whether the product variant is in-stock at this location. */
   available: Scalars['Boolean'];
   /** The location where this product variant is stocked at. */
   location: Location;
@@ -6634,50 +6342,6 @@ export type StringEdge = {
   cursor: Scalars['String'];
   /** The item at the end of StringEdge. */
   node: Scalars['String'];
-};
-
-/**
- * Specifies the fields required to complete a checkout with
- * a tokenized payment.
- *
- */
-export type TokenizedPaymentInput = {
-  /** The amount of the payment. */
-  amount: Scalars['Money'];
-  /** The billing address for the payment. */
-  billingAddress: MailingAddressInput;
-  /** A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one. For more information, refer to [Idempotent requests](https://shopify.dev/api/usage/idempotent-requests). */
-  idempotencyKey: Scalars['String'];
-  /** Public Hash Key used for AndroidPay payments only. */
-  identifier?: InputMaybe<Scalars['String']>;
-  /** A simple string or JSON containing the required payment data for the tokenized payment. */
-  paymentData: Scalars['String'];
-  /** Executes the payment in test mode if possible. Defaults to `false`. */
-  test?: InputMaybe<Scalars['Boolean']>;
-  /** The type of payment token. */
-  type: Scalars['String'];
-};
-
-/**
- * Specifies the fields required to complete a checkout with
- * a tokenized payment.
- *
- */
-export type TokenizedPaymentInputV2 = {
-  /** The billing address for the payment. */
-  billingAddress: MailingAddressInput;
-  /** A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one. For more information, refer to [Idempotent requests](https://shopify.dev/api/usage/idempotent-requests). */
-  idempotencyKey: Scalars['String'];
-  /** Public Hash Key used for AndroidPay payments only. */
-  identifier?: InputMaybe<Scalars['String']>;
-  /** The amount and currency of the payment. */
-  paymentAmount: MoneyInput;
-  /** A simple string or JSON containing the required payment data for the tokenized payment. */
-  paymentData: Scalars['String'];
-  /** Whether to execute the payment in test mode, if possible. Test mode is not supported in production stores. Defaults to `false`. */
-  test?: InputMaybe<Scalars['Boolean']>;
-  /** The type of payment token. */
-  type: Scalars['String'];
 };
 
 /**
@@ -6819,6 +6483,43 @@ export enum UnitSystem {
   MetricSystem = 'METRIC_SYSTEM'
 }
 
+/** A redirect on the online store. */
+export type UrlRedirect = Node & {
+  __typename?: 'UrlRedirect';
+  /** The ID of the URL redirect. */
+  id: Scalars['ID'];
+  /** The old path to be redirected from. When the user visits this path, they'll be redirected to the target location. */
+  path: Scalars['String'];
+  /** The target location where the user will be redirected to. */
+  target: Scalars['String'];
+};
+
+/**
+ * An auto-generated type for paginating through multiple UrlRedirects.
+ *
+ */
+export type UrlRedirectConnection = {
+  __typename?: 'UrlRedirectConnection';
+  /** A list of edges. */
+  edges: Array<UrlRedirectEdge>;
+  /** A list of the nodes contained in UrlRedirectEdge. */
+  nodes: Array<UrlRedirect>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/**
+ * An auto-generated type which holds one UrlRedirect and a cursor during pagination.
+ *
+ */
+export type UrlRedirectEdge = {
+  __typename?: 'UrlRedirectEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of UrlRedirectEdge. */
+  node: UrlRedirect;
+};
+
 /** Represents an error in the input of a mutation. */
 export type UserError = DisplayableError & {
   __typename?: 'UserError';
@@ -6878,7 +6579,7 @@ export enum WeightUnit {
   Pounds = 'POUNDS'
 }
 
-export type Cart_CartFragment = { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> };
+export type Cart_CartFragment = { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> };
 
 export type Image_ImageFragment = { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null };
 
@@ -6896,7 +6597,7 @@ export type CartAttributesUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CartAttributesUpdateMutation = { __typename?: 'Mutation', cartAttributesUpdate?: { __typename?: 'CartAttributesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartAttributesUpdateMutation = { __typename?: 'Mutation', cartAttributesUpdate?: { __typename?: 'CartAttributesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartBuyerIdentityUpdateMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6906,7 +6607,7 @@ export type CartBuyerIdentityUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CartBuyerIdentityUpdateMutation = { __typename?: 'Mutation', cartBuyerIdentityUpdate?: { __typename?: 'CartBuyerIdentityUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartBuyerIdentityUpdateMutation = { __typename?: 'Mutation', cartBuyerIdentityUpdate?: { __typename?: 'CartBuyerIdentityUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartCreateMutationVariables = Exact<{
   input: CartInput;
@@ -6915,7 +6616,7 @@ export type CartCreateMutationVariables = Exact<{
 }>;
 
 
-export type CartCreateMutation = { __typename?: 'Mutation', cartCreate?: { __typename?: 'CartCreatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartCreateMutation = { __typename?: 'Mutation', cartCreate?: { __typename?: 'CartCreatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartDiscountCodesUpdateMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6925,7 +6626,7 @@ export type CartDiscountCodesUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CartDiscountCodesUpdateMutation = { __typename?: 'Mutation', cartDiscountCodesUpdate?: { __typename?: 'CartDiscountCodesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartDiscountCodesUpdateMutation = { __typename?: 'Mutation', cartDiscountCodesUpdate?: { __typename?: 'CartDiscountCodesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartLineAddMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6935,7 +6636,7 @@ export type CartLineAddMutationVariables = Exact<{
 }>;
 
 
-export type CartLineAddMutation = { __typename?: 'Mutation', cartLinesAdd?: { __typename?: 'CartLinesAddPayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartLineAddMutation = { __typename?: 'Mutation', cartLinesAdd?: { __typename?: 'CartLinesAddPayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartLineRemoveMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6945,7 +6646,7 @@ export type CartLineRemoveMutationVariables = Exact<{
 }>;
 
 
-export type CartLineRemoveMutation = { __typename?: 'Mutation', cartLinesRemove?: { __typename?: 'CartLinesRemovePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartLineRemoveMutation = { __typename?: 'Mutation', cartLinesRemove?: { __typename?: 'CartLinesRemovePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartLineUpdateMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6955,7 +6656,7 @@ export type CartLineUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CartLineUpdateMutation = { __typename?: 'Mutation', cartLinesUpdate?: { __typename?: 'CartLinesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartLineUpdateMutation = { __typename?: 'Mutation', cartLinesUpdate?: { __typename?: 'CartLinesUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartNoteUpdateMutationVariables = Exact<{
   cartId: Scalars['ID'];
@@ -6965,7 +6666,7 @@ export type CartNoteUpdateMutationVariables = Exact<{
 }>;
 
 
-export type CartNoteUpdateMutation = { __typename?: 'Mutation', cartNoteUpdate?: { __typename?: 'CartNoteUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
+export type CartNoteUpdateMutation = { __typename?: 'Mutation', cartNoteUpdate?: { __typename?: 'CartNoteUpdatePayload', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null, userErrors: Array<{ __typename?: 'CartUserError', code?: CartErrorCode | null, field?: Array<string> | null, message: string }> } | null };
 
 export type CartQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -6974,4 +6675,4 @@ export type CartQueryVariables = Exact<{
 }>;
 
 
-export type CartQuery = { __typename?: 'QueryRoot', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null };
+export type CartQuery = { __typename?: 'QueryRoot', cart?: { __typename?: 'Cart', id: string, checkoutUrl: any, createdAt: any, updatedAt: any, note?: string | null, buyerIdentity: { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null }, lines: { __typename?: 'CartLineConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'CartLineEdge', cursor: string, node: { __typename?: 'CartLine', id: string, quantity: number, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, estimatedCost: { __typename?: 'CartLineEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode }, totalAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }, discountAllocations: Array<{ __typename?: 'CartAutomaticDiscountAllocation', title: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCodeDiscountAllocation', code: string, discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } } | { __typename?: 'CartCustomDiscountAllocation', discountedAmount: { __typename?: 'MoneyV2', amount: any, currencyCode: CurrencyCode } }>, merchandise: { __typename?: 'ProductVariant', id: string, availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> } } }> }, estimatedCost: { __typename?: 'CartEstimatedCost', subtotalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalAmount: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, totalDutyAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, totalTaxAmount?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null }, attributes: Array<{ __typename?: 'Attribute', key: string, value?: string | null }>, discountCodes: Array<{ __typename?: 'CartDiscountCode', code: string }> } | null };

--- a/packages/shopify-cart/src/utils/createGqlClient.ts
+++ b/packages/shopify-cart/src/utils/createGqlClient.ts
@@ -54,7 +54,7 @@ export default function createGqlClient({
       throw new Error(missingParametersErrorMessage);
     }
     const domain = sanitizeShopId(shopifyShopId);
-    endpoint = `https://${domain}.myshopify.com/api/2022-04/graphql`;
+    endpoint = `https://${domain}.myshopify.com/api/2022-07/graphql`;
   }
 
   const gqlClient: GqlClient = ({ query, variables }) => {


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-6848](https://nacelle.atlassian.net/browse/ENG-6848)

> Update Shopify API to `2022-07` & run `codegen`

## What is this pull request doing?

This PR updates all instances of the Shopify API from `2022-04` to `2022-07`.  All types are generated from the newer API version and mocks are updated.

## How to Test

1. Check out the `ENG-6848/update-shopify-api` branch.
2. `npm run bootstrap` from the monorepo root, as needed.
3. `cd packages/shopify-cart`
4. `npm run test:ci` - tests should pass with 100% coverage:

<img width="370" alt="Screen Shot 2022-08-26 at 10 09 26 AM" src="https://user-images.githubusercontent.com/24395931/186923861-9f202abd-caf8-4e48-808a-69c50459627b.png">

### E2E Checklist
Using the `thinx-test` vite project confirm the following mutations work.

- [x] `cartAttributesUpdate` 
<img width="494" alt="cartAttributesUpdate" src="https://user-images.githubusercontent.com/24395931/186939497-0e7fe536-1858-43ab-a10f-f10db084b0c2.png">

- [x] `cartBuyerIdentityUpdate`
<img width="455" alt="cartBuyerIdentityUpdate" src="https://user-images.githubusercontent.com/24395931/186939525-5a54b9ba-000a-436b-81a5-3ace9389adf8.png">

- [x] `cartCreate` 
<img width="463" alt="cartCreate" src="https://user-images.githubusercontent.com/24395931/186938723-c3e0a539-7441-4518-a73e-56fd48211f79.png">

- [x] `cartDiscountCodesUpdate`
<img width="451" alt="cartDiscountCodesUpdate" src="https://user-images.githubusercontent.com/24395931/186940417-d451f6b8-c740-40a4-a17e-522ebfe66f72.png">

- [x] `cartLinesAdd`
<img width="538" alt="cartLinesAdd" src="https://user-images.githubusercontent.com/24395931/186942168-d7b3b693-6b7f-4622-90da-984ce14f6c86.png">

- [x] `cartLinesRemove`
<img width="456" alt="cartLinesRemove" src="https://user-images.githubusercontent.com/24395931/186942187-a3334ecb-7606-4734-a919-8db94059fb6c.png">

- [x] `cartLinesUpdate`
<img width="522" alt="cartLinesUpdate" src="https://user-images.githubusercontent.com/24395931/186942214-fe1f8b08-23b4-4482-a3c6-9f36eff0f202.png">

- [x] `cartNoteUpdate`
<img width="451" alt="cartNoteUpdate" src="https://user-images.githubusercontent.com/24395931/186942249-f06618ee-b4b8-40b9-a9ba-d837b3f5dca5.png">

