### PR TITLE
feat: adds get/set config functions

### DIFF
--- a/.changeset/old-colts-attend.md
+++ b/.changeset/old-colts-attend.md
@@ -4,5 +4,5 @@
 
 feat: adds `getConfig` and `setConfig` functions
 
-- `getConfig` allows for reviewing options set in the cart client such as the `language`, `country`, the shopify Shop Id, and other options.
+- `getConfig` allows for reviewing options set in the cart client such as the `language`, `country`, the Shopify Shop Id, and other options.
 - `setConfig` allows for updating some of the configuration options used to make requests to Shopify - namely `language` and `country` at this juncture.

--- a/.changeset/old-colts-attend.md
+++ b/.changeset/old-colts-attend.md
@@ -1,0 +1,8 @@
+---
+'@nacelle/shopify-cart': minor
+---
+
+feat: adds `getConfig` and `setConfig` functions
+
+- `getConfig` allows for reviewing options set in the cart client such as the `language`, `country`, the shopify Shop Id, and other options.
+- `setConfig` allows for updating some of the configuration options used to make requests to Shopify - namely `language` and `country` at this juncture.

--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -100,8 +100,10 @@ The cart client exposes the following methods:
 - [`cartLinesRemove`](#cartLinesRemove)
 - [`cartLinesUpdate`](#cartLinesUpdate)
 - [`cartNoteUpdate`](#cartNoteUpdate)
+- [`getConfig`](#getConfig)
+- [`setConfig`](#setConfig)
 
-#### <a id="cart">`cart({ cartId })`</a>
+#### <a id="cart" href="#cart">`cart({ cartId })`</a>
 
 _Retrieves an existing Shopify cart._
 
@@ -115,7 +117,7 @@ const { cart, userErrors, errors } = await cartClient.cart({
 });
 ```
 
-#### <a id="cartAttributesUpdate">`cartAttributesUpdate({ cartId, attributes })`</a>
+#### <a id="cartAttributesUpdate" href="#cartAttributesUpdate">`cartAttributesUpdate({ cartId, attributes })`</a>
 
 _Updates an existing Shopify cart's attributes._
 
@@ -145,7 +147,7 @@ const { cart, userErrors, errors } = await cartClient.cartBuyerIdentityUpdate({
 });
 ```
 
-#### <a id="cartCreate">`cartCreate(cartInput)`</a>
+#### <a id="cartCreate" href="#cartCreate">`cartCreate(cartInput)`</a>
 
 _Creates a new Shopify cart._
 
@@ -166,7 +168,7 @@ const { cart, userErrors, errors } = await cartClient.cartCreate({
 });
 ```
 
-#### <a id="cartDiscountCodesUpdate">`cartDiscountCodesUpdate({ cartId, discountCodes })`</a>
+#### <a id="cartDiscountCodesUpdate" href="#cartDiscountCodesUpdate">`cartDiscountCodesUpdate({ cartId, discountCodes })`</a>
 
 _Updates an existing Shopify cart's discount codes._
 
@@ -181,7 +183,7 @@ const { cart, userErrors, errors } = await cartClient.cartDiscountCodesUpdate({
 });
 ```
 
-#### <a id="cartLinesAdd">`cartLinesAdd({ cartId, lines })`</a>
+#### <a id="cartLinesAdd" href="#cartLinesAdd">`cartLinesAdd({ cartId, lines })`</a>
 
 _Adds lines to an existing Shopify cart._
 
@@ -201,7 +203,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
 });
 ```
 
-#### <a id="cartLinesRemove">`cartLinesRemove({ cartId, lineIds })`</a>
+#### <a id="cartLinesRemove" href="#cartLinesRemove">`cartLinesRemove({ cartId, lineIds })`</a>
 
 _Removes lines from an existing Shopify cart._
 
@@ -218,7 +220,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesRemove({
 });
 ```
 
-#### <a id="cartLinesUpdate">`cartLinesUpdate({ cartId, lines })`</a>
+#### <a id="cartLinesUpdate" href="#cartLinesUpdate">`cartLinesUpdate({ cartId, lines })`</a>
 
 _Updates lines on an existing Shopify cart._
 
@@ -238,7 +240,7 @@ const { cart, userErrors, errors } = await cartClient.cartLinesAdd({
 });
 ```
 
-#### <a id="cartNoteUpdate">`cartNoteUpdate({ cartId, note })`</a>
+#### <a id="cartNoteUpdate" href="#cartNoteUpdate">`cartNoteUpdate({ cartId, note })`</a>
 
 _Updates note on an existing Shopify cart._
 
@@ -251,6 +253,33 @@ const { cart, userErrors, errors } = await cartClient.cartNoteUpdate({
   cartId: 'gid://shopify/Cart/112233',
   note: 'Please use a red ribbon for the bow, if possible :)'
 });
+```
+
+#### <a id="getConfig" href="#getConfig">`getConfig()`</a>
+
+_Gets language and country values used to make requests to Shopify._
+
+#### <a id="setConfig" href="#setConfig">`setConfig({language, country})`</a>
+
+_Updates the language and country settings used to make requests to Shopify._
+
+**Accepts**: config - an object containing optional values for the `language` (`string`) and `country` (`string`). These values should be a `LanguageCode` and `CountryCode` respectively.
+
+##### `setConfig` Example
+
+```js
+// update the language
+cartClient.setConfig({language: "FR"})
+```
+
+```js
+// update country
+cartClient.setConfig({country: "CA"})
+```
+
+```js
+// update the language & country
+cartClient.setConfig({country: "CA", language: "FR"})
 ```
 
 <!-- LINKS -->

--- a/packages/shopify-cart/src/client/client-dom.spec.ts
+++ b/packages/shopify-cart/src/client/client-dom.spec.ts
@@ -512,14 +512,13 @@ describe('createShopifyCartClient', () => {
     );
   });
 
-  it('returns the config options passed in when you call getConfig', () => {
+  it('returns the editable config options passed in when you call getConfig', () => {
     const cartClientWithNonDefaultCountryAndLanguage = createShopifyCartClient({
       ...clientSettings,
       country: 'CA',
       language: 'FR'
     });
     expect(cartClientWithNonDefaultCountryAndLanguage.getConfig()).toEqual({
-      ...clientSettings,
       country: 'CA',
       language: 'FR'
     });
@@ -527,7 +526,6 @@ describe('createShopifyCartClient', () => {
       ...clientSettings
     });
     expect(cartClientWithDefaultLanguageAndCountry.getConfig()).toEqual({
-      ...clientSettings,
       country: defaultCountry,
       language: defaultLanguage
     });
@@ -536,7 +534,6 @@ describe('createShopifyCartClient', () => {
     const cartClient = createShopifyCartClient({ ...clientSettings });
     cartClient.setConfig({ language: 'FR' });
     expect(cartClient.getConfig()).toEqual({
-      ...clientSettings,
       country: defaultCountry,
       language: 'FR'
     });
@@ -545,7 +542,6 @@ describe('createShopifyCartClient', () => {
     const cartClient = createShopifyCartClient({ ...clientSettings });
     cartClient.setConfig({ country: 'CA' });
     expect(cartClient.getConfig()).toEqual({
-      ...clientSettings,
       language: defaultLanguage,
       country: 'CA'
     });

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -76,10 +76,10 @@ type CartNoteUpdate = (params: {
   note: string;
 }) => Promise<CartResponse | void>;
 
-type CartClientConfig = Omit<
-  CreateClientParams,
-  'fetchClient' | 'customFragments'
->;
+type CartClientConfig = {
+  language: LanguageCode;
+  country: CountryCode;
+};
 
 type SetConfig = (configParams: {
   language?: LanguageCode;
@@ -162,7 +162,7 @@ export interface CartClient {
   setConfig: SetConfig;
 
   /**
-   * Retrieve the config info used to make requests to Shopify.
+   * Retrieve the language and country info used to make requests to Shopify.
    * To edit values, use setConfig
    * @returns {object} Cart Client Config
    */
@@ -193,9 +193,6 @@ export default function createShopifyCartClient({
   });
   const sanitizedCustomFragments = sanitizeFragments(customFragments);
   const config = {
-    shopifyShopId,
-    shopifyStorefrontAccessToken,
-    shopifyCustomEndpoint,
     language,
     country
   };

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -76,6 +76,18 @@ type CartNoteUpdate = (params: {
   note: string;
 }) => Promise<CartResponse | void>;
 
+type CartClientConfig = Omit<
+  CreateClientParams,
+  'fetchClient' | 'customFragments'
+>;
+
+type SetConfig = (configParams: {
+  language?: LanguageCode;
+  country?: CountryCode;
+}) => void;
+
+type GetConfig = () => CartClientConfig;
+
 export interface CartClient {
   /**
    * Fetches an existing Shopify Cart.
@@ -141,6 +153,20 @@ export interface CartClient {
    * @returns {object} Shopify cart object
    */
   cartNoteUpdate: CartNoteUpdate;
+
+  /**
+   * Update the editable global config values used to make requests to Shopify.
+   * @param {string} language - Shopify Language Code
+   * @param {string} country - Shopify Country Code
+   */
+  setConfig: SetConfig;
+
+  /**
+   * Retrieve the config info used to make requests to Shopify.
+   * To edit values, use setConfig
+   * @returns {object} Cart Client Config
+   */
+  getConfig: GetConfig;
 }
 
 /**
@@ -166,13 +192,20 @@ export default function createShopifyCartClient({
     fetchClient
   });
   const sanitizedCustomFragments = sanitizeFragments(customFragments);
+  const config = {
+    shopifyShopId,
+    shopifyStorefrontAccessToken,
+    shopifyCustomEndpoint,
+    language,
+    country
+  };
   return {
     cart: (params: { cartId: string }): Promise<CartResponse | void> =>
       cart({
         customFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartAttributesUpdate: (params: {
@@ -182,8 +215,8 @@ export default function createShopifyCartClient({
       cartAttributesUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartBuyerIdentityUpdate: (params: {
@@ -193,16 +226,16 @@ export default function createShopifyCartClient({
       cartBuyerIdentityUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language: language,
-        country: country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartCreate: (params: NacelleCartInput): Promise<CartResponse | void> =>
       cartCreate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         params
       }),
     cartDiscountCodesUpdate: (params: {
@@ -212,8 +245,8 @@ export default function createShopifyCartClient({
       cartDiscountCodesUpdate({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartLinesAdd: (params: {
@@ -223,8 +256,8 @@ export default function createShopifyCartClient({
       cartLinesAdd({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartLinesUpdate: (params: {
@@ -234,8 +267,8 @@ export default function createShopifyCartClient({
       cartLinesUpdate({
         customFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartLinesRemove: (params: {
@@ -245,8 +278,8 @@ export default function createShopifyCartClient({
       cartLinesRemove({
         customFragments: sanitizedCustomFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
       }),
     cartNoteUpdate: (params: {
@@ -256,9 +289,20 @@ export default function createShopifyCartClient({
       cartNoteUpdate({
         customFragments,
         gqlClient,
-        language,
-        country,
+        language: config.language,
+        country: config.country,
         ...params
-      })
+      }),
+    getConfig: (): CartClientConfig => ({ ...config }),
+    setConfig: ({
+      language,
+      country
+    }: {
+      language?: LanguageCode;
+      country?: CountryCode;
+    }): void => {
+      config.language = language ?? config.language;
+      config.country = country ?? config.country;
+    }
   };
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-7167](https://nacelle.atlassian.net/browse/ENG-7167) - Adds a setConfig and getConfig to the cart client. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

- Adds a getConfig method that returns the string options passed to `createCartClient`
- Adds a `setConfig` method to allow you to update the `language` and `countryCode`
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## How to Test

- Checkout this branch `mdarrik/shopify-cart/ENG-7167-add-setConfig-properties-to-cart` 
- Run `npm run test:ci` - all tests should pass
- Run `npm run build` - should build successfully
- To test in a local repo - use `npm link` and try calling `getConfig` to see the options used in the cart, and test updating the language/country with `setConfig`
