### PR TITLE
chore:  clarify line params docs

### DIFF
--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -231,6 +231,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
   cartId: 'gid://shopify/Cart/112233',
   lines: [
     {
+      cartLineId: 'gid://shopify/CartLine/e543caf96fa645b54d07ab2035ef9dba?cart=a7aad2fb1e6611422c946f6827710550'
       nacelleEntryId: '<nacelle-entry-id>',
       quantity: 3
     }

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -149,7 +149,7 @@ const { cart, userErrors, errors } = await cartClient.cartBuyerIdentityUpdate({
 
 _Creates a new Shopify cart._
 
-**Accepts**: params - an optional object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). To initialize an empty cart, exclude all parameters. For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
+**Accepts**: params - an optional object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). To initialize an empty cart, exclude all parameters. For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input].Note that the `lines` parameter differs from Shopify [`CartLineInput`][shopify-cart-line-input] in that it expects the variant's `nacelleEntryId` instead of a Shopify `merchandiseId`.
 
 ##### Example
 
@@ -185,7 +185,7 @@ const { cart, userErrors, errors } = await cartClient.cartDiscountCodesUpdate({
 
 _Adds lines to an existing Shopify cart._
 
-**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to add. For more information on the cart `lines`, checkout Shopify's [`CartLineInput`][shopify-cart-line-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
+**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to add. For more information on the cart `lines`, checkout Shopify's [`CartLineInput`][shopify-cart-line-input]. Note that the `lines` parameter differs from Shopify [`CartLineInput`][shopify-cart-line-input] in that it expects the variant's `nacelleEntryId` instead of a Shopify `merchandiseId`.
 
 ##### Example
 
@@ -222,7 +222,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesRemove({
 
 _Updates lines on an existing Shopify cart._
 
-**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to update. For more information on the cart `lines`, checkout Shopify's [`CartLineUpdateInput`][shopify-cart-line-update-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
+**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to update. For more information on the cart `lines`, checkout Shopify's [`CartLineUpdateInput`][shopify-cart-line-update-input]. Note that the `lines` parameter differs from Shopify [`CartLineInput`][shopify-cart-line-input] in that it expects the variant's `nacelleEntryId` instead of a Shopify `merchandiseId`.
 
 ##### Example
 

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -157,7 +157,7 @@ _Creates a new Shopify cart._
 const { cart, userErrors, errors } = await cartClient.cartCreate({
   lines: [
     {
-      merchandiseId: 'gid://shopify/ProductVariant/33894120718471',
+      nacelleEntryId: '<nacelle-entry-id>',
       quantity: 1
     }
   ],
@@ -194,7 +194,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
   cartId: 'gid://shopify/Cart/112233',
   lines: [
     {
-      merchandiseId: 'gid://shopify/ProductVariant/33894120718471',
+      nacelleEntryId: '<nacelle-entry-id>',
       quantity: 1
     }
   ]
@@ -231,7 +231,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
   cartId: 'gid://shopify/Cart/112233',
   lines: [
     {
-      id: 'gid://shopify/CartLine/e543caf96fa645b54d07ab2035ef9dba?cart=a7aad2fb1e6611422c946f6827710550',
+      nacelleEntryId: '<nacelle-entry-id>',
       quantity: 3
     }
   ]

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -231,7 +231,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesUpdate({
   cartId: 'gid://shopify/Cart/112233',
   lines: [
     {
-      cartLineId: 'gid://shopify/CartLine/e543caf96fa645b54d07ab2035ef9dba?cart=a7aad2fb1e6611422c946f6827710550'
+      id: 'gid://shopify/CartLine/e543caf96fa645b54d07ab2035ef9dba?cart=a7aad2fb1e6611422c946f6827710550'
       nacelleEntryId: '<nacelle-entry-id>',
       quantity: 3
     }

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -149,7 +149,7 @@ const { cart, userErrors, errors } = await cartClient.cartBuyerIdentityUpdate({
 
 _Creates a new Shopify cart._
 
-**Accepts**: params - an optional object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). To initialize an empty cart, exclude all parameters. For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input]
+**Accepts**: params - an optional object containing the following optional values: `attributes` (`array`), `buyerIdentity` (`object`), `discountCodes` (`array`), `lines` (`array`), `note` (`string`). To initialize an empty cart, exclude all parameters. For more information on the cart optional values, checkout Shopify's [`CartInput`][shopify-cart-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
 
 ##### Example
 
@@ -185,7 +185,7 @@ const { cart, userErrors, errors } = await cartClient.cartDiscountCodesUpdate({
 
 _Adds lines to an existing Shopify cart._
 
-**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to add. For more information on the cart `lines`, checkout Shopify's [`CartLineInput`][shopify-cart-line-input]
+**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to add. For more information on the cart `lines`, checkout Shopify's [`CartLineInput`][shopify-cart-line-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
 
 ##### Example
 
@@ -222,12 +222,12 @@ const { cart, userErrors, errors } = await cartClient.cartLinesRemove({
 
 _Updates lines on an existing Shopify cart._
 
-**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to update. For more information on the cart `lines`, checkout Shopify's [`CartLineUpdateInput`][shopify-cart-line-update-input]
+**Accepts**: params - an object containing the `cartId` (`string`) of interest, and the `lines` (`array`) to update. For more information on the cart `lines`, checkout Shopify's [`CartLineUpdateInput`][shopify-cart-line-update-input]. Note that our lines parameter accepts a different value than Shopify's by accepting `nacelleEntryId`.
 
 ##### Example
 
 ```js
-const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
+const { cart, userErrors, errors } = await cartClient.cartLinesUpdate({
   cartId: 'gid://shopify/Cart/112233',
   lines: [
     {


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes [ENG-7057](https://nacelle.atlassian.net/browse/ENG-7057) <!-- link to Jira or Github issue if one exists -->

### WHAT is this pull request doing?

- clarify line params docs for `cartCreate`, `cartLinesAdd`, and `cartLinesUpdate`

### Note

Should we update the ways `cartLinesRemove` works as well? It is making use of the Shopify cart line ID at the moment.

