### PR TITLE
feat: use src/index.ts as new entry file

### DIFF
--- a/packages/shopify-cart/package.json
+++ b/packages/shopify-cart/package.json
@@ -41,7 +41,7 @@
       "require": "./dist/nacelle-shopify-cart.umd.js"
     }
   },
-  "types": "./dist/types/client/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "sideEffects": false,
   "directories": {
     "src": "src",

--- a/packages/shopify-cart/src/index.ts
+++ b/packages/shopify-cart/src/index.ts
@@ -1,0 +1,24 @@
+/**Entry File - Serves as the public api for `@nacelle/shopify-cart`
+ * Any "public" functions and types should be exported from here
+ */
+
+// export the default export of `./client/index.ts` as the package's default export
+export { default } from './client';
+
+// export any other exports, which includes public types
+export * from './client';
+
+// export other public types
+export type {
+  Cart,
+  CartResponse,
+  NacelleCartInput,
+  NacelleCartLineItemInput,
+  NacelleCartLineItemUpdateInput
+} from './types/cart.type';
+export type { ShopifyError } from './types/errors.type';
+export type {
+  AttributeInput,
+  CartBuyerIdentityInput,
+  CartUserError
+} from './types/shopify.type';

--- a/packages/shopify-cart/vite.config.ts
+++ b/packages/shopify-cart/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, UserConfig } from 'vite';
 export const config: UserConfig = {
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src', 'client', 'index.ts'),
+      entry: path.resolve(__dirname, 'src', 'index.ts'),
       fileName: 'nacelle-shopify-cart',
       formats: ['es', 'umd', 'iife'],
       name: 'NacelleShopifyCart'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Fixes [ENG-6992](https://nacelle.atlassian.net/browse/ENG-6992) - Makes all public types exportable from the package base. This helps keep our public type api clean, and reduces the chances that removing/renaming internal types breaks user code.  <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

- Creates a new entry point at `src/index.ts`. This entry point re-exports everything from `src/client.ts` and all other public types.
- Updates vite to use this new entry point
- Updates the `types` key in `package.json` to point to the `dist/types/index.d.ts` file that corresponds to this new entry point. This makes all public types importable from `@nacelle/shopify-cart` 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## How to Test

1. Checkout this branch `mdarrik/shopify-cart/ENG-6992-export-all-public-types-from-package-root`
2. Run a build `npm run build` - should build successfully
3. In a ts project with this package installed by `npm link @nacelle/shopify-cart`, import some of the public types like `CartResponse` or `ShopifyError` from `@nacelle/shopify-cart`. Your editor and `tsc` should be able to find the types. (See below for quick start on a TS project)


### TS Project quick start

Easiest way is to use `vite create` to get up with a quick browser-compatible TS project. 

1. Run `npm link` from `nacelle-js/packages/shopify-cart`
2. Run `npm create vite@latest <your-test-project-name> -- --template vanilla-ts`
3. Run `npm link @nacelle/shopify-cart --save` to link this project locally
4. In your new `src/main.ts` you can test importing from `@nacelle/shopify-cart`.
