### PR TITLE
feat!: error when provided invalid fragment key

### DIFF
--- a/packages/shopify-cart/src/client/actions/cart.ts
+++ b/packages/shopify-cart/src/client/actions/cart.ts
@@ -1,7 +1,7 @@
 import queries from '../../graphql/queries';
 import { formatCartResponse, depaginateLines } from '../../utils';
 import type { CartResponse } from '../../types/cart.type';
-import type { CartFragments } from '../../graphql/fragments/cart';
+import type { CustomFragments } from '../../graphql/fragments';
 import type {
   CartQueryVariables,
   Cart_CartFragment,
@@ -14,7 +14,7 @@ import type { ShopifyError } from '../../types/errors.type';
 export interface CartParams {
   cartId: string;
   gqlClient: GqlClient;
-  customFragments?: CartFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartAttributesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartAttributesUpdate.ts
@@ -9,13 +9,13 @@ import type {
 } from '../../types/shopify.type';
 import type { GqlClient } from '../../cart-client.types';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 
 export interface UpdateCartAttributesParams {
   attributes: AttributeInput[];
   cartId: string;
   gqlClient: GqlClient;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartBuyerIdentityUpdate.ts
@@ -1,7 +1,7 @@
 import mutations from '../../graphql/mutations';
 import { formatCartResponse, depaginateLines } from '../../utils';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type {
   CartBuyerIdentityInput,
   CartBuyerIdentityUpdatePayload,
@@ -15,7 +15,7 @@ export interface CartBuyerIdentityUpdateParams {
   gqlClient: GqlClient;
   cartId: string;
   buyerIdentity: CartBuyerIdentityInput;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartCreate.ts
+++ b/packages/shopify-cart/src/client/actions/cartCreate.ts
@@ -16,12 +16,12 @@ import type {
   LanguageCode,
   CountryCode
 } from '../../types/shopify.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type { GqlClient } from '../../cart-client.types';
 
 export interface CreateCartParams {
   gqlClient: GqlClient;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   params?: NacelleCartInput;
   language: LanguageCode;
   country: CountryCode;

--- a/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartDiscountCodesUpdate.ts
@@ -1,7 +1,7 @@
 import mutations from '../../graphql/mutations';
 import { formatCartResponse, depaginateLines } from '../../utils';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type {
   CartDiscountCodesUpdatePayload,
   CartDiscountCodesUpdateMutationVariables,
@@ -13,7 +13,7 @@ import type { GqlClient } from '../../cart-client.types';
 export interface CreateDiscountCodesUpdateParams {
   cartId: string;
   gqlClient: GqlClient;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   discountCodes?: string[];
   language: LanguageCode;
   country: CountryCode;

--- a/packages/shopify-cart/src/client/actions/cartLinesAdd.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesAdd.ts
@@ -9,7 +9,7 @@ import type {
   CartFragmentResponse,
   NacelleCartLineItemInput
 } from '../../types/cart.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type {
   CartLinesAddPayload,
   CartLineAddMutationVariables,
@@ -22,7 +22,7 @@ export interface CartLinesAddParams {
   cartId: string;
   gqlClient: GqlClient;
   lines: Array<NacelleCartLineItemInput>;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartLinesRemove.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesRemove.ts
@@ -1,6 +1,6 @@
 import mutations from '../../graphql/mutations';
 import { formatCartResponse, depaginateLines } from '../../utils';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
 import {
   CartLinesRemovePayload,
@@ -14,7 +14,7 @@ export interface CartLinesRemoveParams {
   gqlClient: GqlClient;
   cartId: string;
   lineIds: Array<string>;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartLinesUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartLinesUpdate.ts
@@ -4,7 +4,7 @@ import {
   transformNacelleLineItemToShopifyLineItem,
   depaginateLines
 } from '../../utils';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type {
   CartResponse,
   CartFragmentResponse,
@@ -22,7 +22,7 @@ export interface CartLinesUpdateParams {
   cartId: string;
   gqlClient: GqlClient;
   lines: Array<NacelleCartLineItemUpdateInput>;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/actions/cartNoteUpdate.ts
+++ b/packages/shopify-cart/src/client/actions/cartNoteUpdate.ts
@@ -6,7 +6,7 @@ import type {
   LanguageCode,
   CountryCode
 } from '../../types/shopify.type';
-import type { MutationFragments } from '../../graphql/mutations';
+import type { CustomFragments } from '../../graphql/fragments';
 import type { CartResponse, CartFragmentResponse } from '../../types/cart.type';
 import type { GqlClient } from '../../cart-client.types';
 
@@ -14,7 +14,7 @@ export interface UpdateCartNoteParams {
   cartId: string;
   gqlClient: GqlClient;
   note: string;
-  customFragments?: MutationFragments;
+  customFragments?: CustomFragments;
   language: LanguageCode;
   country: CountryCode;
 }

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -10,7 +10,6 @@ import {
   cartNoteUpdate
 } from './actions';
 import { createGqlClient, sanitizeFragments } from '../utils';
-import fragments from '../graphql/fragments';
 import type {
   CartResponse,
   NacelleCartInput,
@@ -23,9 +22,7 @@ import type {
   CountryCode,
   LanguageCode
 } from '../types/shopify.type';
-
-export type UserSuppliedFragmentType = Exclude<keyof typeof fragments, 'CART'>;
-export type CustomFragments = Partial<Record<UserSuppliedFragmentType, string>>;
+import type { CustomFragments } from '../graphql/fragments';
 
 export interface CreateClientParams {
   shopifyStorefrontAccessToken: string;

--- a/packages/shopify-cart/src/graphql/fragments/cart.ts
+++ b/packages/shopify-cart/src/graphql/fragments/cart.ts
@@ -4,24 +4,9 @@ import defaultExtendCart from './extendCart';
 import defaultExtendCartLine from './extendCartLine';
 import defaultMerchandise from './merchandise';
 import defaultMoney from './money';
+import type { CustomFragments } from '.';
 
-export interface CartFragments {
-  // NOTE: @index directives are for the 'Generate Index' VSCode Extension (jayfong.generate-index)
-  //  once the 'Generate Index' extension is installed,
-  //  open the command palette with Command+Shift+P / Ctrl+Shift+P,
-  //  then search for & select 'Generate Index'
-
-  // @index('./!(*.spec|index|userErrors).ts', (f, _) => `${_.constantCase(f.name)}?: string;`)
-  BUYER_IDENTITY?: string;
-  DISCOUNT_ALLOCATION?: string;
-  EXTEND_CART?: string;
-  EXTEND_CART_LINE?: string;
-  MERCHANDISE?: string;
-  MONEY?: string;
-  // @endindex
-}
-
-export default (customFragments?: CartFragments) => /* GraphQL */ `
+export default (customFragments?: CustomFragments) => /* GraphQL */ `
   fragment Cart_cart on Cart {
     ...Cart_extendCart
     id

--- a/packages/shopify-cart/src/graphql/fragments/index.ts
+++ b/packages/shopify-cart/src/graphql/fragments/index.ts
@@ -15,7 +15,40 @@ import { default as money } from './money';
 import { default as userErrors } from './userErrors';
 // @endindex
 
-export default {
+export type CustomFragmentKey =
+  // NOTE: @index directives are for the 'Generate Index' VSCode Extension (jayfong.generate-index)
+  //  once the 'Generate Index' extension is installed,
+  //  open the command palette with Command+Shift+P / Ctrl+Shift+P,
+  //  then search for & select 'Generate Index'
+
+  // @index('./!(*.spec|cart).ts', (f, _, e) => `| '${_.constantCase(f.name)}'${e.isLast ? ';' : ''}`)
+  | 'BUYER_IDENTITY'
+  | 'DISCOUNT_ALLOCATION'
+  | 'EXTEND_CART'
+  | 'EXTEND_CART_LINE'
+  | 'MERCHANDISE'
+  | 'MONEY'
+  | 'USER_ERRORS';
+// @endindex
+
+export type CustomFragments = Partial<Record<CustomFragmentKey, string>>;
+
+export const customFragmentKeys: Set<CustomFragmentKey> = new Set([
+  // @index('./!(*.spec|cart).ts', (f, _) => `'${_.constantCase(f.name)}',`)
+  'BUYER_IDENTITY',
+  'DISCOUNT_ALLOCATION',
+  'EXTEND_CART',
+  'EXTEND_CART_LINE',
+  'MERCHANDISE',
+  'MONEY',
+  'USER_ERRORS'
+  // @endindex
+]);
+
+type FragmentKey = CustomFragmentKey | 'CART';
+type Fragment = (customFragments?: CustomFragments) => string;
+
+const fragments: Record<FragmentKey, Fragment> = {
   // @index('./!(*.spec).ts', (f, _) => `${_.constantCase(f.name)}: ${f.name},`)
   BUYER_IDENTITY: buyerIdentity,
   CART: cart,
@@ -27,3 +60,5 @@ export default {
   USER_ERRORS: userErrors
   // @endindex
 };
+
+export default fragments;

--- a/packages/shopify-cart/src/graphql/mutations/cartAttributesUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartAttributesUpdate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartAttributesUpdate(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartBuyerIdentityUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartBuyerIdentityUpdate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartBuyerIdentityUpdate(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartCreate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartCreate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartCreate(
     $input: CartInput!

--- a/packages/shopify-cart/src/graphql/mutations/cartDiscountCodesUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartDiscountCodesUpdate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartDiscountCodesUpdate(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartLineAdd.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineAdd.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartLineAdd(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartLineRemove.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineRemove.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartLineRemove(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartLineUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartLineUpdate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartLineUpdate(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/cartNoteUpdate.ts
+++ b/packages/shopify-cart/src/graphql/mutations/cartNoteUpdate.ts
@@ -1,8 +1,8 @@
 import defaultFragments from '../fragments';
-import type { MutationFragments } from '.';
+import type { CustomFragments } from '../fragments';
 
 export default (
-  customFragments: MutationFragments = {}
+  customFragments: CustomFragments = {}
 ): string => /* GraphQL */ `
   mutation CartNoteUpdate(
     $cartId: ID!

--- a/packages/shopify-cart/src/graphql/mutations/index.ts
+++ b/packages/shopify-cart/src/graphql/mutations/index.ts
@@ -1,5 +1,3 @@
-import type { CartFragments } from '../fragments/cart';
-
 // NOTE: @index directives are for the 'Generate Index' VSCode Extension (jayfong.generate-index)
 //  once the 'Generate Index' extension is installed,
 //  open the command palette with Command+Shift+P / Ctrl+Shift+P,
@@ -16,10 +14,6 @@ import { default as cartLineAdd } from './cartLineAdd';
 import { default as cartLineUpdate } from './cartLineUpdate';
 import { default as cartNoteUpdate } from './cartNoteUpdate';
 // @endindex
-
-export interface MutationFragments extends CartFragments {
-  USER_ERRORS?: string;
-}
 
 export default {
   // @index('./!(*.spec).ts', (f, _) => `${_.constantCase(f.name)}: ${f.name},`)

--- a/packages/shopify-cart/src/graphql/queries/cart.ts
+++ b/packages/shopify-cart/src/graphql/queries/cart.ts
@@ -1,7 +1,9 @@
 import defaultFragments from '../fragments';
-import type { CartFragments } from '../fragments/cart';
+import type { CustomFragments } from '../fragments';
 
-export default (customFragments: CartFragments = {}): string => /* GraphQL */ `
+export default (
+  customFragments: CustomFragments = {}
+): string => /* GraphQL */ `
   query Cart(
     $id: ID!
     $numCartLines: Int = 250

--- a/packages/shopify-cart/src/index.ts
+++ b/packages/shopify-cart/src/index.ts
@@ -24,3 +24,4 @@ export type {
   CountryCode,
   LanguageCode
 } from './types/shopify.type';
+export type { CustomFragmentKey, CustomFragments } from './graphql/fragments';

--- a/packages/shopify-cart/src/types/shopify.type.ts
+++ b/packages/shopify-cart/src/types/shopify.type.ts
@@ -6543,7 +6543,7 @@ export type Cart_ExtendCartFragment = { __typename?: 'Cart', id: string };
 
 export type CartLine_ExtendCartLineFragment = { __typename?: 'CartLine', id: string };
 
-export type Merchandise_MerchandiseFragment = { __typename?: 'ProductVariant', availableForSale: boolean, requiresShipping: boolean, title: string, sourceEntryId: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> };
+export type Merchandise_MerchandiseFragment = { __typename?: 'ProductVariant', availableForSale: boolean, requiresShipping: boolean, title: string, compareAtPriceV2?: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any } | null, priceV2: { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any }, image?: { __typename?: 'Image', id?: string | null, url: any, altText?: string | null, width?: number | null, height?: number | null } | null, product: { __typename?: 'Product', handle: string, onlineStoreUrl?: any | null, tags: Array<string>, title: string, vendor: string }, selectedOptions: Array<{ __typename?: 'SelectedOption', name: string, value: string }> };
 
 export type Money_MoneyFragment = { __typename?: 'MoneyV2', currencyCode: CurrencyCode, amount: any };
 

--- a/packages/shopify-cart/src/utils/depaginateLines.ts
+++ b/packages/shopify-cart/src/utils/depaginateLines.ts
@@ -5,7 +5,7 @@ import {
   LanguageCode,
   CountryCode
 } from '../types/shopify.type';
-import type { CartFragments } from '../graphql/fragments/cart';
+import type { CustomFragments } from '../graphql/fragments';
 import type { GqlClient } from '../cart-client.types';
 import type { ShopifyCartResponse } from '../client/actions/cart';
 
@@ -17,7 +17,7 @@ export interface PaginateCartLinesQueryArgs extends QueryRootCartArgs {
 
 export interface DepaginateLinesParams {
   cart: Cart_CartFragment | undefined | null;
-  customFragments?: CartFragments;
+  customFragments?: CustomFragments;
   gqlClient: GqlClient;
   language: LanguageCode;
   country: CountryCode;

--- a/packages/shopify-cart/src/utils/sanitizeFragments.spec.ts
+++ b/packages/shopify-cart/src/utils/sanitizeFragments.spec.ts
@@ -1,5 +1,5 @@
 import sanitizeFragments, { sanitizeFragment } from './sanitizeFragments';
-import type { CustomFragments } from '../client';
+import type { CustomFragments } from '../graphql/fragments';
 
 describe('sanitizeFragment', () => {
   it("changes the fragment name to the corresponding default fragment's name", () => {
@@ -62,6 +62,25 @@ describe('sanitizeFragments', () => {
       ] as CustomFragments)
     ).toThrow(
       "`customFragments` must be an object. Please refer to `@nacelle/shopify-cart`'s README."
+    );
+  });
+
+  it('throws an error when the provided `customFragments` contain an invalid fragment key', () => {
+    const customFragments = {
+      MONEY: `
+        fragment Cost on MoneyV2 {
+          amount
+        }
+      `,
+      NURCHENDICE: `
+        fragment Merchandise_merchandise on ProductVariant {
+          availableForSale
+        }
+      `
+    };
+
+    expect(() => sanitizeFragments(customFragments)).toThrow(
+      "Invalid custom fragment 'NURCHENDICE' provided."
     );
   });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Why are these changes introduced?

Addresses [ENG-7164](https://nacelle.atlassian.net/browse/ENG-7164)

> Throw when a fragment in `customFragments` doesn't use a valid fragment key

It was easy for misspelled or otherwise invalid `customFragments` to be supplied to the cart client. Those fragments were being quietly ignored. To surface issues to the merchant developer, we should have invalid `customFragments` fail loudly with a thrown error.

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

1. If any of the supplied `customFragments` don't use the expected fragment keys (such as `MERCHANDISE` or `EXTEND_CART_LINE`), an error is thrown.
2. Updates unit tests to validate that an error is thrown when invalid `customFragments` are supplied.
3. Simplifies the typings, such that the `CustomFragments` type is used universally wherever `customFragments` are used.
4. Updates the generated types to reflect changes from https://github.com/getnacelle/nacelle-js/pull/244/commits/ef7ceaf7cc376ec9c4dac990cc95459be26a1be8.

## How to test

1. Check out the `ENG-7164-error-when-invalid-customFragments-supplied` branch.
2. Navigate to `packages/shopify-cart`
5. `npm run build` - it should build without errors.
6. `npm run codegen` - there should be no uncommitted changes.
7. `npm run test:ci` - all tests should pass with 100% coverage:

![ENG-7164-error-when-invalid-customFragments-supplied all tests passing](https://user-images.githubusercontent.com/5732000/190524858-9d9d9a40-d243-45db-ae0e-86a8b9e058df.png)

## Local testing results

When testing in a local Vite project, invalid `customFragments` resulted in a thrown error:

https://user-images.githubusercontent.com/5732000/190524991-6f265e43-c1de-46fc-86bf-9fe8bdaff4c9.mov


