### PR TITLE
docs: add `customFragments` to client init options

### DIFF
--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -59,7 +59,8 @@ The cart client accepts the following parameters:
 - `shopifyShopId` (`string`) - optional Shopify shop id
 - `shopifyStorefrontAccessToken` (`string`) - required Shopify Storefront API access token
 - `shopifyCustomEndpoint` (`string`) - optional Shopify custom API endpoint
-- `fetchClient` (`object`) - optional fetch API-compatible fetch client
+- `customFragments` (`object`) - optional GraphQL fragments for data customization (see the [Custom Fragments docs][custom-fragments-docs])
+- `fetchClient` (`function`) - optional Fetch API-compatible request function
 
 _You must provide a `shopifyShopId` or a `shopifyCustomEndpoint`_
 


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-7063](https://nacelle.atlassian.net/browse/ENG-7063)

> Add `customFragments` to "Initializing the client" docs in the README

In the "Initializing the client" docs, `customFragments` were missing from the list of initialization options.

## What is this pull request doing?

- Adds `customFragments` to the list of initialization options.
- Corrects the type of `fetchClient` (was `object`, should be `function`).

Here's what the README looks like now:

![@nacelle:shopify-cart initialization options with customFragments](https://user-images.githubusercontent.com/5732000/189234411-54c6746b-42d7-4bf9-aa34-3c7e10e6a3aa.png)
