### PR TITLE
fix: cart create empty params

### DIFF
--- a/.changeset/lucky-monkeys-glow.md
+++ b/.changeset/lucky-monkeys-glow.md
@@ -1,0 +1,5 @@
+---
+"@nacelle/nacelle-js": patch
+---
+
+Allow `cartCreate` mutation to accept no parameters

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -125,7 +125,7 @@ const cart = await cartClient.cartBuyerIdentityUpdate({
 
 _Creates a new Shopify cart._
 
-**Accepts**: params - an object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input]
+**Accepts**: params - an optional object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). To initialize an empty cart, exclude all parameters. For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input]
 
 **Returns**: a Shopify [`Cart`][shopify-cart-object].
 

--- a/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
@@ -25,6 +25,31 @@ describe('cartCreate', () => {
     jest.clearAllMocks();
   });
 
+  it('make a request with the expected query and variables when params empty', async () => {
+    mockedFetchClient.mockImplementationOnce(
+      (): Promise<any> =>
+        mockJsonResponse<CartCreateMutation>(
+          responses.mutations.cartCreate.withoutLine
+        )
+    );
+
+    await expect(cartCreate({ gqlClient })).resolves.toStrictEqual({
+      ...carts.withoutLine,
+      id: cartId,
+      lines: []
+    });
+
+    expect(fetchClient).toHaveBeenCalledTimes(1);
+    expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: mutations.CART_CREATE,
+        variables: { input: {} }
+      })
+    });
+  });
+
   it('make a request with the expected query and variables', async () => {
     mockedFetchClient.mockImplementationOnce(
       (): Promise<any> =>

--- a/packages/shopify-cart/src/client/actions/cartCreate.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.ts
@@ -10,7 +10,7 @@ import { GqlClient } from '../../cart-client.types';
 
 export interface CreateCartParams {
   gqlClient: GqlClient;
-  params: CartInput;
+  params?: CartInput;
 }
 
 export type CartCreateResponse = CartCreatePayload & CartFragmentResponse;
@@ -29,7 +29,7 @@ export default async function cartCreate({
       MutationCartCreateResponse
     >({
       query: mutations.CART_CREATE,
-      variables: { input: params }
+      variables: { input: params ?? {} }
     }).catch((err) => {
       throw new Error(err);
     });


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-6892](https://nacelle.atlassian.net/browse/ENG-6892)

> Allow `cartCreate` to work with no params - `cartCreate()`

## What is this pull request doing?

This PR ensures empty params can be passed to `cartCreate` mutation.  Adds test to cover scenario.

## How to Test

1. Check out the `ENG-6892/cart-create-empty-params` branch.
2. `npm run bootstrap` from the monorepo root, as needed.
3. `cd packages/shopify-cart`
4. `npm run test cartCreate` - tests should pass with 100% coverage:

<img width="453" alt="Screen Shot 2022-08-26 at 12 15 32 PM" src="https://user-images.githubusercontent.com/24395931/186948478-997cb88e-117b-46cf-8293-423ad75b57b0.png">

### E2E Checklist
Using the `thinx-test` vite project confirmed that `cartCreate` can now be called with no params

<img width="448" alt="Screen Shot 2022-08-26 at 12 12 02 PM" src="https://user-images.githubusercontent.com/24395931/186948554-82e218b0-f3e9-469e-b106-cd779ea4c149.png">