### PR TITLE
fix: allow merchandise fragment to be supplied

### DIFF
--- a/packages/shopify-cart/src/client/client-dom.spec.ts
+++ b/packages/shopify-cart/src/client/client-dom.spec.ts
@@ -399,11 +399,6 @@ describe('createShopifyCartClient', () => {
     const cartClient = createShopifyCartClient({
       ...clientSettings,
       customFragments: {
-        USER_ERRORS: `
-          fragment CartUserError_userErrors on CartUserError {
-            message
-          }
-        `,
         BUYER_IDENTITY: `
           fragment CartBuyerIdentity_buyerIdentity on CartBuyerIdentity {
             email
@@ -417,6 +412,21 @@ describe('createShopifyCartClient', () => {
               currencyCode
             }
           }
+        `,
+        MERCHANDISE: `
+          fragment Merchandise_merchandise on ProductVariant {
+            available: availableForSale
+          }
+        `,
+        MONEY: `
+          fragment Money_money on MoneyV2 {
+            cost: amount
+          }
+        `,
+        USER_ERRORS: `
+          fragment CartUserError_userErrors on CartUserError {
+            message
+          }
         `
       }
     });
@@ -426,11 +436,6 @@ describe('createShopifyCartClient', () => {
     expect(windowFetch).toHaveBeenCalledTimes(1);
     const requestBody = (windowFetch.mock.calls[0] as Request[])[1].body;
 
-    // USER_ERRORS
-    expect(requestBody).toMatch(
-      /fragment CartUserError_userErrors on CartUserError {\\n\s+ message\\n\s+ }/
-    );
-
     // BUYER_IDENTITY
     expect(requestBody).toMatch(
       /fragment CartBuyerIdentity_buyerIdentity on CartBuyerIdentity {\\n\s+ email\\n\s+ phone\\n\s+ }/
@@ -439,6 +444,21 @@ describe('createShopifyCartClient', () => {
     // DISCOUNT_ALLOCATION
     expect(requestBody).toMatch(
       /fragment CartDiscountAllocation_discountAllocation on CartDiscountAllocation {\\n\s+ discountedAmount {\\n\s+ amount\\n\s+ currencyCode\\n\s+ }\\n\s+ }/
+    );
+
+    // MERCHANDISE
+    expect(requestBody).toMatch(
+      /fragment Merchandise_merchandise on ProductVariant {\\n\s+ available: availableForSale\\n\s+ }/
+    );
+
+    // MONEY
+    expect(requestBody).toMatch(
+      /fragment Money_money on MoneyV2 {\\n\s+ cost: amount\\n\s+ }/
+    );
+
+    // USER_ERRORS
+    expect(requestBody).toMatch(
+      /fragment CartUserError_userErrors on CartUserError {\\n\s+ message\\n\s+ }/
     );
   });
 

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -24,10 +24,7 @@ import type {
   LanguageCode
 } from '../types/shopify.type';
 
-export type UserSuppliedFragmentType = Exclude<
-  keyof typeof fragments,
-  'CART' | 'MERCHANDISE'
->;
+export type UserSuppliedFragmentType = Exclude<keyof typeof fragments, 'CART'>;
 export type CustomFragments = Partial<Record<UserSuppliedFragmentType, string>>;
 
 export interface CreateClientParams {

--- a/packages/shopify-cart/src/graphql/fragments/cart.ts
+++ b/packages/shopify-cart/src/graphql/fragments/cart.ts
@@ -6,12 +6,19 @@ import defaultMerchandise from './merchandise';
 import defaultMoney from './money';
 
 export interface CartFragments {
+  // NOTE: @index directives are for the 'Generate Index' VSCode Extension (jayfong.generate-index)
+  //  once the 'Generate Index' extension is installed,
+  //  open the command palette with Command+Shift+P / Ctrl+Shift+P,
+  //  then search for & select 'Generate Index'
+
+  // @index('./!(*.spec|index|userErrors).ts', (f, _) => `${_.constantCase(f.name)}?: string;`)
   BUYER_IDENTITY?: string;
   DISCOUNT_ALLOCATION?: string;
   EXTEND_CART?: string;
   EXTEND_CART_LINE?: string;
-  EXTEND_CART_LINE_MERCHANDISE?: string;
+  MERCHANDISE?: string;
   MONEY?: string;
+  // @endindex
 }
 
 export default (customFragments?: CartFragments) => /* GraphQL */ `
@@ -96,7 +103,7 @@ export default (customFragments?: CartFragments) => /* GraphQL */ `
       code
     }
   }
-  ${defaultMerchandise()}
+  ${customFragments?.MERCHANDISE ?? defaultMerchandise()}
   ${customFragments?.BUYER_IDENTITY ?? defaultBuyerIdentity()}
   ${customFragments?.DISCOUNT_ALLOCATION ?? defaultDiscountAllocation()}
   ${customFragments?.EXTEND_CART ?? defaultExtendCart()}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Why are these changes introduced?

Fixes [ENG-7163](https://nacelle.atlassian.net/browse/ENG-7163)

> Merchandise fragment cannot be provided in `customFragments`

There were omissions from #229 that resulted in `MERCHANDISE` custom fragments not being applied.

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

1. Ensures `customFragments.MERCHANDISE` is used in `src/graphql/fragments/cart.ts`.
2. Fixes types and allows them to be generated with [`JayFong.generate-index`](https://marketplace.visualstudio.com/items?itemName=JayFong.generate-index) in the future, if we add more fragments.
3. Adds more unit tests to guard against future regressions.

## How to test

1. Check out the `ENG-7163-fix-merchandise-custom-fragment` branch.
2. Navigate to `packages/shopify-cart`
4. `npm run build` - it should build without errors.
5. `npm run codegen` - there should be no uncommitted changes.
6. `npm run test:ci` - all tests should pass with 100% coverage:

![ENG-7163-fix-merchandise-custom-fragment all tests passing with 100% coverage](https://user-images.githubusercontent.com/5732000/190477025-255de145-fceb-4535-a055-1435e9697fc5.png)

## Local testing results

When testing in a local Vite project, the `MERCHANDISE` fragment was being used as expected when it was supplied in `customFragments`:

![@nacelle:shopify-cart MERCHANDISE fragment working as expected](https://user-images.githubusercontent.com/5732000/190477233-86f756ae-0156-42e1-8276-a7de26779ba2.png)
