### PR TITLE
refactor: conditional types to simplify actions

### DIFF
--- a/packages/shopify-cart/src/client/actions/cartCreate.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.ts
@@ -33,20 +33,25 @@ export default async function cartCreate({
   gqlClient,
   params
 }: CreateCartParams): Promise<void | CartResponse> {
+  let shopifyParams: CartInput = {};
+
   try {
-    let formattedParams: NacelleCartInput | CartInput | undefined = params;
-    if (params && params.lines) {
-      const nacelleLines = params.lines;
-      const shopifyLines =
-        transformNacelleLineItemToShopifyLineItem(nacelleLines);
-      formattedParams = { ...params, lines: shopifyLines } as CartInput;
+    if (params) {
+      const { lines: nacelleLines, ...otherParams } = params;
+      shopifyParams = otherParams;
+
+      if (nacelleLines) {
+        shopifyParams.lines =
+          transformNacelleLineItemToShopifyLineItem(nacelleLines);
+      }
     }
+
     const shopifyResponse = await gqlClient<
       MutationCartCreateArgs,
       MutationCartCreateResponse
     >({
       query: mutations.CART_CREATE(customFragments),
-      variables: { input: (formattedParams as CartInput | undefined) ?? {} }
+      variables: { input: shopifyParams }
     }).catch((err) => {
       throw new Error(err);
     });

--- a/packages/shopify-cart/src/client/actions/cartLinesAdd.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesAdd.ts
@@ -10,7 +10,6 @@ import type {
 } from '../../types/cart.type';
 import type { MutationFragments } from '../../graphql/mutations';
 import type {
-  CartLineInput,
   CartLinesAddPayload,
   MutationCartLinesAddArgs
 } from '../../types/shopify.type';
@@ -36,9 +35,7 @@ export default async function cartLinesAdd({
   lines
 }: CartLinesAddParams): Promise<void | CartResponse> {
   try {
-    const formattedLines = transformNacelleLineItemToShopifyLineItem(
-      lines
-    ) as CartLineInput[];
+    const formattedLines = transformNacelleLineItemToShopifyLineItem(lines);
     const shopifyResponse = await gqlClient<
       MutationCartLinesAddArgs,
       MutationCartLinesAddResponse

--- a/packages/shopify-cart/src/client/actions/cartLinesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesUpdate.ts
@@ -10,7 +10,6 @@ import type {
   NacelleCartLineItemUpdateInput
 } from '../../types/cart.type';
 import type {
-  CartLineUpdateInput,
   CartLinesUpdatePayload,
   MutationCartLinesUpdateArgs
 } from '../../types/shopify.type';
@@ -37,8 +36,7 @@ export default async function cartLinesUpdate({
   lines
 }: CartLinesUpdateParams): Promise<void | CartResponse> {
   try {
-    const formattedLines: CartLineUpdateInput[] =
-      transformNacelleLineItemToShopifyLineItem(lines) as CartLineUpdateInput[];
+    const formattedLines = transformNacelleLineItemToShopifyLineItem(lines);
     const shopifyResponse = await gqlClient<
       MutationCartLinesUpdateArgs,
       MutationCartLinesUpdateResponse

--- a/packages/shopify-cart/src/utils/transformNacelleLineItemToShopifyLineItem.ts
+++ b/packages/shopify-cart/src/utils/transformNacelleLineItemToShopifyLineItem.ts
@@ -1,13 +1,17 @@
-import {
-  NacelleCartLineItemInput,
-  NacelleCartLineItemUpdateInput
-} from '../types/cart.type';
-import { CartLineInput, CartLineUpdateInput } from '../types/shopify.type';
 import { getShopifyIdFromNacelleId } from '.';
+import type { NacelleCartLineItemUpdateInput } from '../types/cart.type';
+import type { CartLineInput, CartLineUpdateInput } from '../types/shopify.type';
 
-export default function (
-  nacelleLines: NacelleCartLineItemInput[] | NacelleCartLineItemUpdateInput[]
-): CartLineInput[] | CartLineUpdateInput[] {
+/**
+ * If type input `T` is an array of objects containing properties of `NacelleCartLineItemUpdateInput`, we'll return `CartLineUpdateInput[]`. Otherwise, we'll return `CartLineInput[]`.
+ */
+type InputOrUpdateInput<T> = T extends NacelleCartLineItemUpdateInput[]
+  ? CartLineUpdateInput[]
+  : CartLineInput[];
+
+export default function transformNacelleLineItemToShopifyLineItem<
+  T extends Partial<NacelleCartLineItemUpdateInput>[]
+>(nacelleLines: T): InputOrUpdateInput<T> {
   return nacelleLines?.map((line) => {
     const { nacelleEntryId, ...rest } = line;
     const shopifyItem = { ...rest } as CartLineInput | CartLineUpdateInput;
@@ -15,5 +19,5 @@ export default function (
       shopifyItem.merchandiseId = getShopifyIdFromNacelleId(nacelleEntryId);
     }
     return shopifyItem;
-  }) as CartLineInput[] | CartLineUpdateInput[];
+  }) as InputOrUpdateInput<T>;
 }


### PR DESCRIPTION
## Why are these changes introduced?

To support #227.

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

Refactors `packages/shopify-cart/src/utils/transformNacelleLineItemToShopifyLineItem.ts` with [conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html). This allows us to eliminate type assertions where `transformNacelleLineItemToShopifyLineItem` is called, which in turn allows us to simplify some of the `packages/shopify-cart/src/client/actions`.

The idea with the conditional types is that by checking to see if the input to `transformNacelleLineItemToShopifyLineItem` is `NacelleCartLineItemUpdateInput` or not (when it's not, it's `NacelleCartInput`), we can have TypeScript automatically know if the `transformNacelleLineItemToShopifyLineItem` return value is `CartLineInput` or `CartLineUpdateInput`.

For example (keeping in mind that the distinction between `NacelleCartInput` and `NacelleCartLineItemUpdateInput` is that `NacelleCartLineItemUpdateInput` has an `id: string` property)...

`transformNacelleLineItemToShopifyLineItem` correctly returns `CartLineInput[]` when its input doesn't have an `id: string`:

![transformNacelleLineItemToShopifyLineItem infer CartLineInput type](https://user-images.githubusercontent.com/5732000/188211469-9661aedf-51f2-44ad-ac4f-5b64cc410377.png)

, and when `transformNacelleLineItemToShopifyLineItem` does have an `id: string`, it correctly returns `CartLineUpdateInput[]`:

![transformNacelleLineItemToShopifyLineItem infer CartLineUpdateInput type](https://user-images.githubusercontent.com/5732000/188211490-a5d9cadc-9db5-4d77-a557-c9bc63762713.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

## How to Ttest

1. Check out the `ENG-7006/conditional-types` branch.
2. Navigate to `packages/shopify-cart`.
3. `npm run test:ci` - all tests should pass with 100% coverage.

<img width="555" alt="ENG-7006:conditional-types all tests passing" src="https://user-images.githubusercontent.com/5732000/188212064-0e2341e8-80da-4fc4-8ca1-6a870268e134.png">

5. `npm run build` - the package should build without errors.

<img width="555" alt="ENG-7006:conditional-types builds without errors" src="https://user-images.githubusercontent.com/5732000/188212234-ed96d8e2-2b16-44bf-b97e-f8089e928df3.png">

6. `npm run codegen` - there should be no new changes to `packages/shopify-cart/src/types/shopify.type.ts`.