### PR TITLE
fix: add missing field to checkout fragment

### DIFF
--- a/.changeset/ten-pears-jam.md
+++ b/.changeset/ten-pears-jam.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/shopify-checkout': patch
+---
+
+Fixes an issue with the checkout `completed` value being returned as `false` when a checkout was in fact completed.

--- a/packages/shopify-checkout/src/graphql/fragments/index.ts
+++ b/packages/shopify-checkout/src/graphql/fragments/index.ts
@@ -48,6 +48,7 @@ const discountApplication = gql`
 const checkout = gql`
   fragment Checkout_checkout on Checkout {
     id
+    completedAt
     webUrl
     lineItems(first: 100) {
       edges {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Why are these changes introduced?

Fixes [ENG-7932](https://nacelle.atlassian.net/browse/ENG-7932)

> Completed checkouts are being returned as completed: false

Our `Checkout_checkout on Checkout` fragment was missing an expected top-level field, `completedAt`:

https://github.com/getnacelle/nacelle-js/blob/fe526713227e275a575c1a406ec105a64ca9e544/packages/shopify-checkout/src/graphql/fragments/index.ts#L48-L69

Because our package code expects `completedAt`, this was causing the `completed` value in the `ShopifyCheckout` payload to be `false` when the checkout had in fact been completed.

## What is this pull request doing?

This PR adds `completedAt` to the checkout fragment.

## How to Test

First, the basics:

1. Check out the `ENG-7932-completed-checkouts-are-being-returned-as-incomplete` branch.
2. `npm run bootstrap` from the monorepo root.
3. Navigate to `packages/shopify-checkout`
4. `npm run build` - the package should build without issues.
5. `npm run test:ci` - all tests should pass without a decrease in coverage.

Next, I'd recommend taking this change for a spin in one of the Reference Stores. I used the Nuxt Reference Store, and found that:

- [x] checkout creation & updates worked as expected.
- [x] completing a checkout led to the checkout response including a valid `completedAt` date, with `completed: true` in the `ShopifyCheckout` payload.

For example:

https://user-images.githubusercontent.com/5732000/203201058-63106df0-b6c9-44fe-8fa0-d4451977ef23.mov

Note: in the example above, I added the following to the `if (checkout?.completed)` block in `reference-stores/nuxt/store/checkout.js`:

```js
console.info('Clearing the checkout ID of a completed checkout :)');
```