### PR TITLE
feat: cleans up vite config to ship mjs

### DIFF
--- a/.changeset/tidy-dryers-decide.md
+++ b/.changeset/tidy-dryers-decide.md
@@ -1,0 +1,8 @@
+---
+'@nacelle/shopify-cart': minor
+---
+
+- feat(breaking!): Exports `esm` builds as `nacelle-shopify-cart.mjs`
+- feat(breaking!): Uses `es2018` instead of `es2015`.
+- chore: removes some rollup `vite.config.js` configuration to use `vite 3.x` defaults
+- chore: uses `esbuild` for building/minifying

--- a/packages/shopify-cart/package.json
+++ b/packages/shopify-cart/package.json
@@ -32,12 +32,12 @@
     "npm": ">=7"
   },
   "main": "./dist/nacelle-shopify-cart.umd.js",
-  "module": "./dist/nacelle-shopify-cart.es.js",
+  "module": "./dist/nacelle-shopify-cart.mjs",
   "unpkg": "./dist/nacelle-shopify-cart.iife.js",
   "jsdelivr": "./dist/nacelle-shopify-cart.iife.js",
   "exports": {
     ".": {
-      "import": "./dist/nacelle-shopify-cart.es.js",
+      "import": "./dist/nacelle-shopify-cart.mjs",
       "require": "./dist/nacelle-shopify-cart.umd.js"
     }
   },

--- a/packages/shopify-cart/vite.config.ts
+++ b/packages/shopify-cart/vite.config.ts
@@ -6,24 +6,12 @@ export const config: UserConfig = {
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src', 'client', 'index.ts'),
-      fileName: (format) => `nacelle-shopify-cart.${format}.js`,
+      fileName: 'nacelle-shopify-cart',
       formats: ['es', 'umd', 'iife'],
       name: 'NacelleShopifyCart'
     },
-    rollupOptions: {
-      treeshake: 'smallest',
-      external: ['graphql-tag'],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          'graphql-tag': 'GraphqlTag'
-        }
-      }
-    },
     sourcemap: true,
-    target: 'es2015',
-    minify: 'esbuild'
+    target: 'es2018'
   },
   plugins: []
 };


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-6979](https://nacelle.atlassian.net/browse/ENG-6979) - Updates vite config for shopify-cart to ship mjs files for esm. This allows node packages to use native esm. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Replaces the file mapping in the `vite.config.js` with just the file name. This causes Vite to ship `mjs` files for `es` targets.
2. Removes the rollup section
3. Sets the target to es2018. Should support most of our users without transpilation, and sites who need older targets can transpile. 
4. Removes the minify key so Vite can use esbuild by default. 
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->


## How to Test

1. Checkout thisbranch locally `mdarrik/shopify-cart/ENG-6979-update-vite-config-for-esm`
2. Run a build with `npm run build`, should see dist files for `nacelle-shopify-cart.mjs`, `nacelle-shopify-cart.iife.js`  & `nacelle-shopify-cart.umd.js`.
3. You should be able to import `@nacelle/shopify-cart` as native esm in node.
   1. Run `npm link` from `nacelle-js/packages/shopify-cart` folder
   2. Go to/create a repo that has this package installed, and use `npm link @nacelle/shopify-cart` to link it locally
   3. Test using either `node` in your terminal or creating a `index.mjs` file and running `node index.mjs` (see below for instructions)

### Testing with node command line repl

1. Follow  how to test instructions above
2. Set `"type": "module"` in the `package.json` of the test repo
3. In the terminal, type `node`
4. Then type `let createShopifyCart = (await import('@nacelle/shopify-cart')).default`
5. You should now be able to use `createShopifyCart` to instantiate a `shopifyCart` instance. Or if you type `createShopifyCart` you should see that it's a function

### Testing with a .mjs file

1. Follow the test instructions above
2. Create an `index.mjs` file
3. import from `@nacelle/shopify-cart`:
    ```js
    import createShopifyCart from '@nacelle/shopifyCart';
    // do whatever you want with this here
    ```
4. Run the script with `node index.mjs` in your terminal
