### PR TITLE
docs: describe Nacelle & Shopify cart differences

### DIFF
--- a/packages/shopify-cart/README.md
+++ b/packages/shopify-cart/README.md
@@ -83,7 +83,7 @@ If you'd like to query for additional fields on the [`Cart`][shopify-cart-object
 
 Every method on the `cartClient` returns an object with the following keys.
 
-1. `cart` - a Shopify [`Cart`][shopify-cart-object] object with the addition of `nacelleEntryIds`
+1. `cart` - a Nacelle-oriented Shopify cart object. The `cart` matches the Shopify [`Cart`][shopify-cart-object] object, with one exception: `cart.lines[idx].merchandise` contains a `nacelleEntryId`, and its `id` is renamed to `sourceEntryId`. This more closely aligns your `cart` data with the commerce data in your Nacelle-powered headless storefront.
 2. `userErrors` - an array of Shopify [`CartUserError`][shopify-cart-user-error] objects.
 3. `errors` - an array of top-level Shopify [API Errors][shopify-api-error]
 


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-7058](https://nacelle.atlassian.net/browse/ENG-7058)

> Document the `cart` format in README

## What is this pull request doing?

More precisely describes the `cart` data and how it differs from Shopify's `cart` schema.