### PR TITLE
feat(shopify-cart): Adds params for setting country and language codes

### DIFF
--- a/.changeset/cold-oranges-study.md
+++ b/.changeset/cold-oranges-study.md
@@ -1,0 +1,7 @@
+---
+'@nacelle/shopify-cart': minor
+---
+
+feat (breaking): Adds options for language and country codes to cart create.
+
+- Now defaults to setting the language to `EN` in all queries and mutations if no language is passed to the `createCart` function.

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -61,6 +61,8 @@ The cart client accepts the following parameters:
 - `shopifyCustomEndpoint` (`string`) - optional Shopify custom API endpoint
 - `customFragments` (`object`) - optional GraphQL fragments for data customization (see the [Custom Fragments docs][custom-fragments-docs])
 - `fetchClient` (`function`) - optional Fetch API-compatible request function
+- `country` (`string`) - optional [Shopify Country Code][shopify-cart-country-code] used for cart queries/responses. Defaults to `ZZ` (unknown region) if not supplied.
+- `language` (`string`) - optional [Shopify Language Code][shopify-cart-language-code] used for cart queries/responses. Defaults to `EN` if not supplied.
 
 _You must provide a `shopifyShopId` or a `shopifyCustomEndpoint`_
 
@@ -266,3 +268,5 @@ const { cart, userErrors, errors } = await cartClient.cartNoteUpdate({
 [shopify-cart-line-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartLineInput
 [shopify-cart-line-update-input]: https://shopify.dev/api/storefront/2022-07/input-objects/CartLineUpdateInput
 [shopify-release-schedule]: https://shopify.dev/api/usage/versioning#release-schedule
+[shopify-cart-language-code]: https://shopify.dev/api/storefront/2022-07/enums/LanguageCode
+[shopify-cart-country-code]: https://shopify.dev/api/storefront/2022-07/enums/CountryCode

--- a/packages/shopify-cart/__tests__/mocks/index.ts
+++ b/packages/shopify-cart/__tests__/mocks/index.ts
@@ -10,7 +10,6 @@ import {
   CartLineUpdateMutation,
   CartLineRemoveMutation,
   CartNoteUpdateMutation,
-  CurrencyCode,
   Cart_CartFragment,
   CartUserError_UserErrorsFragment
 } from '../../src/types/shopify.type';
@@ -91,16 +90,16 @@ export const cartWithoutLine: Cart_CartFragment = {
   },
   cost: {
     checkoutChargeAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     subtotalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     subtotalAmountEstimated: false,
     totalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     totalAmountEstimated: false,
@@ -145,16 +144,16 @@ export const cartWithLine: Cart_CartFragment = {
         cost: {
           subtotalAmount: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           },
           amountPerQuantity: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           },
           compareAtAmountPerQuantity: null,
           totalAmount: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           }
         },
         discountAllocations: [],
@@ -162,11 +161,11 @@ export const cartWithLine: Cart_CartFragment = {
           id: 'gid://shopify/ProductVariant/33894120718471',
           availableForSale: true,
           compareAtPriceV2: {
-            currencyCode: CurrencyCode.Usd,
+            currencyCode: 'USD',
             amount: '300.0'
           },
           priceV2: {
-            currencyCode: CurrencyCode.Usd,
+            currencyCode: 'USD',
             amount: '265.0'
           },
           requiresShipping: false,
@@ -198,15 +197,15 @@ export const cartWithLine: Cart_CartFragment = {
   cost: {
     checkoutChargeAmount: {
       amount: '0.0',
-      currencyCode: CurrencyCode.Usd
+      currencyCode: 'USD'
     },
     subtotalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     subtotalAmountEstimated: true,
     totalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     totalAmountEstimated: true,
@@ -247,16 +246,16 @@ export const cartWithPaginatedLines: Cart_CartFragment = {
         cost: {
           subtotalAmount: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           },
           amountPerQuantity: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           },
           compareAtAmountPerQuantity: null,
           totalAmount: {
             amount: '265.0',
-            currencyCode: CurrencyCode.Usd
+            currencyCode: 'USD'
           }
         },
         discountAllocations: [],
@@ -264,11 +263,11 @@ export const cartWithPaginatedLines: Cart_CartFragment = {
           id: 'gid://shopify/ProductVariant/33894120718471',
           availableForSale: true,
           compareAtPriceV2: {
-            currencyCode: CurrencyCode.Usd,
+            currencyCode: 'USD',
             amount: '300.0'
           },
           priceV2: {
-            currencyCode: CurrencyCode.Usd,
+            currencyCode: 'USD',
             amount: '265.0'
           },
           requiresShipping: false,
@@ -300,15 +299,15 @@ export const cartWithPaginatedLines: Cart_CartFragment = {
   cost: {
     checkoutChargeAmount: {
       amount: '0.0',
-      currencyCode: CurrencyCode.Usd
+      currencyCode: 'USD'
     },
     subtotalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     subtotalAmountEstimated: true,
     totalAmount: {
-      currencyCode: CurrencyCode.Usd,
+      currencyCode: 'USD',
       amount: '0.0'
     },
     totalAmountEstimated: true,

--- a/packages/shopify-cart/codegen.yml
+++ b/packages/shopify-cart/codegen.yml
@@ -9,3 +9,5 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+    config:
+      enumsAsTypes: true

--- a/packages/shopify-cart/src/client/actions/cart.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cart.spec.ts
@@ -24,8 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('fetch cart', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cart.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cart.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { Cart_CartFragment } from '../../types/shopify.type';
+import {
+  Cart_CartFragment,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -20,6 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('fetch cart', () => {
   afterEach(() => {
@@ -32,7 +38,12 @@ describe('fetch cart', () => {
         mockJsonResponse<{ cart: Cart_CartFragment }>(responses.queries.cart)
     );
 
-    await cart({ gqlClient, cartId });
+    await cart({
+      gqlClient,
+      cartId,
+      language: defaultLanguage,
+      country: defaultCountry
+    });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
     expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
@@ -40,7 +51,11 @@ describe('fetch cart', () => {
       headers,
       body: JSON.stringify({
         query: queries.CART(),
-        variables: { id: cartId }
+        variables: {
+          id: cartId,
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
 
@@ -60,8 +75,13 @@ describe('fetch cart', () => {
     );
 
     expect.assertions(1);
-    await expect(cart({ gqlClient, cartId })).rejects.toThrow(
-      networkErrorMessage
-    );
+    await expect(
+      cart({
+        gqlClient,
+        cartId,
+        language: defaultLanguage,
+        country: defaultCountry
+      })
+    ).rejects.toThrow(networkErrorMessage);
   });
 });

--- a/packages/shopify-cart/src/client/actions/cart.ts
+++ b/packages/shopify-cart/src/client/actions/cart.ts
@@ -3,8 +3,10 @@ import { formatCartResponse, depaginateLines } from '../../utils';
 import type { CartResponse } from '../../types/cart.type';
 import type { CartFragments } from '../../graphql/fragments/cart';
 import type {
-  QueryRootCartArgs,
-  Cart_CartFragment
+  CartQueryVariables,
+  Cart_CartFragment,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 import type { ShopifyError } from '../../types/errors.type';
@@ -13,6 +15,8 @@ export interface CartParams {
   cartId: string;
   gqlClient: GqlClient;
   customFragments?: CartFragments;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export interface ShopifyCartResponse {
@@ -23,15 +27,17 @@ export interface ShopifyCartResponse {
 export default async function cart({
   cartId,
   customFragments,
-  gqlClient
+  gqlClient,
+  language,
+  country
 }: CartParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      QueryRootCartArgs,
+      CartQueryVariables,
       ShopifyCartResponse
     >({
       query: queries.CART(customFragments),
-      variables: { id: cartId }
+      variables: { id: cartId, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -39,7 +45,9 @@ export default async function cart({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartAttributesUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartAttributesUpdate.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { CartAttributesUpdateMutation } from '../../types/shopify.type';
+import {
+  CartAttributesUpdateMutation,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -20,6 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartAttributesUpdate', () => {
   afterEach(() => {
@@ -36,7 +42,9 @@ describe('cartAttributesUpdate', () => {
     await cartAttributesUpdate({
       gqlClient,
       cartId,
-      attributes: [{ key: 'testKey', value: 'testValue' }]
+      attributes: [{ key: 'testKey', value: 'testValue' }],
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -47,7 +55,9 @@ describe('cartAttributesUpdate', () => {
         query: mutations.CART_ATTRIBUTES_UPDATE(),
         variables: {
           cartId,
-          attributes: [{ key: 'testKey', value: 'testValue' }]
+          attributes: [{ key: 'testKey', value: 'testValue' }],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -75,7 +85,9 @@ describe('cartAttributesUpdate', () => {
       cartAttributesUpdate({
         gqlClient,
         cartId,
-        attributes: [{ key: 'testKey', value: 'testValue' }]
+        attributes: [{ key: 'testKey', value: 'testValue' }],
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });

--- a/packages/shopify-cart/src/client/actions/cartAttributesUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartAttributesUpdate.spec.ts
@@ -24,8 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartAttributesUpdate', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartAttributesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartAttributesUpdate.ts
@@ -3,7 +3,9 @@ import { formatCartResponse, depaginateLines } from '../../utils';
 import type {
   AttributeInput,
   CartAttributesUpdatePayload,
-  MutationCartAttributesUpdateArgs
+  CartAttributesUpdateMutationVariables,
+  CountryCode,
+  LanguageCode
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
@@ -14,6 +16,8 @@ export interface UpdateCartAttributesParams {
   cartId: string;
   gqlClient: GqlClient;
   customFragments?: MutationFragments;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartAttributesUpdateResponse = CartAttributesUpdatePayload &
@@ -27,15 +31,17 @@ export default async function cartAttributesUpdate({
   attributes,
   cartId,
   customFragments,
-  gqlClient
+  gqlClient,
+  language,
+  country
 }: UpdateCartAttributesParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      MutationCartAttributesUpdateArgs,
+      CartAttributesUpdateMutationVariables,
       MutationCartAttributesUpdateResponse
     >({
       query: mutations.CART_ATTRIBUTES_UPDATE(customFragments),
-      variables: { cartId, attributes }
+      variables: { cartId, attributes, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -43,7 +49,9 @@ export default async function cartAttributesUpdate({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartAttributesUpdate.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.spec.ts
@@ -24,8 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartBuyerIdentityUpdate', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { CartBuyerIdentityUpdateMutation } from '../../types/shopify.type';
+import {
+  CartBuyerIdentityUpdateMutation,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -20,6 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartBuyerIdentityUpdate', () => {
   afterEach(() => {
@@ -39,7 +45,9 @@ describe('cartBuyerIdentityUpdate', () => {
       cartId,
       buyerIdentity: {
         email: 'email@email.com'
-      }
+      },
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -52,7 +60,9 @@ describe('cartBuyerIdentityUpdate', () => {
           cartId,
           buyerIdentity: {
             email: 'email@email.com'
-          }
+          },
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -82,7 +92,9 @@ describe('cartBuyerIdentityUpdate', () => {
         cartId,
         buyerIdentity: {
           email: 'email@email.com'
-        }
+        },
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });

--- a/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.ts
@@ -5,7 +5,9 @@ import type { MutationFragments } from '../../graphql/mutations';
 import type {
   CartBuyerIdentityInput,
   CartBuyerIdentityUpdatePayload,
-  MutationCartBuyerIdentityUpdateArgs
+  CartBuyerIdentityUpdateMutationVariables,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 
@@ -14,6 +16,8 @@ export interface CartBuyerIdentityUpdateParams {
   cartId: string;
   buyerIdentity: CartBuyerIdentityInput;
   customFragments?: MutationFragments;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartBuyerIdentityUpdateResponse = CartBuyerIdentityUpdatePayload &
@@ -27,15 +31,17 @@ export default async function CartBuyerIdentityUpdate({
   buyerIdentity,
   cartId,
   customFragments,
-  gqlClient
+  gqlClient,
+  language,
+  country
 }: CartBuyerIdentityUpdateParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      MutationCartBuyerIdentityUpdateArgs,
+      CartBuyerIdentityUpdateMutationVariables,
       MutationCartBuyerIdentityUpdateResponse
     >({
       query: mutations.CART_BUYER_IDENTITY_UPDATE(customFragments),
-      variables: { cartId, buyerIdentity }
+      variables: { cartId, buyerIdentity, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -43,7 +49,9 @@ export default async function CartBuyerIdentityUpdate({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartBuyerIdentityUpdate.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { CartCreateMutation } from '../../types/shopify.type';
+import {
+  CartCreateMutation,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -19,6 +23,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartCreate', () => {
   afterEach(() => {
@@ -33,7 +39,11 @@ describe('cartCreate', () => {
         )
     );
 
-    await cartCreate({ gqlClient });
+    await cartCreate({
+      gqlClient,
+      language: defaultLanguage,
+      country: defaultCountry
+    });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
     expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
@@ -41,7 +51,11 @@ describe('cartCreate', () => {
       headers,
       body: JSON.stringify({
         query: mutations.CART_CREATE(),
-        variables: { input: {} }
+        variables: {
+          input: {},
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
   });
@@ -54,7 +68,12 @@ describe('cartCreate', () => {
         )
     );
 
-    await cartCreate({ gqlClient, params: { lines: [] } });
+    await cartCreate({
+      gqlClient,
+      params: { lines: [] },
+      language: defaultLanguage,
+      country: defaultCountry
+    });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
     expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
@@ -62,7 +81,11 @@ describe('cartCreate', () => {
       headers,
       body: JSON.stringify({
         query: mutations.CART_CREATE(),
-        variables: { input: { lines: [] } }
+        variables: {
+          input: { lines: [] },
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
 
@@ -84,7 +107,12 @@ describe('cartCreate', () => {
 
     expect.assertions(1);
     await expect(
-      cartCreate({ gqlClient, params: { lines: [] } })
+      cartCreate({
+        gqlClient,
+        params: { lines: [] },
+        language: defaultLanguage,
+        country: defaultCountry
+      })
     ).rejects.toThrow(networkErrorMessage);
   });
 });

--- a/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.spec.ts
@@ -23,8 +23,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartCreate', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartCreate.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.ts
@@ -12,7 +12,9 @@ import type {
 import type {
   CartCreatePayload,
   CartInput,
-  MutationCartCreateArgs
+  CartCreateMutationVariables,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { MutationFragments } from '../../graphql/mutations';
 import type { GqlClient } from '../../cart-client.types';
@@ -21,6 +23,8 @@ export interface CreateCartParams {
   gqlClient: GqlClient;
   customFragments?: MutationFragments;
   params?: NacelleCartInput;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartCreateResponse = CartCreatePayload & CartFragmentResponse;
@@ -32,7 +36,9 @@ export interface MutationCartCreateResponse {
 export default async function cartCreate({
   customFragments,
   gqlClient,
-  params
+  params,
+  language,
+  country
 }: CreateCartParams): Promise<void | CartResponse> {
   let shopifyParams: CartInput = {};
 
@@ -48,11 +54,11 @@ export default async function cartCreate({
     }
 
     const shopifyResponse = await gqlClient<
-      MutationCartCreateArgs,
+      CartCreateMutationVariables,
       MutationCartCreateResponse
     >({
       query: mutations.CART_CREATE(customFragments),
-      variables: { input: shopifyParams }
+      variables: { input: shopifyParams, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -60,7 +66,9 @@ export default async function cartCreate({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartCreate.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { CartDiscountCodesUpdateMutation } from '../../types/shopify.type';
+import {
+  CartDiscountCodesUpdateMutation,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -20,6 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartDiscountCodesUpdate', () => {
   afterEach(() => {
@@ -37,7 +43,9 @@ describe('cartDiscountCodesUpdate', () => {
     await cartDiscountCodesUpdate({
       gqlClient,
       cartId,
-      discountCodes: ['code']
+      discountCodes: ['code'],
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -48,7 +56,9 @@ describe('cartDiscountCodesUpdate', () => {
         query: mutations.CART_DISCOUNT_CODES_UPDATE(),
         variables: {
           cartId,
-          discountCodes: ['code']
+          discountCodes: ['code'],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -76,7 +86,9 @@ describe('cartDiscountCodesUpdate', () => {
       cartDiscountCodesUpdate({
         gqlClient,
         cartId,
-        discountCodes: ['code']
+        discountCodes: ['code'],
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });

--- a/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.spec.ts
@@ -24,8 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartDiscountCodesUpdate', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.ts
@@ -4,7 +4,9 @@ import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
 import type { MutationFragments } from '../../graphql/mutations';
 import type {
   CartDiscountCodesUpdatePayload,
-  MutationCartDiscountCodesUpdateArgs
+  CartDiscountCodesUpdateMutationVariables,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 
@@ -13,6 +15,8 @@ export interface CreateDiscountCodesUpdateParams {
   gqlClient: GqlClient;
   customFragments?: MutationFragments;
   discountCodes?: string[];
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartDiscountCodesUpdateResponse = CartDiscountCodesUpdatePayload &
@@ -26,15 +30,17 @@ export default async function cartDiscountCodesUpdate({
   cartId,
   customFragments,
   discountCodes,
-  gqlClient
+  gqlClient,
+  language,
+  country
 }: CreateDiscountCodesUpdateParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      MutationCartDiscountCodesUpdateArgs,
+      CartDiscountCodesUpdateMutationVariables,
       MutationCartDiscountCodesUpdateResponse
     >({
       query: mutations.CART_DISCOUNT_CODES_UPDATE(customFragments),
-      variables: { cartId, discountCodes }
+      variables: { cartId, discountCodes, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -42,7 +48,9 @@ export default async function cartDiscountCodesUpdate({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartDiscountCodesUpdate.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartLines.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartLines.spec.ts
@@ -30,8 +30,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartLinesAdd', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartLines.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartLines.spec.ts
@@ -17,6 +17,7 @@ import {
   graphqlEndpoint,
   headers
 } from '../../../__tests__/mocks';
+import { CountryCode, LanguageCode } from '../../types/shopify.type';
 import type {
   CartLineAddMutation,
   CartLineUpdateMutation,
@@ -29,6 +30,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartLinesAdd', () => {
   afterEach(() => {
@@ -49,7 +52,9 @@ describe('cartLinesAdd', () => {
           nacelleEntryId: cartWithLineResponse.cart.lines.nodes[0].attributes[0]
             .value as string
         }
-      ]
+      ],
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -65,7 +70,9 @@ describe('cartLinesAdd', () => {
               merchandiseId:
                 cartWithLineResponse.cart.lines.nodes[0].merchandise.id
             }
-          ]
+          ],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -96,7 +103,9 @@ describe('cartLinesAdd', () => {
             nacelleEntryId: cartWithLineResponse.cart.lines.nodes[0]
               .attributes[0].value as string
           }
-        ]
+        ],
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });
@@ -128,7 +137,9 @@ describe('cartLinesUpdate', () => {
             .value as string,
           quantity: 2
         }
-      ]
+      ],
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -145,7 +156,9 @@ describe('cartLinesUpdate', () => {
               quantity: 2,
               merchandiseId: updatedCart.cart.lines.nodes[0].merchandise.id
             }
-          ]
+          ],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -178,7 +191,9 @@ describe('cartLinesUpdate', () => {
               .attributes[0].value as string,
             quantity: 2
           }
-        ]
+        ],
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });
@@ -200,7 +215,9 @@ describe('cartLinesRemove', () => {
     await cartLinesRemove({
       gqlClient,
       cartId,
-      lineIds: [cartWithLineResponse.cart.lines.nodes[0].id]
+      lineIds: [cartWithLineResponse.cart.lines.nodes[0].id],
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -211,7 +228,9 @@ describe('cartLinesRemove', () => {
         query: mutations.CART_LINE_REMOVE(),
         variables: {
           cartId,
-          lineIds: [cartWithLineResponse.cart.lines.nodes[0].id]
+          lineIds: [cartWithLineResponse.cart.lines.nodes[0].id],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -237,7 +256,9 @@ describe('cartLinesRemove', () => {
       cartLinesRemove({
         gqlClient,
         cartId,
-        lineIds: [cartWithLineResponse.cart.lines.nodes[0].id]
+        lineIds: [cartWithLineResponse.cart.lines.nodes[0].id],
+        language: defaultLanguage,
+        country: defaultCountry
       })
     ).rejects.toThrow(networkErrorMessage);
   });

--- a/packages/shopify-cart/src/client/actions/cartLinesRemove.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesRemove.ts
@@ -4,7 +4,9 @@ import type { MutationFragments } from '../../graphql/mutations';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
 import {
   CartLinesRemovePayload,
-  MutationCartLinesRemoveArgs
+  CartLineRemoveMutationVariables,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 
@@ -13,6 +15,8 @@ export interface CartLinesRemoveParams {
   cartId: string;
   lineIds: Array<string>;
   customFragments?: MutationFragments;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartLinesRemoveResponse = CartLinesRemovePayload &
@@ -26,15 +30,17 @@ export default async function cartLinesRemove({
   cartId,
   customFragments,
   gqlClient,
-  lineIds
+  lineIds,
+  language,
+  country
 }: CartLinesRemoveParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      MutationCartLinesRemoveArgs,
+      CartLineRemoveMutationVariables,
       MutationCartLinesRemoveResponse
     >({
       query: mutations.CART_LINE_REMOVE(customFragments),
-      variables: { cartId, lineIds }
+      variables: { cartId, lineIds, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -42,7 +48,9 @@ export default async function cartLinesRemove({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartLinesRemove.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/actions/cartNoteUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartNoteUpdate.spec.ts
@@ -24,8 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('cartNoteUpdate', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/client/actions/cartNoteUpdate.spec.ts
+++ b/packages/shopify-cart/src/client/actions/cartNoteUpdate.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fetchClient from 'cross-fetch';
-import { CartNoteUpdateMutation } from '../../types/shopify.type';
+import {
+  CartNoteUpdateMutation,
+  CountryCode,
+  LanguageCode
+} from '../../types/shopify.type';
 import { createGqlClient } from '../../utils';
 import formatCartResponse from '../../utils/formatCartResponse';
 import { mockJsonResponse } from '../../../__tests__/utils';
@@ -20,6 +24,8 @@ jest.mock('../../utils/formatCartResponse');
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
 const mockedFormatCartResponse = jest.mocked(formatCartResponse, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('cartNoteUpdate', () => {
   afterEach(() => {
@@ -36,7 +42,9 @@ describe('cartNoteUpdate', () => {
     await cartNoteUpdate({
       gqlClient,
       cartId,
-      note: 'Cart Note'
+      note: 'Cart Note',
+      language: defaultLanguage,
+      country: defaultCountry
     });
 
     expect(fetchClient).toHaveBeenCalledTimes(1);
@@ -47,7 +55,9 @@ describe('cartNoteUpdate', () => {
         query: mutations.CART_NOTE_UPDATE(),
         variables: {
           cartId,
-          note: 'Cart Note'
+          note: 'Cart Note',
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -72,7 +82,13 @@ describe('cartNoteUpdate', () => {
 
     expect.assertions(1);
     await expect(
-      cartNoteUpdate({ gqlClient, cartId, note: 'Cart Note' })
+      cartNoteUpdate({
+        gqlClient,
+        cartId,
+        note: 'Cart Note',
+        language: defaultLanguage,
+        country: defaultCountry
+      })
     ).rejects.toThrow(networkErrorMessage);
   });
 });

--- a/packages/shopify-cart/src/client/actions/cartNoteUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartNoteUpdate.ts
@@ -2,7 +2,9 @@ import mutations from '../../graphql/mutations';
 import { formatCartResponse, depaginateLines } from '../../utils';
 import type {
   CartNoteUpdatePayload,
-  MutationCartNoteUpdateArgs
+  CartNoteUpdateMutationVariables,
+  LanguageCode,
+  CountryCode
 } from '../../types/shopify.type';
 import type { MutationFragments } from '../../graphql/mutations';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
@@ -13,6 +15,8 @@ export interface UpdateCartNoteParams {
   gqlClient: GqlClient;
   note: string;
   customFragments?: MutationFragments;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export type CartNoteUpdateResponse = CartNoteUpdatePayload &
@@ -26,15 +30,17 @@ export default async function cartNoteUpdate({
   cartId,
   customFragments,
   gqlClient,
-  note
+  note,
+  language,
+  country
 }: UpdateCartNoteParams): Promise<void | CartResponse> {
   try {
     const shopifyResponse = await gqlClient<
-      MutationCartNoteUpdateArgs,
+      CartNoteUpdateMutationVariables,
       MutationCartNoteUpdateResponse
     >({
       query: mutations.CART_NOTE_UPDATE(customFragments),
-      variables: { cartId, note }
+      variables: { cartId, note, language, country }
     }).catch((err) => {
       throw new Error(err);
     });
@@ -42,7 +48,9 @@ export default async function cartNoteUpdate({
     const cart = await depaginateLines({
       cart: shopifyResponse.data?.cartNoteUpdate.cart,
       customFragments,
-      gqlClient
+      gqlClient,
+      language,
+      country
     });
 
     return formatCartResponse({

--- a/packages/shopify-cart/src/client/client-dom.spec.ts
+++ b/packages/shopify-cart/src/client/client-dom.spec.ts
@@ -22,6 +22,10 @@ import type {
   CartNoteUpdateMutation,
   Cart_CartFragment
 } from '../types/shopify.type';
+import { LanguageCode, CountryCode } from '../types/shopify.type';
+
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('createShopifyCartClient', () => {
   afterEach(() => {
@@ -60,7 +64,11 @@ describe('createShopifyCartClient', () => {
       headers,
       body: JSON.stringify({
         query: mutations.CART_CREATE(),
-        variables: { input: { note } }
+        variables: {
+          input: { note },
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
   });
@@ -82,11 +90,66 @@ describe('createShopifyCartClient', () => {
       headers,
       body: JSON.stringify({
         query: queries.CART(),
-        variables: { id: cartId }
+        variables: {
+          id: cartId,
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
   });
 
+  it('makes a request with provided language when language is passed to createCart', async () => {
+    const windowFetch = jest.fn(
+      (): Promise<any> =>
+        mockJsonResponse<{ cart: Cart_CartFragment }>(responses.queries.cart)
+    );
+    window.fetch = windowFetch;
+    const cartClient = createShopifyCartClient({
+      ...clientSettings,
+      language: LanguageCode.Fr
+    });
+    await cartClient.cart({ cartId });
+    expect(windowFetch).toHaveBeenCalledTimes(1);
+    expect(windowFetch).toHaveBeenCalledWith(graphqlEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: queries.CART(),
+        variables: {
+          id: cartId,
+          language: LanguageCode.Fr,
+          country: defaultCountry
+        }
+      })
+    });
+  });
+
+  it('makes a request with provided country when country is passed to createCart', async () => {
+    const windowFetch = jest.fn(
+      (): Promise<any> =>
+        mockJsonResponse<{ cart: Cart_CartFragment }>(responses.queries.cart)
+    );
+    window.fetch = windowFetch;
+    const cartClient = createShopifyCartClient({
+      ...clientSettings,
+      country: CountryCode.Us
+    });
+    await cartClient.cart({ cartId });
+    expect(windowFetch).toHaveBeenCalledTimes(1);
+    expect(windowFetch).toHaveBeenCalledWith(graphqlEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: queries.CART(),
+        variables: {
+          id: cartId,
+          language: defaultLanguage,
+          country: CountryCode.Us
+        }
+      })
+    });
+  });
   it('makes the expected request when adding line item to cart', async () => {
     const windowFetch = jest.fn(
       (): Promise<any> =>
@@ -109,7 +172,9 @@ describe('createShopifyCartClient', () => {
         query: mutations.CART_LINE_ADD(),
         variables: {
           cartId,
-          lines: []
+          lines: [],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -154,7 +219,9 @@ describe('createShopifyCartClient', () => {
               quantity: 2,
               merchandiseId: updatedCart.cart.lines.nodes[0].merchandise.id
             }
-          ]
+          ],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -184,7 +251,9 @@ describe('createShopifyCartClient', () => {
         query: mutations.CART_LINE_REMOVE(),
         variables: {
           cartId,
-          lineIds: [cartWithLineResponse.cart.lines.nodes[0].id]
+          lineIds: [cartWithLineResponse.cart.lines.nodes[0].id],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -218,7 +287,9 @@ describe('createShopifyCartClient', () => {
           cartId,
           buyerIdentity: {
             email: 'email@email.com'
-          }
+          },
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -248,7 +319,9 @@ describe('createShopifyCartClient', () => {
         query: mutations.CART_DISCOUNT_CODES_UPDATE(),
         variables: {
           cartId,
-          discountCodes: ['code']
+          discountCodes: ['code'],
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -275,7 +348,9 @@ describe('createShopifyCartClient', () => {
         query: mutations.CART_NOTE_UPDATE(),
         variables: {
           cartId,
-          note
+          note,
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -301,7 +376,12 @@ describe('createShopifyCartClient', () => {
       headers,
       body: JSON.stringify({
         query: mutations.CART_ATTRIBUTES_UPDATE(),
-        variables: { cartId, attributes }
+        variables: {
+          cartId,
+          attributes,
+          language: defaultLanguage,
+          country: defaultCountry
+        }
       })
     });
   });

--- a/packages/shopify-cart/src/client/client-dom.spec.ts
+++ b/packages/shopify-cart/src/client/client-dom.spec.ts
@@ -20,12 +20,13 @@ import type {
   CartLineUpdateMutation,
   CartLineRemoveMutation,
   CartNoteUpdateMutation,
-  Cart_CartFragment
+  Cart_CartFragment,
+  LanguageCode,
+  CountryCode
 } from '../types/shopify.type';
-import { LanguageCode, CountryCode } from '../types/shopify.type';
 
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('createShopifyCartClient', () => {
   afterEach(() => {
@@ -107,7 +108,7 @@ describe('createShopifyCartClient', () => {
     window.fetch = windowFetch;
     const cartClient = createShopifyCartClient({
       ...clientSettings,
-      language: LanguageCode.Fr
+      language: 'FR'
     });
     await cartClient.cart({ cartId });
     expect(windowFetch).toHaveBeenCalledTimes(1);
@@ -118,7 +119,7 @@ describe('createShopifyCartClient', () => {
         query: queries.CART(),
         variables: {
           id: cartId,
-          language: LanguageCode.Fr,
+          language: 'FR',
           country: defaultCountry
         }
       })
@@ -133,7 +134,7 @@ describe('createShopifyCartClient', () => {
     window.fetch = windowFetch;
     const cartClient = createShopifyCartClient({
       ...clientSettings,
-      country: CountryCode.Us
+      country: 'US'
     });
     await cartClient.cart({ cartId });
     expect(windowFetch).toHaveBeenCalledTimes(1);
@@ -145,7 +146,7 @@ describe('createShopifyCartClient', () => {
         variables: {
           id: cartId,
           language: defaultLanguage,
-          country: CountryCode.Us
+          country: 'US'
         }
       })
     });

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -17,7 +17,12 @@ import type {
   NacelleCartLineItemInput,
   NacelleCartLineItemUpdateInput
 } from '../types/cart.type';
-import { AttributeInput, CartBuyerIdentityInput } from '../types/shopify.type';
+import {
+  AttributeInput,
+  CartBuyerIdentityInput,
+  CountryCode,
+  LanguageCode
+} from '../types/shopify.type';
 
 export type UserSuppliedFragmentType = Exclude<
   keyof typeof fragments,
@@ -31,6 +36,8 @@ export interface CreateClientParams {
   fetchClient?: typeof fetch;
   shopifyCustomEndpoint?: string;
   shopifyShopId?: string;
+  language?: LanguageCode;
+  country?: CountryCode;
 }
 
 type FetchCart = (params: { cartId: string }) => Promise<CartResponse | void>;
@@ -151,7 +158,9 @@ export default function createShopifyCartClient({
   shopifyStorefrontAccessToken,
   shopifyCustomEndpoint,
   fetchClient,
-  customFragments
+  customFragments,
+  language = LanguageCode.En,
+  country = CountryCode.Zz
 }: CreateClientParams): CartClient {
   const gqlClient = createGqlClient({
     shopifyShopId,
@@ -160,10 +169,15 @@ export default function createShopifyCartClient({
     fetchClient
   });
   const sanitizedCustomFragments = sanitizeFragments(customFragments);
-
   return {
     cart: (params: { cartId: string }): Promise<CartResponse | void> =>
-      cart({ customFragments, gqlClient, ...params }),
+      cart({
+        customFragments,
+        gqlClient,
+        language,
+        country,
+        ...params
+      }),
     cartAttributesUpdate: (params: {
       cartId: string;
       attributes: AttributeInput[];
@@ -171,6 +185,8 @@ export default function createShopifyCartClient({
       cartAttributesUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language,
+        country,
         ...params
       }),
     cartBuyerIdentityUpdate: (params: {
@@ -180,12 +196,16 @@ export default function createShopifyCartClient({
       cartBuyerIdentityUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language: language,
+        country: country,
         ...params
       }),
     cartCreate: (params: NacelleCartInput): Promise<CartResponse | void> =>
       cartCreate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language,
+        country,
         params
       }),
     cartDiscountCodesUpdate: (params: {
@@ -195,6 +215,8 @@ export default function createShopifyCartClient({
       cartDiscountCodesUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language,
+        country,
         ...params
       }),
     cartLinesAdd: (params: {
@@ -204,13 +226,21 @@ export default function createShopifyCartClient({
       cartLinesAdd({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language,
+        country,
         ...params
       }),
     cartLinesUpdate: (params: {
       cartId: string;
       lines: Array<NacelleCartLineItemUpdateInput>;
     }): Promise<CartResponse | void> =>
-      cartLinesUpdate({ customFragments, gqlClient, ...params }),
+      cartLinesUpdate({
+        customFragments,
+        gqlClient,
+        language,
+        country,
+        ...params
+      }),
     cartLinesRemove: (params: {
       cartId: string;
       lineIds: Array<string>;
@@ -218,12 +248,20 @@ export default function createShopifyCartClient({
       cartLinesRemove({
         customFragments: sanitizedCustomFragments,
         gqlClient,
+        language,
+        country,
         ...params
       }),
     cartNoteUpdate: (params: {
       cartId: string;
       note: string;
     }): Promise<CartResponse | void> =>
-      cartNoteUpdate({ customFragments, gqlClient, ...params })
+      cartNoteUpdate({
+        customFragments,
+        gqlClient,
+        language,
+        country,
+        ...params
+      })
   };
 }

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -17,7 +17,7 @@ import type {
   NacelleCartLineItemInput,
   NacelleCartLineItemUpdateInput
 } from '../types/cart.type';
-import {
+import type {
   AttributeInput,
   CartBuyerIdentityInput,
   CountryCode,
@@ -159,8 +159,8 @@ export default function createShopifyCartClient({
   shopifyCustomEndpoint,
   fetchClient,
   customFragments,
-  language = LanguageCode.En,
-  country = CountryCode.Zz
+  language = 'EN',
+  country = 'ZZ'
 }: CreateClientParams): CartClient {
   const gqlClient = createGqlClient({
     shopifyShopId,

--- a/packages/shopify-cart/src/graphql/mutations/cartAttributesUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartAttributesUpdate.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartAttributesUpdate(attributes: $attributes, cartId: $cartId) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartBuyerIdentityUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartBuyerIdentityUpdate.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartCreate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartCreate.ts
@@ -9,7 +9,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartCreate(input: $input) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartDiscountCodesUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartDiscountCodesUpdate.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartLineAdd.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineAdd.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartLinesAdd(cartId: $cartId, lines: $lines) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartLineRemove.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineRemove.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartLineUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineUpdate.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartLinesUpdate(cartId: $cartId, lines: $lines) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/mutations/cartNoteUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartNoteUpdate.ts
@@ -10,7 +10,8 @@ export default (
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cartNoteUpdate(cartId: $cartId, note: $note) {
       cart {
         ...Cart_cart

--- a/packages/shopify-cart/src/graphql/queries/cart.ts
+++ b/packages/shopify-cart/src/graphql/queries/cart.ts
@@ -7,7 +7,8 @@ export default (customFragments: CartFragments = {}): string => /* GraphQL */ `
     $numCartLines: Int = 250
     $afterCursor: String
     $country: CountryCode = ZZ
-  ) @inContext(country: $country) {
+    $language: LanguageCode = EN
+  ) @inContext(country: $country, language: $language) {
     cart(id: $id) {
       ...Cart_cart
     }

--- a/packages/shopify-cart/src/index.ts
+++ b/packages/shopify-cart/src/index.ts
@@ -20,5 +20,7 @@ export type { ShopifyError } from './types/errors.type';
 export type {
   AttributeInput,
   CartBuyerIdentityInput,
-  CartUserError
+  CartUserError,
+  CountryCode,
+  LanguageCode
 } from './types/shopify.type';

--- a/packages/shopify-cart/src/types/shopify.type.ts
+++ b/packages/shopify-cart/src/types/shopify.type.ts
@@ -185,26 +185,25 @@ export type ArticleEdge = {
 };
 
 /** The set of valid sort keys for the Article query. */
-export enum ArticleSortKeys {
+export type ArticleSortKeys =
   /** Sort by the `author` value. */
-  Author = 'AUTHOR',
+  | 'AUTHOR'
   /** Sort by the `blog_title` value. */
-  BlogTitle = 'BLOG_TITLE',
+  | 'BLOG_TITLE'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `published_at` value. */
-  PublishedAt = 'PUBLISHED_AT',
+  | 'PUBLISHED_AT'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE',
+  | 'TITLE'
   /** Sort by the `updated_at` value. */
-  UpdatedAt = 'UPDATED_AT'
-}
+  | 'UPDATED_AT';
 
 /** Represents a generic custom attribute. */
 export type Attribute = {
@@ -344,36 +343,34 @@ export type BlogEdge = {
 };
 
 /** The set of valid sort keys for the Blog query. */
-export enum BlogSortKeys {
+export type BlogSortKeys =
   /** Sort by the `handle` value. */
-  Handle = 'HANDLE',
+  | 'HANDLE'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE'
-}
+  | 'TITLE';
 
 /** Card brand, such as Visa or Mastercard, which can be used for payments. */
-export enum CardBrand {
+export type CardBrand =
   /** American Express. */
-  AmericanExpress = 'AMERICAN_EXPRESS',
+  | 'AMERICAN_EXPRESS'
   /** Diners Club. */
-  DinersClub = 'DINERS_CLUB',
+  | 'DINERS_CLUB'
   /** Discover. */
-  Discover = 'DISCOVER',
+  | 'DISCOVER'
   /** JCB. */
-  Jcb = 'JCB',
+  | 'JCB'
   /** Mastercard. */
-  Mastercard = 'MASTERCARD',
+  | 'MASTERCARD'
   /** Visa. */
-  Visa = 'VISA'
-}
+  | 'VISA';
 
 /** A cart represents the merchandise that a buyer intends to purchase, and the estimated cost associated with the cart. To learn how to interact with a cart during a customer's session, refer to [Manage a cart with the Storefront API](https://shopify.dev/api/examples/cart). */
 export type Cart = Node & {
@@ -644,18 +641,17 @@ export type CartDiscountCodesUpdatePayload = {
 };
 
 /** Possible error codes that can be returned by `CartUserError`. */
-export enum CartErrorCode {
+export type CartErrorCode =
   /** The input value is invalid. */
-  Invalid = 'INVALID',
+  | 'INVALID'
   /** Merchandise line was not found in cart. */
-  InvalidMerchandiseLine = 'INVALID_MERCHANDISE_LINE',
+  | 'INVALID_MERCHANDISE_LINE'
   /** The input value should be less than the maximum value allowed. */
-  LessThan = 'LESS_THAN',
+  | 'LESS_THAN'
   /** Missing discount code. */
-  MissingDiscountCode = 'MISSING_DISCOUNT_CODE',
+  | 'MISSING_DISCOUNT_CODE'
   /** Missing note. */
-  MissingNote = 'MISSING_NOTE'
-}
+  | 'MISSING_NOTE';
 
 /**
  * The estimated costs that the buyer will pay at checkout.
@@ -1174,96 +1170,95 @@ export type CheckoutEmailUpdateV2Payload = {
 };
 
 /** Possible error codes that can be returned by `CheckoutUserError`. */
-export enum CheckoutErrorCode {
+export type CheckoutErrorCode =
   /** Checkout is already completed. */
-  AlreadyCompleted = 'ALREADY_COMPLETED',
+  | 'ALREADY_COMPLETED'
   /** Input email contains an invalid domain name. */
-  BadDomain = 'BAD_DOMAIN',
+  | 'BAD_DOMAIN'
   /** The input value is blank. */
-  Blank = 'BLANK',
+  | 'BLANK'
   /** Cart does not meet discount requirements notice. */
-  CartDoesNotMeetDiscountRequirementsNotice = 'CART_DOES_NOT_MEET_DISCOUNT_REQUIREMENTS_NOTICE',
+  | 'CART_DOES_NOT_MEET_DISCOUNT_REQUIREMENTS_NOTICE'
   /** Customer already used once per customer discount notice. */
-  CustomerAlreadyUsedOncePerCustomerDiscountNotice = 'CUSTOMER_ALREADY_USED_ONCE_PER_CUSTOMER_DISCOUNT_NOTICE',
+  | 'CUSTOMER_ALREADY_USED_ONCE_PER_CUSTOMER_DISCOUNT_NOTICE'
   /** Discount already applied. */
-  DiscountAlreadyApplied = 'DISCOUNT_ALREADY_APPLIED',
+  | 'DISCOUNT_ALREADY_APPLIED'
   /** Discount disabled. */
-  DiscountDisabled = 'DISCOUNT_DISABLED',
+  | 'DISCOUNT_DISABLED'
   /** Discount expired. */
-  DiscountExpired = 'DISCOUNT_EXPIRED',
+  | 'DISCOUNT_EXPIRED'
   /** Discount limit reached. */
-  DiscountLimitReached = 'DISCOUNT_LIMIT_REACHED',
+  | 'DISCOUNT_LIMIT_REACHED'
   /** Discount not found. */
-  DiscountNotFound = 'DISCOUNT_NOT_FOUND',
+  | 'DISCOUNT_NOT_FOUND'
   /** Checkout is already completed. */
-  Empty = 'EMPTY',
+  | 'EMPTY'
   /** Queue token has expired. */
-  ExpiredQueueToken = 'EXPIRED_QUEUE_TOKEN',
+  | 'EXPIRED_QUEUE_TOKEN'
   /** Gift card has already been applied. */
-  GiftCardAlreadyApplied = 'GIFT_CARD_ALREADY_APPLIED',
+  | 'GIFT_CARD_ALREADY_APPLIED'
   /** Gift card code is invalid. */
-  GiftCardCodeInvalid = 'GIFT_CARD_CODE_INVALID',
+  | 'GIFT_CARD_CODE_INVALID'
   /** Gift card currency does not match checkout currency. */
-  GiftCardCurrencyMismatch = 'GIFT_CARD_CURRENCY_MISMATCH',
+  | 'GIFT_CARD_CURRENCY_MISMATCH'
   /** Gift card has no funds left. */
-  GiftCardDepleted = 'GIFT_CARD_DEPLETED',
+  | 'GIFT_CARD_DEPLETED'
   /** Gift card is disabled. */
-  GiftCardDisabled = 'GIFT_CARD_DISABLED',
+  | 'GIFT_CARD_DISABLED'
   /** Gift card is expired. */
-  GiftCardExpired = 'GIFT_CARD_EXPIRED',
+  | 'GIFT_CARD_EXPIRED'
   /** Gift card was not found. */
-  GiftCardNotFound = 'GIFT_CARD_NOT_FOUND',
+  | 'GIFT_CARD_NOT_FOUND'
   /** Gift card cannot be applied to a checkout that contains a gift card. */
-  GiftCardUnusable = 'GIFT_CARD_UNUSABLE',
+  | 'GIFT_CARD_UNUSABLE'
   /** The input value should be greater than or equal to the minimum value allowed. */
-  GreaterThanOrEqualTo = 'GREATER_THAN_OR_EQUAL_TO',
+  | 'GREATER_THAN_OR_EQUAL_TO'
   /** Higher value discount applied. */
-  HigherValueDiscountApplied = 'HIGHER_VALUE_DISCOUNT_APPLIED',
+  | 'HIGHER_VALUE_DISCOUNT_APPLIED'
   /** The input value is invalid. */
-  Invalid = 'INVALID',
+  | 'INVALID'
   /** Cannot specify country and presentment currency code. */
-  InvalidCountryAndCurrency = 'INVALID_COUNTRY_AND_CURRENCY',
+  | 'INVALID_COUNTRY_AND_CURRENCY'
   /** Input Zip is invalid for country provided. */
-  InvalidForCountry = 'INVALID_FOR_COUNTRY',
+  | 'INVALID_FOR_COUNTRY'
   /** Input Zip is invalid for country and province provided. */
-  InvalidForCountryAndProvince = 'INVALID_FOR_COUNTRY_AND_PROVINCE',
+  | 'INVALID_FOR_COUNTRY_AND_PROVINCE'
   /** Invalid province in country. */
-  InvalidProvinceInCountry = 'INVALID_PROVINCE_IN_COUNTRY',
+  | 'INVALID_PROVINCE_IN_COUNTRY'
   /** Queue token is invalid. */
-  InvalidQueueToken = 'INVALID_QUEUE_TOKEN',
+  | 'INVALID_QUEUE_TOKEN'
   /** Invalid region in country. */
-  InvalidRegionInCountry = 'INVALID_REGION_IN_COUNTRY',
+  | 'INVALID_REGION_IN_COUNTRY'
   /** Invalid state in country. */
-  InvalidStateInCountry = 'INVALID_STATE_IN_COUNTRY',
+  | 'INVALID_STATE_IN_COUNTRY'
   /** The input value should be less than the maximum value allowed. */
-  LessThan = 'LESS_THAN',
+  | 'LESS_THAN'
   /** The input value should be less than or equal to the maximum value allowed. */
-  LessThanOrEqualTo = 'LESS_THAN_OR_EQUAL_TO',
+  | 'LESS_THAN_OR_EQUAL_TO'
   /** Line item was not found in checkout. */
-  LineItemNotFound = 'LINE_ITEM_NOT_FOUND',
+  | 'LINE_ITEM_NOT_FOUND'
   /** Checkout is locked. */
-  Locked = 'LOCKED',
+  | 'LOCKED'
   /** Maximum number of discount codes limit reached. */
-  MaximumDiscountCodeLimitReached = 'MAXIMUM_DISCOUNT_CODE_LIMIT_REACHED',
+  | 'MAXIMUM_DISCOUNT_CODE_LIMIT_REACHED'
   /** Missing payment input. */
-  MissingPaymentInput = 'MISSING_PAYMENT_INPUT',
+  | 'MISSING_PAYMENT_INPUT'
   /** Not enough in stock. */
-  NotEnoughInStock = 'NOT_ENOUGH_IN_STOCK',
+  | 'NOT_ENOUGH_IN_STOCK'
   /** Input value is not supported. */
-  NotSupported = 'NOT_SUPPORTED',
+  | 'NOT_SUPPORTED'
   /** The input value needs to be blank. */
-  Present = 'PRESENT',
+  | 'PRESENT'
   /** Shipping rate expired. */
-  ShippingRateExpired = 'SHIPPING_RATE_EXPIRED',
+  | 'SHIPPING_RATE_EXPIRED'
   /** Throttled during checkout. */
-  ThrottledDuringCheckout = 'THROTTLED_DURING_CHECKOUT',
+  | 'THROTTLED_DURING_CHECKOUT'
   /** The input value is too long. */
-  TooLong = 'TOO_LONG',
+  | 'TOO_LONG'
   /** The amount of the payment does not match the value to be paid. */
-  TotalPriceMismatch = 'TOTAL_PRICE_MISMATCH',
+  | 'TOTAL_PRICE_MISMATCH'
   /** Unable to apply discount. */
-  UnableToApply = 'UNABLE_TO_APPLY'
-}
+  | 'UNABLE_TO_APPLY';
 
 /** Return type for `checkoutGiftCardRemoveV2` mutation. */
 export type CheckoutGiftCardRemoveV2Payload = {
@@ -1544,20 +1539,19 @@ export type CollectionEdge = {
 };
 
 /** The set of valid sort keys for the Collection query. */
-export enum CollectionSortKeys {
+export type CollectionSortKeys =
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE',
+  | 'TITLE'
   /** Sort by the `updated_at` value. */
-  UpdatedAt = 'UPDATED_AT'
-}
+  | 'UPDATED_AT';
 
 /** A comment on an article. */
 export type Comment = Node & {
@@ -1635,498 +1629,497 @@ export type Country = {
  * and the territories associated with the United States of America are represented by the country code `US`.
  *
  */
-export enum CountryCode {
+export type CountryCode =
   /** Ascension Island. */
-  Ac = 'AC',
+  | 'AC'
   /** Andorra. */
-  Ad = 'AD',
+  | 'AD'
   /** United Arab Emirates. */
-  Ae = 'AE',
+  | 'AE'
   /** Afghanistan. */
-  Af = 'AF',
+  | 'AF'
   /** Antigua & Barbuda. */
-  Ag = 'AG',
+  | 'AG'
   /** Anguilla. */
-  Ai = 'AI',
+  | 'AI'
   /** Albania. */
-  Al = 'AL',
+  | 'AL'
   /** Armenia. */
-  Am = 'AM',
+  | 'AM'
   /** Netherlands Antilles. */
-  An = 'AN',
+  | 'AN'
   /** Angola. */
-  Ao = 'AO',
+  | 'AO'
   /** Argentina. */
-  Ar = 'AR',
+  | 'AR'
   /** Austria. */
-  At = 'AT',
+  | 'AT'
   /** Australia. */
-  Au = 'AU',
+  | 'AU'
   /** Aruba. */
-  Aw = 'AW',
+  | 'AW'
   /** Åland Islands. */
-  Ax = 'AX',
+  | 'AX'
   /** Azerbaijan. */
-  Az = 'AZ',
+  | 'AZ'
   /** Bosnia & Herzegovina. */
-  Ba = 'BA',
+  | 'BA'
   /** Barbados. */
-  Bb = 'BB',
+  | 'BB'
   /** Bangladesh. */
-  Bd = 'BD',
+  | 'BD'
   /** Belgium. */
-  Be = 'BE',
+  | 'BE'
   /** Burkina Faso. */
-  Bf = 'BF',
+  | 'BF'
   /** Bulgaria. */
-  Bg = 'BG',
+  | 'BG'
   /** Bahrain. */
-  Bh = 'BH',
+  | 'BH'
   /** Burundi. */
-  Bi = 'BI',
+  | 'BI'
   /** Benin. */
-  Bj = 'BJ',
+  | 'BJ'
   /** St. Barthélemy. */
-  Bl = 'BL',
+  | 'BL'
   /** Bermuda. */
-  Bm = 'BM',
+  | 'BM'
   /** Brunei. */
-  Bn = 'BN',
+  | 'BN'
   /** Bolivia. */
-  Bo = 'BO',
+  | 'BO'
   /** Caribbean Netherlands. */
-  Bq = 'BQ',
+  | 'BQ'
   /** Brazil. */
-  Br = 'BR',
+  | 'BR'
   /** Bahamas. */
-  Bs = 'BS',
+  | 'BS'
   /** Bhutan. */
-  Bt = 'BT',
+  | 'BT'
   /** Bouvet Island. */
-  Bv = 'BV',
+  | 'BV'
   /** Botswana. */
-  Bw = 'BW',
+  | 'BW'
   /** Belarus. */
-  By = 'BY',
+  | 'BY'
   /** Belize. */
-  Bz = 'BZ',
+  | 'BZ'
   /** Canada. */
-  Ca = 'CA',
+  | 'CA'
   /** Cocos (Keeling) Islands. */
-  Cc = 'CC',
+  | 'CC'
   /** Congo - Kinshasa. */
-  Cd = 'CD',
+  | 'CD'
   /** Central African Republic. */
-  Cf = 'CF',
+  | 'CF'
   /** Congo - Brazzaville. */
-  Cg = 'CG',
+  | 'CG'
   /** Switzerland. */
-  Ch = 'CH',
+  | 'CH'
   /** Côte d’Ivoire. */
-  Ci = 'CI',
+  | 'CI'
   /** Cook Islands. */
-  Ck = 'CK',
+  | 'CK'
   /** Chile. */
-  Cl = 'CL',
+  | 'CL'
   /** Cameroon. */
-  Cm = 'CM',
+  | 'CM'
   /** China. */
-  Cn = 'CN',
+  | 'CN'
   /** Colombia. */
-  Co = 'CO',
+  | 'CO'
   /** Costa Rica. */
-  Cr = 'CR',
+  | 'CR'
   /** Cuba. */
-  Cu = 'CU',
+  | 'CU'
   /** Cape Verde. */
-  Cv = 'CV',
+  | 'CV'
   /** Curaçao. */
-  Cw = 'CW',
+  | 'CW'
   /** Christmas Island. */
-  Cx = 'CX',
+  | 'CX'
   /** Cyprus. */
-  Cy = 'CY',
+  | 'CY'
   /** Czechia. */
-  Cz = 'CZ',
+  | 'CZ'
   /** Germany. */
-  De = 'DE',
+  | 'DE'
   /** Djibouti. */
-  Dj = 'DJ',
+  | 'DJ'
   /** Denmark. */
-  Dk = 'DK',
+  | 'DK'
   /** Dominica. */
-  Dm = 'DM',
+  | 'DM'
   /** Dominican Republic. */
-  Do = 'DO',
+  | 'DO'
   /** Algeria. */
-  Dz = 'DZ',
+  | 'DZ'
   /** Ecuador. */
-  Ec = 'EC',
+  | 'EC'
   /** Estonia. */
-  Ee = 'EE',
+  | 'EE'
   /** Egypt. */
-  Eg = 'EG',
+  | 'EG'
   /** Western Sahara. */
-  Eh = 'EH',
+  | 'EH'
   /** Eritrea. */
-  Er = 'ER',
+  | 'ER'
   /** Spain. */
-  Es = 'ES',
+  | 'ES'
   /** Ethiopia. */
-  Et = 'ET',
+  | 'ET'
   /** Finland. */
-  Fi = 'FI',
+  | 'FI'
   /** Fiji. */
-  Fj = 'FJ',
+  | 'FJ'
   /** Falkland Islands. */
-  Fk = 'FK',
+  | 'FK'
   /** Faroe Islands. */
-  Fo = 'FO',
+  | 'FO'
   /** France. */
-  Fr = 'FR',
+  | 'FR'
   /** Gabon. */
-  Ga = 'GA',
+  | 'GA'
   /** United Kingdom. */
-  Gb = 'GB',
+  | 'GB'
   /** Grenada. */
-  Gd = 'GD',
+  | 'GD'
   /** Georgia. */
-  Ge = 'GE',
+  | 'GE'
   /** French Guiana. */
-  Gf = 'GF',
+  | 'GF'
   /** Guernsey. */
-  Gg = 'GG',
+  | 'GG'
   /** Ghana. */
-  Gh = 'GH',
+  | 'GH'
   /** Gibraltar. */
-  Gi = 'GI',
+  | 'GI'
   /** Greenland. */
-  Gl = 'GL',
+  | 'GL'
   /** Gambia. */
-  Gm = 'GM',
+  | 'GM'
   /** Guinea. */
-  Gn = 'GN',
+  | 'GN'
   /** Guadeloupe. */
-  Gp = 'GP',
+  | 'GP'
   /** Equatorial Guinea. */
-  Gq = 'GQ',
+  | 'GQ'
   /** Greece. */
-  Gr = 'GR',
+  | 'GR'
   /** South Georgia & South Sandwich Islands. */
-  Gs = 'GS',
+  | 'GS'
   /** Guatemala. */
-  Gt = 'GT',
+  | 'GT'
   /** Guinea-Bissau. */
-  Gw = 'GW',
+  | 'GW'
   /** Guyana. */
-  Gy = 'GY',
+  | 'GY'
   /** Hong Kong SAR. */
-  Hk = 'HK',
+  | 'HK'
   /** Heard & McDonald Islands. */
-  Hm = 'HM',
+  | 'HM'
   /** Honduras. */
-  Hn = 'HN',
+  | 'HN'
   /** Croatia. */
-  Hr = 'HR',
+  | 'HR'
   /** Haiti. */
-  Ht = 'HT',
+  | 'HT'
   /** Hungary. */
-  Hu = 'HU',
+  | 'HU'
   /** Indonesia. */
-  Id = 'ID',
+  | 'ID'
   /** Ireland. */
-  Ie = 'IE',
+  | 'IE'
   /** Israel. */
-  Il = 'IL',
+  | 'IL'
   /** Isle of Man. */
-  Im = 'IM',
+  | 'IM'
   /** India. */
-  In = 'IN',
+  | 'IN'
   /** British Indian Ocean Territory. */
-  Io = 'IO',
+  | 'IO'
   /** Iraq. */
-  Iq = 'IQ',
+  | 'IQ'
   /** Iran. */
-  Ir = 'IR',
+  | 'IR'
   /** Iceland. */
-  Is = 'IS',
+  | 'IS'
   /** Italy. */
-  It = 'IT',
+  | 'IT'
   /** Jersey. */
-  Je = 'JE',
+  | 'JE'
   /** Jamaica. */
-  Jm = 'JM',
+  | 'JM'
   /** Jordan. */
-  Jo = 'JO',
+  | 'JO'
   /** Japan. */
-  Jp = 'JP',
+  | 'JP'
   /** Kenya. */
-  Ke = 'KE',
+  | 'KE'
   /** Kyrgyzstan. */
-  Kg = 'KG',
+  | 'KG'
   /** Cambodia. */
-  Kh = 'KH',
+  | 'KH'
   /** Kiribati. */
-  Ki = 'KI',
+  | 'KI'
   /** Comoros. */
-  Km = 'KM',
+  | 'KM'
   /** St. Kitts & Nevis. */
-  Kn = 'KN',
+  | 'KN'
   /** North Korea. */
-  Kp = 'KP',
+  | 'KP'
   /** South Korea. */
-  Kr = 'KR',
+  | 'KR'
   /** Kuwait. */
-  Kw = 'KW',
+  | 'KW'
   /** Cayman Islands. */
-  Ky = 'KY',
+  | 'KY'
   /** Kazakhstan. */
-  Kz = 'KZ',
+  | 'KZ'
   /** Laos. */
-  La = 'LA',
+  | 'LA'
   /** Lebanon. */
-  Lb = 'LB',
+  | 'LB'
   /** St. Lucia. */
-  Lc = 'LC',
+  | 'LC'
   /** Liechtenstein. */
-  Li = 'LI',
+  | 'LI'
   /** Sri Lanka. */
-  Lk = 'LK',
+  | 'LK'
   /** Liberia. */
-  Lr = 'LR',
+  | 'LR'
   /** Lesotho. */
-  Ls = 'LS',
+  | 'LS'
   /** Lithuania. */
-  Lt = 'LT',
+  | 'LT'
   /** Luxembourg. */
-  Lu = 'LU',
+  | 'LU'
   /** Latvia. */
-  Lv = 'LV',
+  | 'LV'
   /** Libya. */
-  Ly = 'LY',
+  | 'LY'
   /** Morocco. */
-  Ma = 'MA',
+  | 'MA'
   /** Monaco. */
-  Mc = 'MC',
+  | 'MC'
   /** Moldova. */
-  Md = 'MD',
+  | 'MD'
   /** Montenegro. */
-  Me = 'ME',
+  | 'ME'
   /** St. Martin. */
-  Mf = 'MF',
+  | 'MF'
   /** Madagascar. */
-  Mg = 'MG',
+  | 'MG'
   /** North Macedonia. */
-  Mk = 'MK',
+  | 'MK'
   /** Mali. */
-  Ml = 'ML',
+  | 'ML'
   /** Myanmar (Burma). */
-  Mm = 'MM',
+  | 'MM'
   /** Mongolia. */
-  Mn = 'MN',
+  | 'MN'
   /** Macao SAR. */
-  Mo = 'MO',
+  | 'MO'
   /** Martinique. */
-  Mq = 'MQ',
+  | 'MQ'
   /** Mauritania. */
-  Mr = 'MR',
+  | 'MR'
   /** Montserrat. */
-  Ms = 'MS',
+  | 'MS'
   /** Malta. */
-  Mt = 'MT',
+  | 'MT'
   /** Mauritius. */
-  Mu = 'MU',
+  | 'MU'
   /** Maldives. */
-  Mv = 'MV',
+  | 'MV'
   /** Malawi. */
-  Mw = 'MW',
+  | 'MW'
   /** Mexico. */
-  Mx = 'MX',
+  | 'MX'
   /** Malaysia. */
-  My = 'MY',
+  | 'MY'
   /** Mozambique. */
-  Mz = 'MZ',
+  | 'MZ'
   /** Namibia. */
-  Na = 'NA',
+  | 'NA'
   /** New Caledonia. */
-  Nc = 'NC',
+  | 'NC'
   /** Niger. */
-  Ne = 'NE',
+  | 'NE'
   /** Norfolk Island. */
-  Nf = 'NF',
+  | 'NF'
   /** Nigeria. */
-  Ng = 'NG',
+  | 'NG'
   /** Nicaragua. */
-  Ni = 'NI',
+  | 'NI'
   /** Netherlands. */
-  Nl = 'NL',
+  | 'NL'
   /** Norway. */
-  No = 'NO',
+  | 'NO'
   /** Nepal. */
-  Np = 'NP',
+  | 'NP'
   /** Nauru. */
-  Nr = 'NR',
+  | 'NR'
   /** Niue. */
-  Nu = 'NU',
+  | 'NU'
   /** New Zealand. */
-  Nz = 'NZ',
+  | 'NZ'
   /** Oman. */
-  Om = 'OM',
+  | 'OM'
   /** Panama. */
-  Pa = 'PA',
+  | 'PA'
   /** Peru. */
-  Pe = 'PE',
+  | 'PE'
   /** French Polynesia. */
-  Pf = 'PF',
+  | 'PF'
   /** Papua New Guinea. */
-  Pg = 'PG',
+  | 'PG'
   /** Philippines. */
-  Ph = 'PH',
+  | 'PH'
   /** Pakistan. */
-  Pk = 'PK',
+  | 'PK'
   /** Poland. */
-  Pl = 'PL',
+  | 'PL'
   /** St. Pierre & Miquelon. */
-  Pm = 'PM',
+  | 'PM'
   /** Pitcairn Islands. */
-  Pn = 'PN',
+  | 'PN'
   /** Palestinian Territories. */
-  Ps = 'PS',
+  | 'PS'
   /** Portugal. */
-  Pt = 'PT',
+  | 'PT'
   /** Paraguay. */
-  Py = 'PY',
+  | 'PY'
   /** Qatar. */
-  Qa = 'QA',
+  | 'QA'
   /** Réunion. */
-  Re = 'RE',
+  | 'RE'
   /** Romania. */
-  Ro = 'RO',
+  | 'RO'
   /** Serbia. */
-  Rs = 'RS',
+  | 'RS'
   /** Russia. */
-  Ru = 'RU',
+  | 'RU'
   /** Rwanda. */
-  Rw = 'RW',
+  | 'RW'
   /** Saudi Arabia. */
-  Sa = 'SA',
+  | 'SA'
   /** Solomon Islands. */
-  Sb = 'SB',
+  | 'SB'
   /** Seychelles. */
-  Sc = 'SC',
+  | 'SC'
   /** Sudan. */
-  Sd = 'SD',
+  | 'SD'
   /** Sweden. */
-  Se = 'SE',
+  | 'SE'
   /** Singapore. */
-  Sg = 'SG',
+  | 'SG'
   /** St. Helena. */
-  Sh = 'SH',
+  | 'SH'
   /** Slovenia. */
-  Si = 'SI',
+  | 'SI'
   /** Svalbard & Jan Mayen. */
-  Sj = 'SJ',
+  | 'SJ'
   /** Slovakia. */
-  Sk = 'SK',
+  | 'SK'
   /** Sierra Leone. */
-  Sl = 'SL',
+  | 'SL'
   /** San Marino. */
-  Sm = 'SM',
+  | 'SM'
   /** Senegal. */
-  Sn = 'SN',
+  | 'SN'
   /** Somalia. */
-  So = 'SO',
+  | 'SO'
   /** Suriname. */
-  Sr = 'SR',
+  | 'SR'
   /** South Sudan. */
-  Ss = 'SS',
+  | 'SS'
   /** São Tomé & Príncipe. */
-  St = 'ST',
+  | 'ST'
   /** El Salvador. */
-  Sv = 'SV',
+  | 'SV'
   /** Sint Maarten. */
-  Sx = 'SX',
+  | 'SX'
   /** Syria. */
-  Sy = 'SY',
+  | 'SY'
   /** Eswatini. */
-  Sz = 'SZ',
+  | 'SZ'
   /** Tristan da Cunha. */
-  Ta = 'TA',
+  | 'TA'
   /** Turks & Caicos Islands. */
-  Tc = 'TC',
+  | 'TC'
   /** Chad. */
-  Td = 'TD',
+  | 'TD'
   /** French Southern Territories. */
-  Tf = 'TF',
+  | 'TF'
   /** Togo. */
-  Tg = 'TG',
+  | 'TG'
   /** Thailand. */
-  Th = 'TH',
+  | 'TH'
   /** Tajikistan. */
-  Tj = 'TJ',
+  | 'TJ'
   /** Tokelau. */
-  Tk = 'TK',
+  | 'TK'
   /** Timor-Leste. */
-  Tl = 'TL',
+  | 'TL'
   /** Turkmenistan. */
-  Tm = 'TM',
+  | 'TM'
   /** Tunisia. */
-  Tn = 'TN',
+  | 'TN'
   /** Tonga. */
-  To = 'TO',
+  | 'TO'
   /** Turkey. */
-  Tr = 'TR',
+  | 'TR'
   /** Trinidad & Tobago. */
-  Tt = 'TT',
+  | 'TT'
   /** Tuvalu. */
-  Tv = 'TV',
+  | 'TV'
   /** Taiwan. */
-  Tw = 'TW',
+  | 'TW'
   /** Tanzania. */
-  Tz = 'TZ',
+  | 'TZ'
   /** Ukraine. */
-  Ua = 'UA',
+  | 'UA'
   /** Uganda. */
-  Ug = 'UG',
+  | 'UG'
   /** U.S. Outlying Islands. */
-  Um = 'UM',
+  | 'UM'
   /** United States. */
-  Us = 'US',
+  | 'US'
   /** Uruguay. */
-  Uy = 'UY',
+  | 'UY'
   /** Uzbekistan. */
-  Uz = 'UZ',
+  | 'UZ'
   /** Vatican City. */
-  Va = 'VA',
+  | 'VA'
   /** St. Vincent & Grenadines. */
-  Vc = 'VC',
+  | 'VC'
   /** Venezuela. */
-  Ve = 'VE',
+  | 'VE'
   /** British Virgin Islands. */
-  Vg = 'VG',
+  | 'VG'
   /** Vietnam. */
-  Vn = 'VN',
+  | 'VN'
   /** Vanuatu. */
-  Vu = 'VU',
+  | 'VU'
   /** Wallis & Futuna. */
-  Wf = 'WF',
+  | 'WF'
   /** Samoa. */
-  Ws = 'WS',
+  | 'WS'
   /** Kosovo. */
-  Xk = 'XK',
+  | 'XK'
   /** Yemen. */
-  Ye = 'YE',
+  | 'YE'
   /** Mayotte. */
-  Yt = 'YT',
+  | 'YT'
   /** South Africa. */
-  Za = 'ZA',
+  | 'ZA'
   /** Zambia. */
-  Zm = 'ZM',
+  | 'ZM'
   /** Zimbabwe. */
-  Zw = 'ZW',
+  | 'ZW'
   /** Unknown Region. */
-  Zz = 'ZZ'
-}
+  | 'ZZ';
 
 /** Credit card information used for a payment. */
 export type CreditCard = {
@@ -2168,18 +2161,17 @@ export type CreditCardPaymentInputV2 = {
 };
 
 /** The part of the image that should remain after cropping. */
-export enum CropRegion {
+export type CropRegion =
   /** Keep the bottom of the image. */
-  Bottom = 'BOTTOM',
+  | 'BOTTOM'
   /** Keep the center of the image. */
-  Center = 'CENTER',
+  | 'CENTER'
   /** Keep the left of the image. */
-  Left = 'LEFT',
+  | 'LEFT'
   /** Keep the right of the image. */
-  Right = 'RIGHT',
+  | 'RIGHT'
   /** Keep the top of the image. */
-  Top = 'TOP'
-}
+  | 'TOP';
 
 /** A currency. */
 export type Currency = {
@@ -2197,339 +2189,329 @@ export type Currency = {
  * and non-standard codes.
  *
  */
-export enum CurrencyCode {
+export type CurrencyCode =
   /** United Arab Emirates Dirham (AED). */
-  Aed = 'AED',
+  | 'AED'
   /** Afghan Afghani (AFN). */
-  Afn = 'AFN',
+  | 'AFN'
   /** Albanian Lek (ALL). */
-  All = 'ALL',
+  | 'ALL'
   /** Armenian Dram (AMD). */
-  Amd = 'AMD',
+  | 'AMD'
   /** Netherlands Antillean Guilder. */
-  Ang = 'ANG',
+  | 'ANG'
   /** Angolan Kwanza (AOA). */
-  Aoa = 'AOA',
+  | 'AOA'
   /** Argentine Pesos (ARS). */
-  Ars = 'ARS',
+  | 'ARS'
   /** Australian Dollars (AUD). */
-  Aud = 'AUD',
+  | 'AUD'
   /** Aruban Florin (AWG). */
-  Awg = 'AWG',
+  | 'AWG'
   /** Azerbaijani Manat (AZN). */
-  Azn = 'AZN',
+  | 'AZN'
   /** Bosnia and Herzegovina Convertible Mark (BAM). */
-  Bam = 'BAM',
+  | 'BAM'
   /** Barbadian Dollar (BBD). */
-  Bbd = 'BBD',
+  | 'BBD'
   /** Bangladesh Taka (BDT). */
-  Bdt = 'BDT',
+  | 'BDT'
   /** Bulgarian Lev (BGN). */
-  Bgn = 'BGN',
+  | 'BGN'
   /** Bahraini Dinar (BHD). */
-  Bhd = 'BHD',
+  | 'BHD'
   /** Burundian Franc (BIF). */
-  Bif = 'BIF',
+  | 'BIF'
   /** Bermudian Dollar (BMD). */
-  Bmd = 'BMD',
+  | 'BMD'
   /** Brunei Dollar (BND). */
-  Bnd = 'BND',
+  | 'BND'
   /** Bolivian Boliviano (BOB). */
-  Bob = 'BOB',
+  | 'BOB'
   /** Brazilian Real (BRL). */
-  Brl = 'BRL',
+  | 'BRL'
   /** Bahamian Dollar (BSD). */
-  Bsd = 'BSD',
+  | 'BSD'
   /** Bhutanese Ngultrum (BTN). */
-  Btn = 'BTN',
+  | 'BTN'
   /** Botswana Pula (BWP). */
-  Bwp = 'BWP',
+  | 'BWP'
   /** Belarusian Ruble (BYN). */
-  Byn = 'BYN',
-  /**
-   * Belarusian Ruble (BYR).
-   * @deprecated `BYR` is deprecated. Use `BYN` available from version `2021-01` onwards instead.
-   */
-  Byr = 'BYR',
+  | 'BYN'
+  /** Belarusian Ruble (BYR). */
+  | 'BYR'
   /** Belize Dollar (BZD). */
-  Bzd = 'BZD',
+  | 'BZD'
   /** Canadian Dollars (CAD). */
-  Cad = 'CAD',
+  | 'CAD'
   /** Congolese franc (CDF). */
-  Cdf = 'CDF',
+  | 'CDF'
   /** Swiss Francs (CHF). */
-  Chf = 'CHF',
+  | 'CHF'
   /** Chilean Peso (CLP). */
-  Clp = 'CLP',
+  | 'CLP'
   /** Chinese Yuan Renminbi (CNY). */
-  Cny = 'CNY',
+  | 'CNY'
   /** Colombian Peso (COP). */
-  Cop = 'COP',
+  | 'COP'
   /** Costa Rican Colones (CRC). */
-  Crc = 'CRC',
+  | 'CRC'
   /** Cape Verdean escudo (CVE). */
-  Cve = 'CVE',
+  | 'CVE'
   /** Czech Koruny (CZK). */
-  Czk = 'CZK',
+  | 'CZK'
   /** Djiboutian Franc (DJF). */
-  Djf = 'DJF',
+  | 'DJF'
   /** Danish Kroner (DKK). */
-  Dkk = 'DKK',
+  | 'DKK'
   /** Dominican Peso (DOP). */
-  Dop = 'DOP',
+  | 'DOP'
   /** Algerian Dinar (DZD). */
-  Dzd = 'DZD',
+  | 'DZD'
   /** Egyptian Pound (EGP). */
-  Egp = 'EGP',
+  | 'EGP'
   /** Eritrean Nakfa (ERN). */
-  Ern = 'ERN',
+  | 'ERN'
   /** Ethiopian Birr (ETB). */
-  Etb = 'ETB',
+  | 'ETB'
   /** Euro (EUR). */
-  Eur = 'EUR',
+  | 'EUR'
   /** Fijian Dollars (FJD). */
-  Fjd = 'FJD',
+  | 'FJD'
   /** Falkland Islands Pounds (FKP). */
-  Fkp = 'FKP',
+  | 'FKP'
   /** United Kingdom Pounds (GBP). */
-  Gbp = 'GBP',
+  | 'GBP'
   /** Georgian Lari (GEL). */
-  Gel = 'GEL',
+  | 'GEL'
   /** Ghanaian Cedi (GHS). */
-  Ghs = 'GHS',
+  | 'GHS'
   /** Gibraltar Pounds (GIP). */
-  Gip = 'GIP',
+  | 'GIP'
   /** Gambian Dalasi (GMD). */
-  Gmd = 'GMD',
+  | 'GMD'
   /** Guinean Franc (GNF). */
-  Gnf = 'GNF',
+  | 'GNF'
   /** Guatemalan Quetzal (GTQ). */
-  Gtq = 'GTQ',
+  | 'GTQ'
   /** Guyanese Dollar (GYD). */
-  Gyd = 'GYD',
+  | 'GYD'
   /** Hong Kong Dollars (HKD). */
-  Hkd = 'HKD',
+  | 'HKD'
   /** Honduran Lempira (HNL). */
-  Hnl = 'HNL',
+  | 'HNL'
   /** Croatian Kuna (HRK). */
-  Hrk = 'HRK',
+  | 'HRK'
   /** Haitian Gourde (HTG). */
-  Htg = 'HTG',
+  | 'HTG'
   /** Hungarian Forint (HUF). */
-  Huf = 'HUF',
+  | 'HUF'
   /** Indonesian Rupiah (IDR). */
-  Idr = 'IDR',
+  | 'IDR'
   /** Israeli New Shekel (NIS). */
-  Ils = 'ILS',
+  | 'ILS'
   /** Indian Rupees (INR). */
-  Inr = 'INR',
+  | 'INR'
   /** Iraqi Dinar (IQD). */
-  Iqd = 'IQD',
+  | 'IQD'
   /** Iranian Rial (IRR). */
-  Irr = 'IRR',
+  | 'IRR'
   /** Icelandic Kronur (ISK). */
-  Isk = 'ISK',
+  | 'ISK'
   /** Jersey Pound. */
-  Jep = 'JEP',
+  | 'JEP'
   /** Jamaican Dollars (JMD). */
-  Jmd = 'JMD',
+  | 'JMD'
   /** Jordanian Dinar (JOD). */
-  Jod = 'JOD',
+  | 'JOD'
   /** Japanese Yen (JPY). */
-  Jpy = 'JPY',
+  | 'JPY'
   /** Kenyan Shilling (KES). */
-  Kes = 'KES',
+  | 'KES'
   /** Kyrgyzstani Som (KGS). */
-  Kgs = 'KGS',
+  | 'KGS'
   /** Cambodian Riel. */
-  Khr = 'KHR',
+  | 'KHR'
   /** Kiribati Dollar (KID). */
-  Kid = 'KID',
+  | 'KID'
   /** Comorian Franc (KMF). */
-  Kmf = 'KMF',
+  | 'KMF'
   /** South Korean Won (KRW). */
-  Krw = 'KRW',
+  | 'KRW'
   /** Kuwaiti Dinar (KWD). */
-  Kwd = 'KWD',
+  | 'KWD'
   /** Cayman Dollars (KYD). */
-  Kyd = 'KYD',
+  | 'KYD'
   /** Kazakhstani Tenge (KZT). */
-  Kzt = 'KZT',
+  | 'KZT'
   /** Laotian Kip (LAK). */
-  Lak = 'LAK',
+  | 'LAK'
   /** Lebanese Pounds (LBP). */
-  Lbp = 'LBP',
+  | 'LBP'
   /** Sri Lankan Rupees (LKR). */
-  Lkr = 'LKR',
+  | 'LKR'
   /** Liberian Dollar (LRD). */
-  Lrd = 'LRD',
+  | 'LRD'
   /** Lesotho Loti (LSL). */
-  Lsl = 'LSL',
+  | 'LSL'
   /** Lithuanian Litai (LTL). */
-  Ltl = 'LTL',
+  | 'LTL'
   /** Latvian Lati (LVL). */
-  Lvl = 'LVL',
+  | 'LVL'
   /** Libyan Dinar (LYD). */
-  Lyd = 'LYD',
+  | 'LYD'
   /** Moroccan Dirham. */
-  Mad = 'MAD',
+  | 'MAD'
   /** Moldovan Leu (MDL). */
-  Mdl = 'MDL',
+  | 'MDL'
   /** Malagasy Ariary (MGA). */
-  Mga = 'MGA',
+  | 'MGA'
   /** Macedonia Denar (MKD). */
-  Mkd = 'MKD',
+  | 'MKD'
   /** Burmese Kyat (MMK). */
-  Mmk = 'MMK',
+  | 'MMK'
   /** Mongolian Tugrik. */
-  Mnt = 'MNT',
+  | 'MNT'
   /** Macanese Pataca (MOP). */
-  Mop = 'MOP',
+  | 'MOP'
   /** Mauritanian Ouguiya (MRU). */
-  Mru = 'MRU',
+  | 'MRU'
   /** Mauritian Rupee (MUR). */
-  Mur = 'MUR',
+  | 'MUR'
   /** Maldivian Rufiyaa (MVR). */
-  Mvr = 'MVR',
+  | 'MVR'
   /** Malawian Kwacha (MWK). */
-  Mwk = 'MWK',
+  | 'MWK'
   /** Mexican Pesos (MXN). */
-  Mxn = 'MXN',
+  | 'MXN'
   /** Malaysian Ringgits (MYR). */
-  Myr = 'MYR',
+  | 'MYR'
   /** Mozambican Metical. */
-  Mzn = 'MZN',
+  | 'MZN'
   /** Namibian Dollar. */
-  Nad = 'NAD',
+  | 'NAD'
   /** Nigerian Naira (NGN). */
-  Ngn = 'NGN',
+  | 'NGN'
   /** Nicaraguan Córdoba (NIO). */
-  Nio = 'NIO',
+  | 'NIO'
   /** Norwegian Kroner (NOK). */
-  Nok = 'NOK',
+  | 'NOK'
   /** Nepalese Rupee (NPR). */
-  Npr = 'NPR',
+  | 'NPR'
   /** New Zealand Dollars (NZD). */
-  Nzd = 'NZD',
+  | 'NZD'
   /** Omani Rial (OMR). */
-  Omr = 'OMR',
+  | 'OMR'
   /** Panamian Balboa (PAB). */
-  Pab = 'PAB',
+  | 'PAB'
   /** Peruvian Nuevo Sol (PEN). */
-  Pen = 'PEN',
+  | 'PEN'
   /** Papua New Guinean Kina (PGK). */
-  Pgk = 'PGK',
+  | 'PGK'
   /** Philippine Peso (PHP). */
-  Php = 'PHP',
+  | 'PHP'
   /** Pakistani Rupee (PKR). */
-  Pkr = 'PKR',
+  | 'PKR'
   /** Polish Zlotych (PLN). */
-  Pln = 'PLN',
+  | 'PLN'
   /** Paraguayan Guarani (PYG). */
-  Pyg = 'PYG',
+  | 'PYG'
   /** Qatari Rial (QAR). */
-  Qar = 'QAR',
+  | 'QAR'
   /** Romanian Lei (RON). */
-  Ron = 'RON',
+  | 'RON'
   /** Serbian dinar (RSD). */
-  Rsd = 'RSD',
+  | 'RSD'
   /** Russian Rubles (RUB). */
-  Rub = 'RUB',
+  | 'RUB'
   /** Rwandan Franc (RWF). */
-  Rwf = 'RWF',
+  | 'RWF'
   /** Saudi Riyal (SAR). */
-  Sar = 'SAR',
+  | 'SAR'
   /** Solomon Islands Dollar (SBD). */
-  Sbd = 'SBD',
+  | 'SBD'
   /** Seychellois Rupee (SCR). */
-  Scr = 'SCR',
+  | 'SCR'
   /** Sudanese Pound (SDG). */
-  Sdg = 'SDG',
+  | 'SDG'
   /** Swedish Kronor (SEK). */
-  Sek = 'SEK',
+  | 'SEK'
   /** Singapore Dollars (SGD). */
-  Sgd = 'SGD',
+  | 'SGD'
   /** Saint Helena Pounds (SHP). */
-  Shp = 'SHP',
+  | 'SHP'
   /** Sierra Leonean Leone (SLL). */
-  Sll = 'SLL',
+  | 'SLL'
   /** Somali Shilling (SOS). */
-  Sos = 'SOS',
+  | 'SOS'
   /** Surinamese Dollar (SRD). */
-  Srd = 'SRD',
+  | 'SRD'
   /** South Sudanese Pound (SSP). */
-  Ssp = 'SSP',
-  /**
-   * Sao Tome And Principe Dobra (STD).
-   * @deprecated `STD` is deprecated. Use `STN` available from version `2022-07` onwards instead.
-   */
-  Std = 'STD',
+  | 'SSP'
+  /** Sao Tome And Principe Dobra (STD). */
+  | 'STD'
   /** Sao Tome And Principe Dobra (STN). */
-  Stn = 'STN',
+  | 'STN'
   /** Syrian Pound (SYP). */
-  Syp = 'SYP',
+  | 'SYP'
   /** Swazi Lilangeni (SZL). */
-  Szl = 'SZL',
+  | 'SZL'
   /** Thai baht (THB). */
-  Thb = 'THB',
+  | 'THB'
   /** Tajikistani Somoni (TJS). */
-  Tjs = 'TJS',
+  | 'TJS'
   /** Turkmenistani Manat (TMT). */
-  Tmt = 'TMT',
+  | 'TMT'
   /** Tunisian Dinar (TND). */
-  Tnd = 'TND',
+  | 'TND'
   /** Tongan Pa'anga (TOP). */
-  Top = 'TOP',
+  | 'TOP'
   /** Turkish Lira (TRY). */
-  Try = 'TRY',
+  | 'TRY'
   /** Trinidad and Tobago Dollars (TTD). */
-  Ttd = 'TTD',
+  | 'TTD'
   /** Taiwan Dollars (TWD). */
-  Twd = 'TWD',
+  | 'TWD'
   /** Tanzanian Shilling (TZS). */
-  Tzs = 'TZS',
+  | 'TZS'
   /** Ukrainian Hryvnia (UAH). */
-  Uah = 'UAH',
+  | 'UAH'
   /** Ugandan Shilling (UGX). */
-  Ugx = 'UGX',
+  | 'UGX'
   /** United States Dollars (USD). */
-  Usd = 'USD',
+  | 'USD'
   /** Uruguayan Pesos (UYU). */
-  Uyu = 'UYU',
+  | 'UYU'
   /** Uzbekistan som (UZS). */
-  Uzs = 'UZS',
+  | 'UZS'
   /** Venezuelan Bolivares (VED). */
-  Ved = 'VED',
-  /**
-   * Venezuelan Bolivares (VEF).
-   * @deprecated `VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.
-   */
-  Vef = 'VEF',
+  | 'VED'
+  /** Venezuelan Bolivares (VEF). */
+  | 'VEF'
   /** Venezuelan Bolivares (VES). */
-  Ves = 'VES',
+  | 'VES'
   /** Vietnamese đồng (VND). */
-  Vnd = 'VND',
+  | 'VND'
   /** Vanuatu Vatu (VUV). */
-  Vuv = 'VUV',
+  | 'VUV'
   /** Samoan Tala (WST). */
-  Wst = 'WST',
+  | 'WST'
   /** Central African CFA Franc (XAF). */
-  Xaf = 'XAF',
+  | 'XAF'
   /** East Caribbean Dollar (XCD). */
-  Xcd = 'XCD',
+  | 'XCD'
   /** West African CFA franc (XOF). */
-  Xof = 'XOF',
+  | 'XOF'
   /** CFP Franc (XPF). */
-  Xpf = 'XPF',
+  | 'XPF'
   /** Unrecognized currency. */
-  Xxx = 'XXX',
+  | 'XXX'
   /** Yemeni Rial (YER). */
-  Yer = 'YER',
+  | 'YER'
   /** South African Rand (ZAR). */
-  Zar = 'ZAR',
+  | 'ZAR'
   /** Zambian Kwacha (ZMW). */
-  Zmw = 'ZMW'
-}
+  | 'ZMW';
 
 /** A customer represents a customer account with the shop. Customer accounts store contact information for the customer, saving logged-in customers the trouble of having to provide it at every checkout. */
 export type Customer = HasMetafields & {
@@ -2797,38 +2779,37 @@ export type CustomerDefaultAddressUpdatePayload = {
 };
 
 /** Possible error codes that can be returned by `CustomerUserError`. */
-export enum CustomerErrorCode {
+export type CustomerErrorCode =
   /** Customer already enabled. */
-  AlreadyEnabled = 'ALREADY_ENABLED',
+  | 'ALREADY_ENABLED'
   /** Input email contains an invalid domain name. */
-  BadDomain = 'BAD_DOMAIN',
+  | 'BAD_DOMAIN'
   /** The input value is blank. */
-  Blank = 'BLANK',
+  | 'BLANK'
   /** Input contains HTML tags. */
-  ContainsHtmlTags = 'CONTAINS_HTML_TAGS',
+  | 'CONTAINS_HTML_TAGS'
   /** Input contains URL. */
-  ContainsUrl = 'CONTAINS_URL',
+  | 'CONTAINS_URL'
   /** Customer is disabled. */
-  CustomerDisabled = 'CUSTOMER_DISABLED',
+  | 'CUSTOMER_DISABLED'
   /** The input value is invalid. */
-  Invalid = 'INVALID',
+  | 'INVALID'
   /** Multipass token is not valid. */
-  InvalidMultipassRequest = 'INVALID_MULTIPASS_REQUEST',
+  | 'INVALID_MULTIPASS_REQUEST'
   /** Address does not exist. */
-  NotFound = 'NOT_FOUND',
+  | 'NOT_FOUND'
   /** Input password starts or ends with whitespace. */
-  PasswordStartsOrEndsWithWhitespace = 'PASSWORD_STARTS_OR_ENDS_WITH_WHITESPACE',
+  | 'PASSWORD_STARTS_OR_ENDS_WITH_WHITESPACE'
   /** The input value is already taken. */
-  Taken = 'TAKEN',
+  | 'TAKEN'
   /** Invalid activation token. */
-  TokenInvalid = 'TOKEN_INVALID',
+  | 'TOKEN_INVALID'
   /** The input value is too long. */
-  TooLong = 'TOO_LONG',
+  | 'TOO_LONG'
   /** The input value is too short. */
-  TooShort = 'TOO_SHORT',
+  | 'TOO_SHORT'
   /** Unidentified customer. */
-  UnidentifiedCustomer = 'UNIDENTIFIED_CUSTOMER'
-}
+  | 'UNIDENTIFIED_CUSTOMER';
 
 /** Return type for `customerRecover` mutation. */
 export type CustomerRecoverPayload = {
@@ -2935,32 +2916,30 @@ export type CustomerUserError = DisplayableError & {
 };
 
 /** List of different delivery method types. */
-export enum DeliveryMethodType {
+export type DeliveryMethodType =
   /** Local Delivery. */
-  Local = 'LOCAL',
+  | 'LOCAL'
   /** None. */
-  None = 'NONE',
+  | 'NONE'
   /** Shipping to a Pickup Point. */
-  PickupPoint = 'PICKUP_POINT',
+  | 'PICKUP_POINT'
   /** Local Pickup. */
-  PickUp = 'PICK_UP',
+  | 'PICK_UP'
   /** Retail. */
-  Retail = 'RETAIL',
+  | 'RETAIL'
   /** Shipping. */
-  Shipping = 'SHIPPING'
-}
+  | 'SHIPPING';
 
 /** Digital wallet, such as Apple Pay, which can be used for accelerated checkouts. */
-export enum DigitalWallet {
+export type DigitalWallet =
   /** Android Pay. */
-  AndroidPay = 'ANDROID_PAY',
+  | 'ANDROID_PAY'
   /** Apple Pay. */
-  ApplePay = 'APPLE_PAY',
+  | 'APPLE_PAY'
   /** Google Pay. */
-  GooglePay = 'GOOGLE_PAY',
+  | 'GOOGLE_PAY'
   /** Shopify Pay. */
-  ShopifyPay = 'SHOPIFY_PAY'
-}
+  | 'SHOPIFY_PAY';
 
 /**
  * An amount discounting the line that has been allocated by a discount.
@@ -2991,17 +2970,13 @@ export type DiscountApplication = {
 };
 
 /** The method by which the discount's value is allocated onto its entitled lines. */
-export enum DiscountApplicationAllocationMethod {
+export type DiscountApplicationAllocationMethod =
   /** The value is spread across all entitled lines. */
-  Across = 'ACROSS',
+  | 'ACROSS'
   /** The value is applied onto every entitled line. */
-  Each = 'EACH',
-  /**
-   * The value is specifically applied onto a particular line.
-   * @deprecated Use ACROSS instead.
-   */
-  One = 'ONE'
-}
+  | 'EACH'
+  /** The value is specifically applied onto a particular line. */
+  | 'ONE';
 
 /**
  * An auto-generated type for paginating through multiple DiscountApplications.
@@ -3036,25 +3011,23 @@ export type DiscountApplicationEdge = {
  * The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
  *
  */
-export enum DiscountApplicationTargetSelection {
+export type DiscountApplicationTargetSelection =
   /** The discount is allocated onto all the lines. */
-  All = 'ALL',
+  | 'ALL'
   /** The discount is allocated onto only the lines that it's entitled for. */
-  Entitled = 'ENTITLED',
+  | 'ENTITLED'
   /** The discount is allocated onto explicitly chosen lines. */
-  Explicit = 'EXPLICIT'
-}
+  | 'EXPLICIT';
 
 /**
  * The type of line (i.e. line item or shipping line) on an order that the discount is applicable towards.
  *
  */
-export enum DiscountApplicationTargetType {
+export type DiscountApplicationTargetType =
   /** The discount applies onto line items. */
-  LineItem = 'LINE_ITEM',
+  | 'LINE_ITEM'
   /** The discount applies onto shipping lines. */
-  ShippingLine = 'SHIPPING_LINE'
-}
+  | 'SHIPPING_LINE';
 
 /**
  * Discount code applications capture the intentions of a discount code at
@@ -3140,14 +3113,13 @@ export type Filter = {
  * (https://shopify.dev/api/examples/filter-products).
  *
  */
-export enum FilterType {
+export type FilterType =
   /** A boolean value. */
-  Boolean = 'BOOLEAN',
+  | 'BOOLEAN'
   /** A list of selectable values. */
-  List = 'LIST',
+  | 'LIST'
   /** A range of prices. */
-  PriceRange = 'PRICE_RANGE'
-}
+  | 'PRICE_RANGE';
 
 /** A selectable value within a filter. */
 export type FilterValue = {
@@ -3376,14 +3348,13 @@ export type ImageConnection = {
 };
 
 /** List of supported image content types. */
-export enum ImageContentType {
+export type ImageContentType =
   /** A JPG image. */
-  Jpg = 'JPG',
+  | 'JPG'
   /** A PNG image. */
-  Png = 'PNG',
+  | 'PNG'
   /** A WEBP image. */
-  Webp = 'WEBP'
-}
+  | 'WEBP';
 
 /**
  * An auto-generated type which holds one Image and a cursor during pagination.
@@ -3448,282 +3419,281 @@ export type Language = {
 };
 
 /** ISO 639-1 language codes supported by Shopify. */
-export enum LanguageCode {
+export type LanguageCode =
   /** Afrikaans. */
-  Af = 'AF',
+  | 'AF'
   /** Akan. */
-  Ak = 'AK',
+  | 'AK'
   /** Amharic. */
-  Am = 'AM',
+  | 'AM'
   /** Arabic. */
-  Ar = 'AR',
+  | 'AR'
   /** Assamese. */
-  As = 'AS',
+  | 'AS'
   /** Azerbaijani. */
-  Az = 'AZ',
+  | 'AZ'
   /** Belarusian. */
-  Be = 'BE',
+  | 'BE'
   /** Bulgarian. */
-  Bg = 'BG',
+  | 'BG'
   /** Bambara. */
-  Bm = 'BM',
+  | 'BM'
   /** Bangla. */
-  Bn = 'BN',
+  | 'BN'
   /** Tibetan. */
-  Bo = 'BO',
+  | 'BO'
   /** Breton. */
-  Br = 'BR',
+  | 'BR'
   /** Bosnian. */
-  Bs = 'BS',
+  | 'BS'
   /** Catalan. */
-  Ca = 'CA',
+  | 'CA'
   /** Chechen. */
-  Ce = 'CE',
+  | 'CE'
   /** Czech. */
-  Cs = 'CS',
+  | 'CS'
   /** Church Slavic. */
-  Cu = 'CU',
+  | 'CU'
   /** Welsh. */
-  Cy = 'CY',
+  | 'CY'
   /** Danish. */
-  Da = 'DA',
+  | 'DA'
   /** German. */
-  De = 'DE',
+  | 'DE'
   /** Dzongkha. */
-  Dz = 'DZ',
+  | 'DZ'
   /** Ewe. */
-  Ee = 'EE',
+  | 'EE'
   /** Greek. */
-  El = 'EL',
+  | 'EL'
   /** English. */
-  En = 'EN',
+  | 'EN'
   /** Esperanto. */
-  Eo = 'EO',
+  | 'EO'
   /** Spanish. */
-  Es = 'ES',
+  | 'ES'
   /** Estonian. */
-  Et = 'ET',
+  | 'ET'
   /** Basque. */
-  Eu = 'EU',
+  | 'EU'
   /** Persian. */
-  Fa = 'FA',
+  | 'FA'
   /** Fulah. */
-  Ff = 'FF',
+  | 'FF'
   /** Finnish. */
-  Fi = 'FI',
+  | 'FI'
   /** Faroese. */
-  Fo = 'FO',
+  | 'FO'
   /** French. */
-  Fr = 'FR',
+  | 'FR'
   /** Western Frisian. */
-  Fy = 'FY',
+  | 'FY'
   /** Irish. */
-  Ga = 'GA',
+  | 'GA'
   /** Scottish Gaelic. */
-  Gd = 'GD',
+  | 'GD'
   /** Galician. */
-  Gl = 'GL',
+  | 'GL'
   /** Gujarati. */
-  Gu = 'GU',
+  | 'GU'
   /** Manx. */
-  Gv = 'GV',
+  | 'GV'
   /** Hausa. */
-  Ha = 'HA',
+  | 'HA'
   /** Hebrew. */
-  He = 'HE',
+  | 'HE'
   /** Hindi. */
-  Hi = 'HI',
+  | 'HI'
   /** Croatian. */
-  Hr = 'HR',
+  | 'HR'
   /** Hungarian. */
-  Hu = 'HU',
+  | 'HU'
   /** Armenian. */
-  Hy = 'HY',
+  | 'HY'
   /** Interlingua. */
-  Ia = 'IA',
+  | 'IA'
   /** Indonesian. */
-  Id = 'ID',
+  | 'ID'
   /** Igbo. */
-  Ig = 'IG',
+  | 'IG'
   /** Sichuan Yi. */
-  Ii = 'II',
+  | 'II'
   /** Icelandic. */
-  Is = 'IS',
+  | 'IS'
   /** Italian. */
-  It = 'IT',
+  | 'IT'
   /** Japanese. */
-  Ja = 'JA',
+  | 'JA'
   /** Javanese. */
-  Jv = 'JV',
+  | 'JV'
   /** Georgian. */
-  Ka = 'KA',
+  | 'KA'
   /** Kikuyu. */
-  Ki = 'KI',
+  | 'KI'
   /** Kazakh. */
-  Kk = 'KK',
+  | 'KK'
   /** Kalaallisut. */
-  Kl = 'KL',
+  | 'KL'
   /** Khmer. */
-  Km = 'KM',
+  | 'KM'
   /** Kannada. */
-  Kn = 'KN',
+  | 'KN'
   /** Korean. */
-  Ko = 'KO',
+  | 'KO'
   /** Kashmiri. */
-  Ks = 'KS',
+  | 'KS'
   /** Kurdish. */
-  Ku = 'KU',
+  | 'KU'
   /** Cornish. */
-  Kw = 'KW',
+  | 'KW'
   /** Kyrgyz. */
-  Ky = 'KY',
+  | 'KY'
   /** Luxembourgish. */
-  Lb = 'LB',
+  | 'LB'
   /** Ganda. */
-  Lg = 'LG',
+  | 'LG'
   /** Lingala. */
-  Ln = 'LN',
+  | 'LN'
   /** Lao. */
-  Lo = 'LO',
+  | 'LO'
   /** Lithuanian. */
-  Lt = 'LT',
+  | 'LT'
   /** Luba-Katanga. */
-  Lu = 'LU',
+  | 'LU'
   /** Latvian. */
-  Lv = 'LV',
+  | 'LV'
   /** Malagasy. */
-  Mg = 'MG',
+  | 'MG'
   /** Māori. */
-  Mi = 'MI',
+  | 'MI'
   /** Macedonian. */
-  Mk = 'MK',
+  | 'MK'
   /** Malayalam. */
-  Ml = 'ML',
+  | 'ML'
   /** Mongolian. */
-  Mn = 'MN',
+  | 'MN'
   /** Marathi. */
-  Mr = 'MR',
+  | 'MR'
   /** Malay. */
-  Ms = 'MS',
+  | 'MS'
   /** Maltese. */
-  Mt = 'MT',
+  | 'MT'
   /** Burmese. */
-  My = 'MY',
+  | 'MY'
   /** Norwegian (Bokmål). */
-  Nb = 'NB',
+  | 'NB'
   /** North Ndebele. */
-  Nd = 'ND',
+  | 'ND'
   /** Nepali. */
-  Ne = 'NE',
+  | 'NE'
   /** Dutch. */
-  Nl = 'NL',
+  | 'NL'
   /** Norwegian Nynorsk. */
-  Nn = 'NN',
+  | 'NN'
   /** Norwegian. */
-  No = 'NO',
+  | 'NO'
   /** Oromo. */
-  Om = 'OM',
+  | 'OM'
   /** Odia. */
-  Or = 'OR',
+  | 'OR'
   /** Ossetic. */
-  Os = 'OS',
+  | 'OS'
   /** Punjabi. */
-  Pa = 'PA',
+  | 'PA'
   /** Polish. */
-  Pl = 'PL',
+  | 'PL'
   /** Pashto. */
-  Ps = 'PS',
+  | 'PS'
   /** Portuguese. */
-  Pt = 'PT',
+  | 'PT'
   /** Portuguese (Brazil). */
-  PtBr = 'PT_BR',
+  | 'PT_BR'
   /** Portuguese (Portugal). */
-  PtPt = 'PT_PT',
+  | 'PT_PT'
   /** Quechua. */
-  Qu = 'QU',
+  | 'QU'
   /** Romansh. */
-  Rm = 'RM',
+  | 'RM'
   /** Rundi. */
-  Rn = 'RN',
+  | 'RN'
   /** Romanian. */
-  Ro = 'RO',
+  | 'RO'
   /** Russian. */
-  Ru = 'RU',
+  | 'RU'
   /** Kinyarwanda. */
-  Rw = 'RW',
+  | 'RW'
   /** Sindhi. */
-  Sd = 'SD',
+  | 'SD'
   /** Northern Sami. */
-  Se = 'SE',
+  | 'SE'
   /** Sango. */
-  Sg = 'SG',
+  | 'SG'
   /** Sinhala. */
-  Si = 'SI',
+  | 'SI'
   /** Slovak. */
-  Sk = 'SK',
+  | 'SK'
   /** Slovenian. */
-  Sl = 'SL',
+  | 'SL'
   /** Shona. */
-  Sn = 'SN',
+  | 'SN'
   /** Somali. */
-  So = 'SO',
+  | 'SO'
   /** Albanian. */
-  Sq = 'SQ',
+  | 'SQ'
   /** Serbian. */
-  Sr = 'SR',
+  | 'SR'
   /** Sundanese. */
-  Su = 'SU',
+  | 'SU'
   /** Swedish. */
-  Sv = 'SV',
+  | 'SV'
   /** Swahili. */
-  Sw = 'SW',
+  | 'SW'
   /** Tamil. */
-  Ta = 'TA',
+  | 'TA'
   /** Telugu. */
-  Te = 'TE',
+  | 'TE'
   /** Tajik. */
-  Tg = 'TG',
+  | 'TG'
   /** Thai. */
-  Th = 'TH',
+  | 'TH'
   /** Tigrinya. */
-  Ti = 'TI',
+  | 'TI'
   /** Turkmen. */
-  Tk = 'TK',
+  | 'TK'
   /** Tongan. */
-  To = 'TO',
+  | 'TO'
   /** Turkish. */
-  Tr = 'TR',
+  | 'TR'
   /** Tatar. */
-  Tt = 'TT',
+  | 'TT'
   /** Uyghur. */
-  Ug = 'UG',
+  | 'UG'
   /** Ukrainian. */
-  Uk = 'UK',
+  | 'UK'
   /** Urdu. */
-  Ur = 'UR',
+  | 'UR'
   /** Uzbek. */
-  Uz = 'UZ',
+  | 'UZ'
   /** Vietnamese. */
-  Vi = 'VI',
+  | 'VI'
   /** Volapük. */
-  Vo = 'VO',
+  | 'VO'
   /** Wolof. */
-  Wo = 'WO',
+  | 'WO'
   /** Xhosa. */
-  Xh = 'XH',
+  | 'XH'
   /** Yiddish. */
-  Yi = 'YI',
+  | 'YI'
   /** Yoruba. */
-  Yo = 'YO',
+  | 'YO'
   /** Chinese. */
-  Zh = 'ZH',
+  | 'ZH'
   /** Chinese (Simplified). */
-  ZhCn = 'ZH_CN',
+  | 'ZH_CN'
   /** Chinese (Traditional). */
-  ZhTw = 'ZH_TW',
+  | 'ZH_TW'
   /** Zulu. */
-  Zu = 'ZU'
-}
+  | 'ZU';
 
 /** Information about the localized experiences configured for the shop. */
 export type Localization = {
@@ -3811,16 +3781,15 @@ export type LocationEdge = {
 };
 
 /** The set of valid sort keys for the Location query. */
-export enum LocationSortKeys {
+export type LocationSortKeys =
   /** Sort by the `city` value. */
-  City = 'CITY',
+  | 'CITY'
   /** Sort by the `distance` value. */
-  Distance = 'DISTANCE',
+  | 'DISTANCE'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `name` value. */
-  Name = 'NAME'
-}
+  | 'NAME';
 
 /** Represents a mailing address for customers and shipping. */
 export type MailingAddress = Node & {
@@ -4020,16 +3989,15 @@ export type MediaConnection = {
 };
 
 /** The possible content types for a media object. */
-export enum MediaContentType {
+export type MediaContentType =
   /** An externally hosted video. */
-  ExternalVideo = 'EXTERNAL_VIDEO',
+  | 'EXTERNAL_VIDEO'
   /** A Shopify hosted image. */
-  Image = 'IMAGE',
+  | 'IMAGE'
   /** A 3d model. */
-  Model_3D = 'MODEL_3D',
+  | 'MODEL_3D'
   /** A Shopify hosted video. */
-  Video = 'VIDEO'
-}
+  | 'VIDEO';
 
 /**
  * An auto-generated type which holds one Media and a cursor during pagination.
@@ -4044,12 +4012,11 @@ export type MediaEdge = {
 };
 
 /** Host for a Media Resource. */
-export enum MediaHost {
+export type MediaHost =
   /** Host for Vimeo embedded videos. */
-  Vimeo = 'VIMEO',
+  | 'VIMEO'
   /** Host for YouTube embedded videos. */
-  Youtube = 'YOUTUBE'
-}
+  | 'YOUTUBE';
 
 /** Represents a Shopify hosted image. */
 export type MediaImage = Media & Node & {
@@ -4107,30 +4074,29 @@ export type MenuItem = Node & {
 };
 
 /** A menu item type. */
-export enum MenuItemType {
+export type MenuItemType =
   /** An article link. */
-  Article = 'ARTICLE',
+  | 'ARTICLE'
   /** A blog link. */
-  Blog = 'BLOG',
+  | 'BLOG'
   /** A catalog link. */
-  Catalog = 'CATALOG',
+  | 'CATALOG'
   /** A collection link. */
-  Collection = 'COLLECTION',
+  | 'COLLECTION'
   /** A collection link. */
-  Collections = 'COLLECTIONS',
+  | 'COLLECTIONS'
   /** A frontpage link. */
-  Frontpage = 'FRONTPAGE',
+  | 'FRONTPAGE'
   /** An http link. */
-  Http = 'HTTP',
+  | 'HTTP'
   /** A page link. */
-  Page = 'PAGE',
+  | 'PAGE'
   /** A product link. */
-  Product = 'PRODUCT',
+  | 'PRODUCT'
   /** A search link. */
-  Search = 'SEARCH',
+  | 'SEARCH'
   /** A shop policy link. */
-  ShopPolicy = 'SHOP_POLICY'
-}
+  | 'SHOP_POLICY';
 
 /** The merchandise to be purchased at checkout. */
 export type Merchandise = ProductVariant;
@@ -4809,18 +4775,17 @@ export type OrderSuccessfulFulfillmentsArgs = {
 };
 
 /** Represents the reason for the order's cancellation. */
-export enum OrderCancelReason {
+export type OrderCancelReason =
   /** The customer wanted to cancel the order. */
-  Customer = 'CUSTOMER',
+  | 'CUSTOMER'
   /** Payment was declined. */
-  Declined = 'DECLINED',
+  | 'DECLINED'
   /** The order was fraudulent. */
-  Fraud = 'FRAUD',
+  | 'FRAUD'
   /** There was insufficient inventory. */
-  Inventory = 'INVENTORY',
+  | 'INVENTORY'
   /** The order was canceled for an unlisted reason. */
-  Other = 'OTHER'
-}
+  | 'OTHER';
 
 /**
  * An auto-generated type for paginating through multiple Orders.
@@ -4849,44 +4814,42 @@ export type OrderEdge = {
 };
 
 /** Represents the order's current financial status. */
-export enum OrderFinancialStatus {
+export type OrderFinancialStatus =
   /** Displayed as **Authorized**. */
-  Authorized = 'AUTHORIZED',
+  | 'AUTHORIZED'
   /** Displayed as **Paid**. */
-  Paid = 'PAID',
+  | 'PAID'
   /** Displayed as **Partially paid**. */
-  PartiallyPaid = 'PARTIALLY_PAID',
+  | 'PARTIALLY_PAID'
   /** Displayed as **Partially refunded**. */
-  PartiallyRefunded = 'PARTIALLY_REFUNDED',
+  | 'PARTIALLY_REFUNDED'
   /** Displayed as **Pending**. */
-  Pending = 'PENDING',
+  | 'PENDING'
   /** Displayed as **Refunded**. */
-  Refunded = 'REFUNDED',
+  | 'REFUNDED'
   /** Displayed as **Voided**. */
-  Voided = 'VOIDED'
-}
+  | 'VOIDED';
 
 /** Represents the order's aggregated fulfillment status for display purposes. */
-export enum OrderFulfillmentStatus {
+export type OrderFulfillmentStatus =
   /** Displayed as **Fulfilled**. All of the items in the order have been fulfilled. */
-  Fulfilled = 'FULFILLED',
+  | 'FULFILLED'
   /** Displayed as **In progress**. Some of the items in the order have been fulfilled, or a request for fulfillment has been sent to the fulfillment service. */
-  InProgress = 'IN_PROGRESS',
+  | 'IN_PROGRESS'
   /** Displayed as **On hold**. All of the unfulfilled items in this order are on hold. */
-  OnHold = 'ON_HOLD',
+  | 'ON_HOLD'
   /** Displayed as **Open**. None of the items in the order have been fulfilled. Replaced by "UNFULFILLED" status. */
-  Open = 'OPEN',
+  | 'OPEN'
   /** Displayed as **Partially fulfilled**. Some of the items in the order have been fulfilled. */
-  PartiallyFulfilled = 'PARTIALLY_FULFILLED',
+  | 'PARTIALLY_FULFILLED'
   /** Displayed as **Pending fulfillment**. A request for fulfillment of some items awaits a response from the fulfillment service. Replaced by "IN_PROGRESS" status. */
-  PendingFulfillment = 'PENDING_FULFILLMENT',
+  | 'PENDING_FULFILLMENT'
   /** Displayed as **Restocked**. All of the items in the order have been restocked. Replaced by "UNFULFILLED" status. */
-  Restocked = 'RESTOCKED',
+  | 'RESTOCKED'
   /** Displayed as **Scheduled**. All of the unfulfilled items in this order are scheduled for fulfillment at later time. */
-  Scheduled = 'SCHEDULED',
+  | 'SCHEDULED'
   /** Displayed as **Unfulfilled**. None of the items in the order have been fulfilled. */
-  Unfulfilled = 'UNFULFILLED'
-}
+  | 'UNFULFILLED';
 
 /** Represents a single line in an order. There is one line item for each distinct product variant. */
 export type OrderLineItem = {
@@ -4936,20 +4899,19 @@ export type OrderLineItemEdge = {
 };
 
 /** The set of valid sort keys for the Order query. */
-export enum OrderSortKeys {
+export type OrderSortKeys =
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `processed_at` value. */
-  ProcessedAt = 'PROCESSED_AT',
+  | 'PROCESSED_AT'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `total_price` value. */
-  TotalPrice = 'TOTAL_PRICE'
-}
+  | 'TOTAL_PRICE';
 
 /** Shopify merchants can create pages to hold static HTML content. Each Page object represents a custom page on the online store. */
 export type Page = HasMetafields & Node & OnlineStorePublishable & {
@@ -5038,20 +5000,19 @@ export type PageInfo = {
 };
 
 /** The set of valid sort keys for the Page query. */
-export enum PageSortKeys {
+export type PageSortKeys =
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE',
+  | 'TITLE'
   /** Sort by the `updated_at` value. */
-  UpdatedAt = 'UPDATED_AT'
-}
+  | 'UPDATED_AT';
 
 /** A payment applied to a checkout. */
 export type Payment = Node & {
@@ -5110,18 +5071,17 @@ export type PaymentSettings = {
 };
 
 /** The valid values for the types of payment token. */
-export enum PaymentTokenType {
+export type PaymentTokenType =
   /** Apple Pay token type. */
-  ApplePay = 'APPLE_PAY',
+  | 'APPLE_PAY'
   /** Google Pay token type. */
-  GooglePay = 'GOOGLE_PAY',
+  | 'GOOGLE_PAY'
   /** Shopify Pay token type. */
-  ShopifyPay = 'SHOPIFY_PAY',
+  | 'SHOPIFY_PAY'
   /** Stripe token type. */
-  StripeVaultToken = 'STRIPE_VAULT_TOKEN',
+  | 'STRIPE_VAULT_TOKEN'
   /** Vault payment token type. */
-  Vault = 'VAULT'
-}
+  | 'VAULT';
 
 /** A filter used to view a subset of products in a collection matching a specific price range. */
 export type PriceRangeFilter = {
@@ -5347,28 +5307,27 @@ export type ProductVariantsArgs = {
 };
 
 /** The set of valid sort keys for the ProductCollection query. */
-export enum ProductCollectionSortKeys {
+export type ProductCollectionSortKeys =
   /** Sort by the `best-selling` value. */
-  BestSelling = 'BEST_SELLING',
+  | 'BEST_SELLING'
   /** Sort by the `collection-default` value. */
-  CollectionDefault = 'COLLECTION_DEFAULT',
+  | 'COLLECTION_DEFAULT'
   /** Sort by the `created` value. */
-  Created = 'CREATED',
+  | 'CREATED'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `manual` value. */
-  Manual = 'MANUAL',
+  | 'MANUAL'
   /** Sort by the `price` value. */
-  Price = 'PRICE',
+  | 'PRICE'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE'
-}
+  | 'TITLE';
 
 /**
  * An auto-generated type for paginating through multiple Products.
@@ -5417,34 +5376,32 @@ export type ProductFilter = {
 };
 
 /** The set of valid sort keys for the ProductImage query. */
-export enum ProductImageSortKeys {
+export type ProductImageSortKeys =
   /** Sort by the `created_at` value. */
-  CreatedAt = 'CREATED_AT',
+  | 'CREATED_AT'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `position` value. */
-  Position = 'POSITION',
+  | 'POSITION'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE'
-}
+  | 'RELEVANCE';
 
 /** The set of valid sort keys for the ProductMedia query. */
-export enum ProductMediaSortKeys {
+export type ProductMediaSortKeys =
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `position` value. */
-  Position = 'POSITION',
+  | 'POSITION'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE'
-}
+  | 'RELEVANCE';
 
 /**
  * Product property names like "Size", "Color", and "Material" that the customers can select.
@@ -5472,30 +5429,29 @@ export type ProductPriceRange = {
 };
 
 /** The set of valid sort keys for the Product query. */
-export enum ProductSortKeys {
+export type ProductSortKeys =
   /** Sort by the `best_selling` value. */
-  BestSelling = 'BEST_SELLING',
+  | 'BEST_SELLING'
   /** Sort by the `created_at` value. */
-  CreatedAt = 'CREATED_AT',
+  | 'CREATED_AT'
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `price` value. */
-  Price = 'PRICE',
+  | 'PRICE'
   /** Sort by the `product_type` value. */
-  ProductType = 'PRODUCT_TYPE',
+  | 'PRODUCT_TYPE'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `title` value. */
-  Title = 'TITLE',
+  | 'TITLE'
   /** Sort by the `updated_at` value. */
-  UpdatedAt = 'UPDATED_AT',
+  | 'UPDATED_AT'
   /** Sort by the `vendor` value. */
-  Vendor = 'VENDOR'
-}
+  | 'VENDOR';
 
 /** A product variant represents a different version of a product, such as differing sizes or differing colors. */
 export type ProductVariant = HasMetafields & Node & {
@@ -5620,22 +5576,21 @@ export type ProductVariantEdge = {
 };
 
 /** The set of valid sort keys for the ProductVariant query. */
-export enum ProductVariantSortKeys {
+export type ProductVariantSortKeys =
   /** Sort by the `id` value. */
-  Id = 'ID',
+  | 'ID'
   /** Sort by the `position` value. */
-  Position = 'POSITION',
+  | 'POSITION'
   /**
    * Sort by relevance to the search terms when the `query` parameter is specified on the connection.
    * Don't use this sort key when no search query is specified.
    *
    */
-  Relevance = 'RELEVANCE',
+  | 'RELEVANCE'
   /** Sort by the `sku` value. */
-  Sku = 'SKU',
+  | 'SKU'
   /** Sort by the `title` value. */
-  Title = 'TITLE'
-}
+  | 'TITLE';
 
 /** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
 export type QueryRoot = {
@@ -6039,12 +5994,11 @@ export type SellingPlanCheckoutChargePercentageValue = {
 };
 
 /** The checkout charge when the full amount isn't charged at checkout. */
-export enum SellingPlanCheckoutChargeType {
+export type SellingPlanCheckoutChargeType =
   /** The checkout charge is a percentage of the product or variant price. */
-  Percentage = 'PERCENTAGE',
+  | 'PERCENTAGE'
   /** The checkout charge is a fixed price amount. */
-  Price = 'PRICE'
-}
+  | 'PRICE';
 
 /** The portion of the price to be charged at checkout. */
 export type SellingPlanCheckoutChargeValue = MoneyV2 | SellingPlanCheckoutChargePercentageValue;
@@ -6390,34 +6344,32 @@ export type Transaction = {
 };
 
 /** The different kinds of order transactions. */
-export enum TransactionKind {
+export type TransactionKind =
   /**
    * An amount reserved against the cardholder's funding source.
    * Money does not change hands until the authorization is captured.
    *
    */
-  Authorization = 'AUTHORIZATION',
+  | 'AUTHORIZATION'
   /** A transfer of the money that was reserved during the authorization stage. */
-  Capture = 'CAPTURE',
+  | 'CAPTURE'
   /** Money returned to the customer when they have paid too much. */
-  Change = 'CHANGE',
+  | 'CHANGE'
   /** An authorization for a payment taken with an EMV credit card reader. */
-  EmvAuthorization = 'EMV_AUTHORIZATION',
+  | 'EMV_AUTHORIZATION'
   /** An authorization and capture performed together in a single step. */
-  Sale = 'SALE'
-}
+  | 'SALE';
 
 /** Transaction statuses describe the status of a transaction. */
-export enum TransactionStatus {
+export type TransactionStatus =
   /** There was an error while processing the transaction. */
-  Error = 'ERROR',
+  | 'ERROR'
   /** The transaction failed. */
-  Failure = 'FAILURE',
+  | 'FAILURE'
   /** The transaction is pending. */
-  Pending = 'PENDING',
+  | 'PENDING'
   /** The transaction succeeded. */
-  Success = 'SUCCESS'
-}
+  | 'SUCCESS';
 
 /**
  * The measurement used to calculate a unit price for a product variant (e.g. $9.99 / 100ml).
@@ -6438,50 +6390,47 @@ export type UnitPriceMeasurement = {
 };
 
 /** The accepted types of unit of measurement. */
-export enum UnitPriceMeasurementMeasuredType {
+export type UnitPriceMeasurementMeasuredType =
   /** Unit of measurements representing areas. */
-  Area = 'AREA',
+  | 'AREA'
   /** Unit of measurements representing lengths. */
-  Length = 'LENGTH',
+  | 'LENGTH'
   /** Unit of measurements representing volumes. */
-  Volume = 'VOLUME',
+  | 'VOLUME'
   /** Unit of measurements representing weights. */
-  Weight = 'WEIGHT'
-}
+  | 'WEIGHT';
 
 /** The valid units of measurement for a unit price measurement. */
-export enum UnitPriceMeasurementMeasuredUnit {
+export type UnitPriceMeasurementMeasuredUnit =
   /** 100 centiliters equals 1 liter. */
-  Cl = 'CL',
+  | 'CL'
   /** 100 centimeters equals 1 meter. */
-  Cm = 'CM',
+  | 'CM'
   /** Metric system unit of weight. */
-  G = 'G',
+  | 'G'
   /** 1 kilogram equals 1000 grams. */
-  Kg = 'KG',
+  | 'KG'
   /** Metric system unit of volume. */
-  L = 'L',
+  | 'L'
   /** Metric system unit of length. */
-  M = 'M',
+  | 'M'
   /** Metric system unit of area. */
-  M2 = 'M2',
+  | 'M2'
   /** 1 cubic meter equals 1000 liters. */
-  M3 = 'M3',
+  | 'M3'
   /** 1000 milligrams equals 1 gram. */
-  Mg = 'MG',
+  | 'MG'
   /** 1000 milliliters equals 1 liter. */
-  Ml = 'ML',
+  | 'ML'
   /** 1000 millimeters equals 1 meter. */
-  Mm = 'MM'
-}
+  | 'MM';
 
 /** Systems of weights and measures. */
-export enum UnitSystem {
+export type UnitSystem =
   /** Imperial system of weights and measures. */
-  ImperialSystem = 'IMPERIAL_SYSTEM',
+  | 'IMPERIAL_SYSTEM'
   /** Metric system of weights and measures. */
-  MetricSystem = 'METRIC_SYSTEM'
-}
+  | 'METRIC_SYSTEM';
 
 /** A redirect on the online store. */
 export type UrlRedirect = Node & {
@@ -6568,16 +6517,15 @@ export type VideoSource = {
 };
 
 /** Units of measurement for weight. */
-export enum WeightUnit {
+export type WeightUnit =
   /** Metric system unit of mass. */
-  Grams = 'GRAMS',
+  | 'GRAMS'
   /** 1 kilogram equals 1000 grams. */
-  Kilograms = 'KILOGRAMS',
+  | 'KILOGRAMS'
   /** Imperial system unit of mass. */
-  Ounces = 'OUNCES',
+  | 'OUNCES'
   /** 1 pound equals 16 ounces. */
-  Pounds = 'POUNDS'
-}
+  | 'POUNDS';
 
 export type CartBuyerIdentity_BuyerIdentityFragment = { __typename?: 'CartBuyerIdentity', countryCode?: CountryCode | null, email?: string | null, phone?: string | null, customer?: { __typename?: 'Customer', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayName: string } | null };
 

--- a/packages/shopify-cart/src/types/shopify.type.ts
+++ b/packages/shopify-cart/src/types/shopify.type.ts
@@ -6607,6 +6607,7 @@ export type CartAttributesUpdateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6618,6 +6619,7 @@ export type CartBuyerIdentityUpdateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6628,6 +6630,7 @@ export type CartCreateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6639,6 +6642,7 @@ export type CartDiscountCodesUpdateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6650,6 +6654,7 @@ export type CartLineAddMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6661,6 +6666,7 @@ export type CartLineRemoveMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6672,6 +6678,7 @@ export type CartLineUpdateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6683,6 +6690,7 @@ export type CartNoteUpdateMutationVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 
@@ -6693,6 +6701,7 @@ export type CartQueryVariables = Exact<{
   numCartLines?: InputMaybe<Scalars['Int']>;
   afterCursor?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<CountryCode>;
+  language?: InputMaybe<LanguageCode>;
 }>;
 
 

--- a/packages/shopify-cart/src/utils/depaginateLines.spec.ts
+++ b/packages/shopify-cart/src/utils/depaginateLines.spec.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import depaginateLines from './depaginateLines';
 import fetchClient from 'cross-fetch';
-import { Cart_CartFragment } from '../types/shopify.type';
+import {
+  Cart_CartFragment,
+  CountryCode,
+  LanguageCode
+} from '../types/shopify.type';
 import { createGqlClient } from '../utils';
 import { mockJsonResponse } from '../../__tests__/utils';
 import {
@@ -17,6 +21,8 @@ jest.mock('cross-fetch');
 
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
+const defaultLanguage = LanguageCode.En;
+const defaultCountry = CountryCode.Zz;
 
 describe('depaginate lines', () => {
   afterEach(() => {
@@ -30,7 +36,9 @@ describe('depaginate lines', () => {
 
     await depaginateLines({
       cart: cartWithPaginatedLines,
-      gqlClient
+      gqlClient,
+      language: defaultLanguage,
+      country: defaultCountry
     });
     expect(fetchClient).toHaveBeenCalledTimes(1);
     expect(fetchClient).toHaveBeenCalledWith(graphqlEndpoint, {
@@ -40,7 +48,9 @@ describe('depaginate lines', () => {
         query: queries.CART(),
         variables: {
           id: cartWithPaginatedLines.id,
-          afterCursor: cartWithPaginatedLines.lines.pageInfo.endCursor
+          afterCursor: cartWithPaginatedLines.lines.pageInfo.endCursor,
+          language: defaultLanguage,
+          country: defaultCountry
         }
       })
     });
@@ -60,12 +70,21 @@ describe('depaginate lines', () => {
 
     await depaginateLines({
       cart: cartWithPaginatedLines,
-      gqlClient
+      gqlClient,
+      language: defaultLanguage,
+      country: defaultCountry
     });
     expect(fetchClient).toHaveBeenCalledTimes(2);
   });
   it('returns null if cart param is falsy', async () => {
-    expect(await depaginateLines({ cart: undefined, gqlClient })).toBe(null);
+    expect(
+      await depaginateLines({
+        cart: undefined,
+        gqlClient,
+        language: defaultLanguage,
+        country: defaultCountry
+      })
+    ).toBe(null);
   });
   it('throws an error if there are problems with the request', async () => {
     const networkErrorMessage = 'Network error!';
@@ -75,7 +94,12 @@ describe('depaginate lines', () => {
 
     expect.assertions(1);
     await expect(
-      depaginateLines({ gqlClient, cart: cartWithPaginatedLines })
+      depaginateLines({
+        gqlClient,
+        cart: cartWithPaginatedLines,
+        language: defaultLanguage,
+        country: defaultCountry
+      })
     ).rejects.toThrow(networkErrorMessage);
   });
 });

--- a/packages/shopify-cart/src/utils/depaginateLines.spec.ts
+++ b/packages/shopify-cart/src/utils/depaginateLines.spec.ts
@@ -21,8 +21,8 @@ jest.mock('cross-fetch');
 
 const gqlClient = createGqlClient({ ...clientSettings, fetchClient });
 const mockedFetchClient = jest.mocked(fetchClient, true);
-const defaultLanguage = LanguageCode.En;
-const defaultCountry = CountryCode.Zz;
+const defaultLanguage: LanguageCode = 'EN';
+const defaultCountry: CountryCode = 'ZZ';
 
 describe('depaginate lines', () => {
   afterEach(() => {

--- a/packages/shopify-cart/src/utils/depaginateLines.ts
+++ b/packages/shopify-cart/src/utils/depaginateLines.ts
@@ -1,17 +1,26 @@
 import queries from '../graphql/queries';
-import { QueryRootCartArgs, Cart_CartFragment } from '../types/shopify.type';
+import {
+  QueryRootCartArgs,
+  Cart_CartFragment,
+  LanguageCode,
+  CountryCode
+} from '../types/shopify.type';
 import type { CartFragments } from '../graphql/fragments/cart';
 import type { GqlClient } from '../cart-client.types';
 import type { ShopifyCartResponse } from '../client/actions/cart';
 
 export interface PaginateCartLinesQueryArgs extends QueryRootCartArgs {
   afterCursor: string;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 export interface DepaginateLinesParams {
   cart: Cart_CartFragment | undefined | null;
   customFragments?: CartFragments;
   gqlClient: GqlClient;
+  language: LanguageCode;
+  country: CountryCode;
 }
 
 /**
@@ -23,7 +32,9 @@ export interface DepaginateLinesParams {
 export default async function depaginateLines({
   cart,
   customFragments,
-  gqlClient
+  gqlClient,
+  language,
+  country
 }: DepaginateLinesParams): Promise<Cart_CartFragment | null> {
   try {
     if (cart) {
@@ -36,7 +47,12 @@ export default async function depaginateLines({
           ShopifyCartResponse
         >({
           query: queries.CART(customFragments),
-          variables: { id: cart.id, afterCursor: pageInfo.endCursor }
+          variables: {
+            id: cart.id,
+            afterCursor: pageInfo.endCursor,
+            language,
+            country
+          }
         }).catch((err) => {
           throw new Error(err);
         });


### PR DESCRIPTION
<!-- - feat: adds settings for setting language and country in queries
- docs: add language/country settings to README
- docs: adds changeset for lang/country options -->

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-7060](https://nacelle.atlassian.net/browse/ENG-7060) - Adds parameters to `cartCreate` for setting the `language` and `country` in all Cart queries and mutations. This allows the cart to support internationalized stores. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Adds `language` and `country` params to the `createCart` function that correspond to the Shopify GQL [Language Code][shopify-cart-language-code] and [Country Code][shopify-cart-country-code] enums. If not provided, the language code defaults to `EN` and the country code corresponds to `ZZ`. Note that prior to this PR, no language code was used and all queries used `ZZ` for the country code.
2. Updates All Shopify Enums to be types - this makes them easily accessible as strings, which makes a better public API for users. 
3. Updates every query/mutation GQL to use accept a `language` variable parameter, and to use the `language` in the `inContext` directive.
4. Passes the `language` & `country` variables to every action, and uses them in the queries. Updates the types passed to the `GQLClient` in each action to use the `<QueryName>Variables` type so that `language` and `country`  are expected. This should allow us to update query variables without needing to change types in the future too. 
5. Adds `language` and `country` to the args/responses for all tests.
6. Adds a test for passing a non-default language to `createCart` & a test passing a non-default `country` to `createCart`
7. Updates the `README` to document the 2 new parameters to `createCart`. 
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## How to Test

1. Clone this branch `mdarrik/shopify-cart/ENG-7060-add-params-for-setting-and-language` (or `gh pr checkout #` if using the gh cli)
2. Run `npm run test:ci` - all tests should passed
3. Run `npm run build` - build should complete successfully
4. Use `npm link` to test a local project featuring shopify cart. Outgoing queries should include the `language` and `country` specified, or default to `EN` and `ZZ` respectively.


<!--Links -->
[shopify-cart-language-code]: https://shopify.dev/api/storefront/2022-07/enums/LanguageCode
[shopify-cart-country-code]: https://shopify.dev/api/storefront/2022-07/enums/CountryCode