### PR TITLE
chore: configure tsconfig for production

### DIFF
--- a/packages/shopify-cart/package.json
+++ b/packages/shopify-cart/package.json
@@ -16,7 +16,7 @@
     "test": "jest --watch",
     "test:ci": "jest --silent --runInBand --collectCoverage",
     "changeset": "changeset",
-    "build": "vite build && tsc && mv dist/src dist/types",
+    "build": "vite build && tsc --project tsconfig.production.json && mv dist/src dist/types",
     "release": "npm run build && changeset publish"
   },
   "homepage": "https://github.com/getnacelle/nacelle-js/tree/main/packages/shopify-cart#readme",

--- a/packages/shopify-cart/package.json
+++ b/packages/shopify-cart/package.json
@@ -16,6 +16,8 @@
     "test": "jest --watch",
     "test:ci": "jest --silent --runInBand --collectCoverage",
     "changeset": "changeset",
+    "tsc": "tsc",
+    "tsc:production": "tsc --project tsconfig.production.json",
     "build": "vite build && tsc --project tsconfig.production.json && mv dist/src dist/types",
     "release": "npm run build && changeset publish"
   },

--- a/packages/shopify-cart/tsconfig.production.json
+++ b/packages/shopify-cart/tsconfig.production.json
@@ -21,6 +21,6 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },
-  "include": ["src", "__tests__"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "__tests__"]
 }


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-7255](https://nacelle.atlassian.net/browse/ENG-7255)

> Configure @nacelle/shopify-cart typescript for production

Previously, unit tests had type errors because `src/**/*.spec.ts` and `__tests__` were excluded from TypeScript compilation:

![unit test type errors](https://user-images.githubusercontent.com/5732000/192569832-f7ce52ee-e4b8-45c3-87a1-eb91b2ade17a.png)

## What is this pull request doing?

This PR doesn't exclude `src/**/*.spec.ts` and `__tests__` in development, and only excludes them in production (`npm run build`). We accomplish this by creating a separate `tsconfig` and using it in `npm run build`.

## How to test

1. Check out the `ENG-7255-configure-ts-for-production` branch.
2. Navigate to `packages/shopify-cart`.
3. `npm run build` - there should be no build errors.
4. Open a unit test file. There should be no type errors:

![unit test no type errors](https://user-images.githubusercontent.com/5732000/192570595-08c14262-7515-4a5d-8f1c-783ddc08e3f2.png)

## Testing checklist

* [x] The only differences between the development & production `tsconfig`s are intended differences:

![tsconfig dev and prod differences include exclude](https://user-images.githubusercontent.com/5732000/192570878-267f47d5-5155-435e-91ba-196be9909eb6.png)
