### PR TITLE
chore: Configure Changesets to publish Shopify Cart Beta

### DIFF
--- a/.changeset/cold-oranges-study.md
+++ b/.changeset/cold-oranges-study.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/shopify-cart': minor
+'@nacelle/shopify-cart': major
 ---
 
 feat (breaking): Adds options for language and country codes to cart create.

--- a/.changeset/gorgeous-gifts-sip.md
+++ b/.changeset/gorgeous-gifts-sip.md
@@ -1,5 +1,5 @@
 ---
-"@nacelle/nacelle-js": patch
+"@nacelle/shopify-cart": patch
 ---
 
 docs: support/release schedule

--- a/.changeset/lucky-monkeys-glow.md
+++ b/.changeset/lucky-monkeys-glow.md
@@ -1,5 +1,5 @@
 ---
-"@nacelle/nacelle-js": patch
+"@nacelle/shopify-cart": patch
 ---
 
 Allow `cartCreate` mutation to accept no parameters

--- a/.changeset/old-monkeys-reply.md
+++ b/.changeset/old-monkeys-reply.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/shopify-cart': minor
+'@nacelle/shopify-cart': major
 ---
 
 feat(breaking!): allows for nacelleEntryId's to be passed into cart methods. 

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,24 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "contentful-rich-text": "1.0.5",
+    "flash-sale": "0.1.1",
+    "next-preview": "0.1.3",
+    "nuxt-2-composition-api": "0.0.18",
+    "@nacelle/nuxt-3-starter-example": "0.0.1",
+    "shopify-accounts": "0.1.1",
+    "svelte-starter": "0.0.2",
+    "@nacelle/gatsby-source-nacelle": "9.0.0",
+    "@nacelle/sanity-plugin-nacelle-input": "0.1.0",
+    "@nacelle/shopify-cart": "0.2.1",
+    "@nacelle/shopify-checkout": "0.1.0",
+    "@nacelle/vue": "0.0.16",
+    "nacelle-next-reference-store": "0.1.3",
+    "nuxt-reference-store": "1.0.5",
+    "gatsby-starter": "0.2.1",
+    "next-starter": "0.1.3",
+    "nuxt-starter": "1.0.7"
+  },
+  "changesets": []
+}

--- a/.changeset/soft-terms-visit.md
+++ b/.changeset/soft-terms-visit.md
@@ -1,5 +1,5 @@
 ---
-"@nacelle/nacelle-js": patch
+"@nacelle/shopify-cart": major
 ---
 
 feat: return `cart`, `userErrors` and `errors` from all client methods

--- a/.changeset/tame-dryers-visit.md
+++ b/.changeset/tame-dryers-visit.md
@@ -1,5 +1,5 @@
 ---
-"@nacelle/nacelle-js": patch
+"@nacelle/shopify-cart": patch
 ---
 
 docs: updated responses/errors

--- a/.changeset/tidy-dryers-decide.md
+++ b/.changeset/tidy-dryers-decide.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/shopify-cart': minor
+'@nacelle/shopify-cart': major
 ---
 
 - feat(breaking!): Exports `esm` builds as `nacelle-shopify-cart.mjs`

--- a/.changeset/tricky-melons-fry.md
+++ b/.changeset/tricky-melons-fry.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/shopify-cart': minor
+'@nacelle/shopify-cart': major
 ---
 
 Breaking!: Uses `cost` in query for `Cart` and `LineItems` instead of deprecated `estimatedCost`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ENG-6843/shopify-cart-1.0.0
     paths:
       - 'packages/**'
 

--- a/examples/nuxt-3/package.json
+++ b/examples/nuxt-3/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nacelle/nuxt-3-starter-example",
   "private": true,
+  "version": "0.0.1",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",

--- a/reference-stores/next/package.json
+++ b/reference-stores/next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next",
+  "name": "nacelle-next-reference-store",
   "version": "0.1.3",
   "private": true,
   "scripts": {


### PR DESCRIPTION
<!-- - docs: preps changesets for pre-release
- chore: configure changeset for pre-release mode -->

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

**NOTE:** This PR is a draft PR until we're ready to release the 1.0.0-beta. 

## WHY are these changes introduced?

Addresses [ENG-7143](https://nacelle.atlassian.net/browse/ENG-7143) - sets up changesets and the gh actions for releasing the Shopify Cart 1.0.0-beta <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Adds missing "version" key to `examples/nuxt-3/package.json`. This fixes an error preventing `changeset version` from working in pre-release mode
2. Updates the "name" key in `reference-store/next/package.json` to be `next-reference-store` instead of `next` since this confused changesets into thinking all NextJS repos were using the reference store as a dependency.
3. Updates any changesets for breaking changes to be tagged as `major` instead of `minor` so that changeset knows to up the version to `1.0.0-beta` instead of `0.X.X-beta`
4. Enters changeset's pre-release mode with the `beta` tag. This will cause `changesets version` to publish the version as `1.0.0-beta`
5. Adds `ENG-6843/shopify-cart-1.0.0` as a branch to trigger the `release` workflow from. (Uncertainty: I'm not 100% certain if updating it here will work or if I'll need to update it on the `main` branch via another PR. Some things work at the branch level in actions, and some have to be set at the main branch level). 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

##  How to Test

There's not much testing since this is more of  a config PR, but you can test the version bump by running `npm run changeset version` from the root of the repo after checking out `mdarrik/shopify-cart/ENG-7143-configure-beta-publish-step` in git.
