### PR TITLE
chore: prevent erroneous package publish

### DIFF
--- a/.changeset/twenty-ducks-vanish.md
+++ b/.changeset/twenty-ducks-vanish.md
@@ -1,5 +1,0 @@
----
-'@nacelle/sanity-plugin-nacelle-input': patch
----
-
-Move documentation for `@nacelle/sanity-plugin-nacelle-input` from `README` to documentation website


### PR DESCRIPTION
## Why?

#281 is erroneously trying to publish `@nacelle/sanity-plugin-nacelle-input`. By removing this changeset (which was removed from `main` in #271), we can stop `changesets/bot` from trying to publish a `@beta` version of `@nacelle/sanity-plugin-nacelle-input`.