### PR TITLE
fix: allow plaintext Shopify global IDs

### DIFF
--- a/.changeset/tricky-scissors-flash.md
+++ b/.changeset/tricky-scissors-flash.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/shopify-checkout': patch
+---
+
+Fixes an issue with Shopify global IDs. Shopify have updated their Storefront API to return plaintext global IDs, rather than Base64-encoded global IDs, as has been the norm for a very long time. Now, `@nacelle/shopify-checkout` will accept either plaintext or Base64-encoded global IDs in its methods.

--- a/packages/shopify-checkout/README.md
+++ b/packages/shopify-checkout/README.md
@@ -232,6 +232,7 @@ Other example mutations from Shopify docs:
 
 - [`checkoutShippingAddressUpdateV2`][shopify-mutation-checkout-shipping-address-update-v2]
 - [`checkoutCustomerAssociateV2`][shopify-mutation-checkout-customer-associate-v2]
+
 ### Advanced Usage
 
 #### Using a custom `fetchClient`
@@ -253,7 +254,7 @@ The only requirement of the `fetchClient` is that it implements the [`Fetch API`
 
 #### Using a custom Shopify endpoint
 
-If you'd prefer to specify a Shopify Storefront GraphQL API endpoint directly, without supplying a `myshopifyDomain` or `storefrontApiVersion`, you may do so by specifying a `customEndpoint` when initializing the checkout client. For example:
+If you'd prefer to specify a Shopify Storefront GraphQL API endpoint directly, without supplying a `myshopifyDomain`, you may do so by specifying a `customEndpoint` when initializing the checkout client. For example:
 
 ```js
 const checkoutClient = createShopifyCheckoutClient({

--- a/packages/shopify-checkout/__tests__/mocks/index.ts
+++ b/packages/shopify-checkout/__tests__/mocks/index.ts
@@ -24,16 +24,15 @@ const checkoutUuids = {
 export const checkoutIds = {
   encoded: {
     beginsWithLetter: Buffer.from(
-      'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter
+      `gid://shopify/Checkout/${checkoutUuids.beginsWithLetter}`
     ).toString('base64'),
     beginsWithNumber: Buffer.from(
-      'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
+      `gid://shopify/Checkout/${checkoutUuids.beginsWithNumber}`
     ).toString('base64')
   },
   plaintext: {
-    beginsWithLetter:
-      'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter,
-    beginsWithNumber: 'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
+    beginsWithLetter: `gid://shopify/Checkout/${checkoutUuids.beginsWithLetter}`,
+    beginsWithNumber: `gid://shopify/Checkout/${checkoutUuids.beginsWithNumber}`
   }
 };
 

--- a/packages/shopify-checkout/__tests__/mocks/index.ts
+++ b/packages/shopify-checkout/__tests__/mocks/index.ts
@@ -22,12 +22,19 @@ const checkoutUuids = {
   beginsWithNumber: '998877?key=123123'
 };
 export const checkoutIds = {
-  beginsWithLetter: Buffer.from(
-    'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter
-  ).toString('base64'),
-  beginsWithNumber: Buffer.from(
-    'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
-  ).toString('base64')
+  encoded: {
+    beginsWithLetter: Buffer.from(
+      'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter
+    ).toString('base64'),
+    beginsWithNumber: Buffer.from(
+      'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
+    ).toString('base64')
+  },
+  plaintext: {
+    beginsWithLetter:
+      'gid://shopify/Checkout/' + checkoutUuids.beginsWithLetter,
+    beginsWithNumber: 'gid://shopify/Checkout/' + checkoutUuids.beginsWithNumber
+  }
 };
 
 export const webUrl =
@@ -84,7 +91,7 @@ interface Checkouts {
 }
 
 export const emptyCheckout: ShopifyCheckoutResponseProperties = {
-  id: checkoutIds.beginsWithLetter,
+  id: checkoutIds.encoded.beginsWithLetter,
   webUrl,
   completedAt: null,
   lineItems: { edges: [] },
@@ -133,7 +140,7 @@ export const checkouts: Checkouts = {
     data: {
       checkoutShippingAddressUpdateV2: {
         checkout: {
-          id: checkoutIds.beginsWithLetter,
+          id: checkoutIds.encoded.beginsWithLetter,
           webUrl
         },
         checkoutUserErrors: []

--- a/packages/shopify-checkout/src/client/actions/applyDiscount.ts
+++ b/packages/shopify-checkout/src/client/actions/applyDiscount.ts
@@ -37,7 +37,7 @@ export default async function applyDiscount({
   try {
     if (!isVerifiedCheckoutId(id)) {
       throw new Error(
-        `Invalid checkout ID. Expected a Base64-encoded Shopify Global ID. Received: ${id}`
+        `Invalid checkout ID. Expected a Shopify Global ID. Received: ${id}`
       );
     }
 

--- a/packages/shopify-checkout/src/client/actions/discount.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/discount.spec.ts
@@ -35,7 +35,7 @@ describe('discount', () => {
     await expect(
       applyDiscount({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         discountCode
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
@@ -58,7 +58,7 @@ describe('discount', () => {
     await expect(
       removeDiscount({
         gqlClient,
-        id: checkoutIds.beginsWithLetter
+        id: checkoutIds.encoded.beginsWithLetter
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
       buildCheckout(
@@ -78,12 +78,12 @@ describe('discount', () => {
 
     // [1/2] `applyDiscount`
     await expect(
-      applyDiscount({ gqlClient, id: checkoutIds.beginsWithLetter })
+      applyDiscount({ gqlClient, id: checkoutIds.encoded.beginsWithLetter })
     ).rejects.toThrow(networkErrorMessage);
 
     // [2/2] `removeDiscount`
     await expect(
-      removeDiscount({ gqlClient, id: checkoutIds.beginsWithLetter })
+      removeDiscount({ gqlClient, id: checkoutIds.encoded.beginsWithLetter })
     ).rejects.toThrow(networkErrorMessage);
   });
 
@@ -128,7 +128,7 @@ describe('discount', () => {
 
     applyDiscount({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       discountCode
     }).catch((e) =>
       expect(String(e).includes(checkoutDoesNotExistError.message)).toBe(true)
@@ -144,7 +144,7 @@ describe('discount', () => {
 
     removeDiscount({
       gqlClient,
-      id: checkoutIds.beginsWithLetter
+      id: checkoutIds.encoded.beginsWithLetter
     }).catch((e) =>
       expect(String(e).includes(checkoutDoesNotExistError.message)).toBe(true)
     );

--- a/packages/shopify-checkout/src/client/actions/findCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/findCheckout.spec.ts
@@ -31,11 +31,12 @@ describe('findCheckout', () => {
     );
 
     await expect(
-      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
-        (checkout) => checkout
-      )
+      findCheckout({
+        gqlClient,
+        id: checkoutIds.encoded.beginsWithLetter
+      }).then((checkout) => checkout)
     ).resolves.toMatchObject({
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -47,7 +48,7 @@ describe('findCheckout', () => {
       headers,
       body: JSON.stringify({
         query: queries.getCheckout,
-        variables: { id: checkoutIds.beginsWithLetter }
+        variables: { id: checkoutIds.encoded.beginsWithLetter }
       })
     });
   });
@@ -64,9 +65,10 @@ describe('findCheckout', () => {
     );
 
     await expect(
-      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
-        (checkout) => (checkout as ShopifyCheckout)?.completed
-      )
+      findCheckout({
+        gqlClient,
+        id: checkoutIds.encoded.beginsWithLetter
+      }).then((checkout) => (checkout as ShopifyCheckout)?.completed)
     ).resolves.toBe(false);
   });
 
@@ -81,9 +83,10 @@ describe('findCheckout', () => {
         mockJsonResponse<queries.GetCheckoutData>(checkoutResponse)
     );
     await expect(
-      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).then(
-        (checkout) => (checkout as ShopifyCheckout)?.completed
-      )
+      findCheckout({
+        gqlClient,
+        id: checkoutIds.encoded.beginsWithLetter
+      }).then((checkout) => (checkout as ShopifyCheckout)?.completed)
     ).resolves.toBe(true);
   });
 
@@ -96,7 +99,7 @@ describe('findCheckout', () => {
 
     expect.assertions(1);
     await expect(
-      findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter })
+      findCheckout({ gqlClient, id: checkoutIds.encoded.beginsWithLetter })
     ).rejects.toThrow(networkErrorMessage);
   });
 
@@ -111,11 +114,13 @@ describe('findCheckout', () => {
     );
 
     expect.assertions(1);
-    await findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).catch(
-      (e) =>
-        expect(
-          String(e).includes('[findCheckout] Checkout response has no data')
-        ).toBe(true)
+    await findCheckout({
+      gqlClient,
+      id: checkoutIds.encoded.beginsWithLetter
+    }).catch((e) =>
+      expect(
+        String(e).includes('[findCheckout] Checkout response has no data')
+      ).toBe(true)
     );
   });
 
@@ -134,8 +139,9 @@ describe('findCheckout', () => {
     );
 
     expect.assertions(1);
-    await findCheckout({ gqlClient, id: checkoutIds.beginsWithLetter }).catch(
-      (e) => expect(String(e).includes(problemMessage)).toBe(true)
-    );
+    await findCheckout({
+      gqlClient,
+      id: checkoutIds.encoded.beginsWithLetter
+    }).catch((e) => expect(String(e).includes(problemMessage)).toBe(true));
   });
 });

--- a/packages/shopify-checkout/src/client/actions/putCheckout.spec.ts
+++ b/packages/shopify-checkout/src/client/actions/putCheckout.spec.ts
@@ -148,7 +148,7 @@ describe('putCheckout', () => {
     const note = 'Happy Birthday!';
 
     const checkoutUpdate = checkouts.checkoutUpdate({
-      checkoutId: checkoutIds.beginsWithLetter,
+      checkoutId: checkoutIds.encoded.beginsWithLetter,
       input: { customAttributes, note }
     });
 
@@ -167,7 +167,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         customAttributes,
         note
       }).then((checkout) => checkout)
@@ -182,7 +182,7 @@ describe('putCheckout', () => {
       body: JSON.stringify({
         query: mutations.checkoutAttributesUpdate,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter,
+          checkoutId: checkoutIds.encoded.beginsWithLetter,
           input: {
             customAttributes,
             note
@@ -194,7 +194,7 @@ describe('putCheckout', () => {
 
   it("updates an existing checkout's line items", async () => {
     const checkoutLineItemsReplace = checkouts.checkoutLineItemsReplace({
-      checkoutId: checkoutIds.beginsWithLetter,
+      checkoutId: checkoutIds.encoded.beginsWithLetter,
       lineItems: newCartItems
     });
 
@@ -212,7 +212,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         lineItems: newCartItems
       }).then((checkout) => checkout)
     ).resolves.toMatchObject(
@@ -228,7 +228,7 @@ describe('putCheckout', () => {
       body: JSON.stringify({
         query: mutations.checkoutLineItemsReplace,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter,
+          checkoutId: checkoutIds.encoded.beginsWithLetter,
           lineItems: newCartItems
         }
       })
@@ -258,7 +258,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         note: 'Happy Birthday!'
       })
     ).rejects.toThrow(networkErrorMessage);
@@ -267,7 +267,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         lineItems: newCartItems
       })
     ).rejects.toThrow(networkErrorMessage);
@@ -290,7 +290,7 @@ describe('putCheckout', () => {
     );
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       note: noteText
     }).catch((e) => expect(String(e).includes(mockErrorMesssage)).toBe(true));
   });
@@ -315,7 +315,7 @@ describe('putCheckout', () => {
     );
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       note: noteText
     }).catch((e) => expect(String(e).includes(mockErrorMessage)).toBe(true));
   });
@@ -359,7 +359,7 @@ describe('putCheckout', () => {
     );
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       lineItems: newCartItems
     }).catch((e) => expect(String(e).includes(mockErrorMessage)).toBe(true));
   });
@@ -383,7 +383,7 @@ describe('putCheckout', () => {
     );
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       lineItems: newCartItems
     }).catch((e) => expect(String(e).includes(mockErrorMessage)).toBe(true));
   });
@@ -498,7 +498,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         note: 'Happy Birthday!'
       }).catch((e) =>
         expect(String(e).includes(doesNotExistMessage)).toBe(true)
@@ -516,7 +516,7 @@ describe('putCheckout', () => {
     await expect(
       putCheckout({
         gqlClient,
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         lineItems: newCartItems
       }).catch((e) =>
         expect(String(e).includes(doesNotExistMessage)).toBe(true)
@@ -545,7 +545,7 @@ describe('putCheckout', () => {
 
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       note: 'Happy Birthday!'
     }).catch((e) => expect(String(e).includes(problemMessage)).toBe(true));
 
@@ -559,7 +559,7 @@ describe('putCheckout', () => {
 
     await putCheckout({
       gqlClient,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       lineItems: newCartItems
     }).catch((e) => expect(String(e).includes(problemMessage)).toBe(true));
   });

--- a/packages/shopify-checkout/src/client/actions/putCheckout.ts
+++ b/packages/shopify-checkout/src/client/actions/putCheckout.ts
@@ -32,7 +32,7 @@ export default async function putCheckout({
     if (id) {
       if (!isVerifiedCheckoutId(id)) {
         throw new Error(
-          `Invalid checkout ID. Expected a Base64-encoded Shopify Global ID. Received: ${id}`
+          `Invalid checkout ID. Expected a Shopify Global ID. Received: ${id}`
         );
       }
 

--- a/packages/shopify-checkout/src/client/actions/removeDiscount.ts
+++ b/packages/shopify-checkout/src/client/actions/removeDiscount.ts
@@ -33,7 +33,7 @@ export default async function removeDiscount({
   try {
     if (!isVerifiedCheckoutId(id)) {
       throw new Error(
-        `Invalid checkout ID. Expected a Base64-encoded Shopify Global ID. Received: ${id}`
+        `Invalid checkout ID. Expected a Shopify Global ID. Received: ${id}`
       );
     }
 

--- a/packages/shopify-checkout/src/client/client-dom.spec.ts
+++ b/packages/shopify-checkout/src/client/client-dom.spec.ts
@@ -80,7 +80,7 @@ describe('createShopifyCheckoutClient', () => {
         mockJsonResponse<queries.GetCheckoutData>({
           data: {
             node: {
-              id: checkoutIds.beginsWithLetter,
+              id: checkoutIds.encoded.beginsWithLetter,
               webUrl,
               completedAt: null,
               lineItems: { edges: [] },
@@ -94,7 +94,7 @@ describe('createShopifyCheckoutClient', () => {
       checkoutClient.get({ id: '998877' }).then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -122,7 +122,7 @@ describe('createShopifyCheckoutClient', () => {
         mockJsonResponse<queries.GetCheckoutData>({
           data: {
             node: {
-              id: checkoutIds.beginsWithLetter,
+              id: checkoutIds.encoded.beginsWithLetter,
               webUrl: customEndointCheckoutUrl,
               completedAt: null,
               lineItems: { edges: [] },
@@ -136,7 +136,7 @@ describe('createShopifyCheckoutClient', () => {
       checkoutClient.get({ id: '998877' }).then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: customEndointCheckoutUrl,
       lines: [],
       discounts: []
@@ -170,7 +170,7 @@ describe('createShopifyCheckoutClient', () => {
         .then((checkout) => checkout)
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -199,7 +199,7 @@ describe('createShopifyCheckoutClient', () => {
 
     // providing `cartItems` without `metafields` or `note` should only run `checkoutLineItemsReplace`
     const checkoutLineItemsReplace = checkouts.checkoutLineItemsReplace({
-      checkoutId: checkoutIds.beginsWithLetter,
+      checkoutId: checkoutIds.encoded.beginsWithLetter,
       lineItems: cartItemsToCheckoutItems({ cartItems })
     });
 
@@ -210,7 +210,7 @@ describe('createShopifyCheckoutClient', () => {
         )
     );
     await checkoutClient.process({
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       cartItems
     });
 
@@ -221,7 +221,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutLineItemsReplace,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter,
+          checkoutId: checkoutIds.encoded.beginsWithLetter,
           lineItems: cartItemsToCheckoutItems({ cartItems })
         }
       })
@@ -243,7 +243,7 @@ describe('createShopifyCheckoutClient', () => {
     ];
     const note = 'Many thanks!';
     const checkoutUpdate = checkouts.checkoutUpdate({
-      checkoutId: checkoutIds.beginsWithLetter,
+      checkoutId: checkoutIds.encoded.beginsWithLetter,
       input: { customAttributes: checkoutAttributes, note }
     });
 
@@ -253,7 +253,7 @@ describe('createShopifyCheckoutClient', () => {
     );
 
     await checkoutClient.process({
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       metafields: checkoutAttributes,
       note
     });
@@ -265,7 +265,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutAttributesUpdate,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter,
+          checkoutId: checkoutIds.encoded.beginsWithLetter,
           input: {
             customAttributes: checkoutAttributes,
             note
@@ -290,12 +290,12 @@ describe('createShopifyCheckoutClient', () => {
 
     await expect(
       checkoutClient.discountApply({
-        id: checkoutIds.beginsWithLetter,
+        id: checkoutIds.encoded.beginsWithLetter,
         discountCode: 'BFCM2020'
       })
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -307,7 +307,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutDiscountCodeApplyV2,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter,
+          checkoutId: checkoutIds.encoded.beginsWithLetter,
           discountCode: 'BFCM2020'
         }
       })
@@ -329,11 +329,11 @@ describe('createShopifyCheckoutClient', () => {
 
     await expect(
       checkoutClient.discountRemove({
-        id: checkoutIds.beginsWithLetter
+        id: checkoutIds.encoded.beginsWithLetter
       })
     ).resolves.toMatchObject({
       completed: false,
-      id: checkoutIds.beginsWithLetter,
+      id: checkoutIds.encoded.beginsWithLetter,
       url: webUrl,
       lines: [],
       discounts: []
@@ -345,7 +345,7 @@ describe('createShopifyCheckoutClient', () => {
       body: JSON.stringify({
         query: mutations.checkoutDiscountCodeRemove,
         variables: {
-          checkoutId: checkoutIds.beginsWithLetter
+          checkoutId: checkoutIds.encoded.beginsWithLetter
         }
       })
     });

--- a/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.spec.ts
+++ b/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.spec.ts
@@ -3,14 +3,18 @@ import { checkoutIds } from '../../__tests__/mocks';
 
 describe('handleShopifyError', () => {
   it('returns `true` when provided a valid Shopify checkout ID', async () => {
-    expect(isVerifiedCheckoutId(checkoutIds.beginsWithLetter)).toBe(true);
-    expect(isVerifiedCheckoutId(checkoutIds.beginsWithNumber)).toBe(true);
-  });
-
-  it('returns `false` when provided a non-base64 Shopify checkout ID', async () => {
-    expect(
-      isVerifiedCheckoutId('gid://shopify/Checkout/a9b8c7?key=123123')
-    ).toBe(false);
+    expect(isVerifiedCheckoutId(checkoutIds.encoded.beginsWithLetter)).toBe(
+      true
+    );
+    expect(isVerifiedCheckoutId(checkoutIds.encoded.beginsWithNumber)).toBe(
+      true
+    );
+    expect(isVerifiedCheckoutId(checkoutIds.plaintext.beginsWithLetter)).toBe(
+      true
+    );
+    expect(isVerifiedCheckoutId(checkoutIds.plaintext.beginsWithNumber)).toBe(
+      true
+    );
   });
 
   it("returns `false` when provided a base64 string that doesn't correspond to a Shopify checkout ID", async () => {

--- a/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts
+++ b/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts
@@ -1,9 +1,13 @@
 export default function isVerifiedCheckoutId(id: string): boolean {
-  // Shopify CheckoutIds are Base64-encoded urls formatted like:
-  // 'gid://shopify/Checkout/<id>' and therefore must include 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC'
+  // Shopify CheckoutIds are either plaintext or Base64-encoded urls formatted like:
+  // 'gid://shopify/Checkout/<id>'. If they are Base64 encoded, they must include
+  // 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC', which is Base64-encoded 'gid://shopify/Checkout'.
   if (!id?.length) {
     return false;
   }
 
-  return id.includes('Z2lkOi8vc2hvcGlmeS9DaGVja291dC') && id !== '';
+  return (
+    id.includes('Z2lkOi8vc2hvcGlmeS9DaGVja291dC') ||
+    id.includes('gid://shopify/Checkout')
+  );
 }


### PR DESCRIPTION
## Why are these changes introduced?

Fixes [ENG-7943](https://nacelle.atlassian.net/browse/ENG-7943)

> Shopify checkout ID verification doesn't account for plaintext IDs

Shopify [made a change](https://shopify.dev/changelog/improvements-and-changes-coming-to-the-storefront-api) to the Shopify Storefront API that creates a bug in `@nacelle/shopify-checkout`. Previously, Shopify returned base64-encoded global IDs for all nodes (including Checkout nodes).

[Shopify’s description of this change includes](https://shopify.dev/changelog/changes-to-storefront-api-object-ids):

> …when requesting the unstable, 2022-04 release candidate, or future versions of the Storefront API, the object IDs returned will no longer be Base64 encoded.

This change breaks [@nacelle/shopify-checkout's `isVerifiedCheckoutId` utility function](https://github.com/getnacelle/nacelle-js/blob/main/packages/shopify-checkout/src/utils/isVerifiedCheckoutId.ts), which currently expects that all global IDs are Base64-encoded.

This bug flew under the radar because the `starters/*` and `reference-stores/*` projects don't supply an `id` to `checkoutClient.process`. Arguably, they should, when a checkout `id` has been persisted.

## What is this pull request doing?

- Updates the `isVerifiedCheckoutId` utility function to accept either plaintext or base64-encoded checkout IDs.
  - Also updates associated tests & mocks.
- Removes `storefrontApiVersion` language from the README to avoid confusion. This parameter was removed in a previous version of `@nacelle/shopify-checkout`.

## How to Test

First, the basics:

1. Check out the `ENG-7943-shopify-checkout-allow-plaintext-ids` branch.
2. Navigate to `packages/shopify-checkout`
3. `npm run build` - the package should build without issues.
4. `npm run test:ci` - all tests should pass without a decrease in coverage.

Next, I'd recommend taking this change for a spin in one of the Reference Stores. I used the Nuxt Reference Store, and found that:

- [x] checkout creation & updates worked as expected.
- [x] when passing an `id` to `processCheckout`, there were no errors, and `checkoutId` was included in the request.

https://user-images.githubusercontent.com/5732000/203462840-859a4bd9-d0f9-4dc8-acc2-ba8f9a379e48.mov

Here are the steps I followed, in addition to "the basics" described above:

1. Navigate to `reference-stores/nuxt`
2. `npm i @nacelle/shopify-checkout@latest`
3. Navigate back to the monorepo root
4. `npm run bootstrap`
5. Navigate back to  `reference-stores/nuxt`
6. In `reference-stores/nuxt/store/checkout.js`'s `processCheckout` action, add the following after line 45, modify the `checkoutClient.process` call to include the persisted checkout ID:
```js
const checkoutId = await get('checkoutId');
const checkoutData = await checkoutClient.process({
  id: checkoutId,
  cartItems
});
```
7. `npm run dev` and visit [`localhost:3000`](http://localhost:3000)
8. Add an item to the cart
9. Initiate a checkout, but do not complete the checkout
10. Hit the back button to return to [`localhost:3000`](http://localhost:3000)
11. In devtools, check the **Application** tab and inspect the IndexDB store. The `checkoutId` should be a plaintext ID.
12. Add more items to the cart
13. Initiate a checkout. The `checkoutId` should be included in the request payload, and there should be no errors.

## Next steps

While troubleshooting this issue, it became clear that our monorepo versioning setup isn't bumping versions as expected. For example, in https://github.com/getnacelle/nacelle-js/pull/291, the version of `@nacelle/shopify-checkout` was bumped, but it was not bumped in the `"dependencies"` of the various starters & reference stores' `package.json`s.