### PR TITLE
chore: update script name to match feature branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/examples/nuxt-3/package.json
+++ b/examples/nuxt-3/package.json
@@ -6,7 +6,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "nuxt:prepare": "nuxt prepare",
+    "nuxt-prepare": "nuxt prepare",
     "typecheck": "nuxt typecheck"
   },
   "devDependencies": {

--- a/packages/sanity-plugin-nacelle-input/README.md
+++ b/packages/sanity-plugin-nacelle-input/README.md
@@ -150,11 +150,11 @@ Instructions for working on the repo directly.
 
 The best way to test changes to this plugin is by using `npm link` to use it from a Sanity project with the plugin installed. The instructions for doing that should be below:
 
-1. Open your local fork of this project in your terminal
+1. Open your local fork of this project in your terminal.
 2. Run `npm run build` to generate the dist files for this project locally.
-3. Run `npm link` to setup an npm symlink for this project
+3. Run `npm link` to setup an npm symlink for this project.
 4. (Optional) Run `npm run build -- --watch`, this will automatically rebuild whenever you make any local changes
-5. In another terminal, navigate to an existing Sanity project which has this plugin installed. (If you don't have one, you can follow the instructions above to create one)
+5. In another terminal, navigate to an existing Sanity project which has this plugin installed. (If you don't have one, you can follow the instructions above to create one).
 6. Run `npm link @nacelle/sanity-plugin-nacelle-input` - this will link the version of the `@nacelle/sanity-plugin-nacelle-input` in your local Sanity Project to your local clone of this repo.
 7. Run your command to start Sanity Studio, e.g. `npm run start`. You should see any changes you've made locally to this repo in your studio.
    - If you used the watch command in step 4, you should be able to make changes to this repo and then reload the page to see them reflected in the studio.


### PR DESCRIPTION
This PR:

1. Updates a npm script name to match: https://github.com/getnacelle/nacelle-js/blob/e2785872175c8ec84957def0af07e2d33d284faf/examples/nuxt-3/package.json#L10

2. Makes a small change to a `packages/*` project in order to trigger the `Release` workflow.

3. [Enables](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) the `Release` workflow to be manually triggered from https://github.com/getnacelle/nacelle-js/actions/workflows/release.yml in the future.