### PR TITLE
build: prepare shopify cart for 1.0.0 publish

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "contentful-rich-text": "1.0.5",

--- a/.changeset/spindrifts-taste-tasty.md
+++ b/.changeset/spindrifts-taste-tasty.md
@@ -1,0 +1,11 @@
+---
+'@nacelle/shopify-cart': patch
+'nacelle-reference-store-gatsby': patch
+'nacelle-next-reference-store': patch
+'nuxt-reference-store': patch
+'gatsby-starter': patch
+'next-starter': patch
+'nuxt-starter': patch
+---
+
+Update projects to use the latest version of `@nacelle/shopify-cart`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,8 +9,16 @@ body:
       label: Project
       description: Which project is this bug report for?
       options:
+        - 'packages/gatsby-source-nacelle'
+        - 'packages/sanity-plugin-nacelle-input'
+        - 'packages/shopify-cart'
         - 'packages/shopify-checkout'
         - 'packages/vue'
+        - 'reference-stores/gatsby'
+        - 'reference-stores/next'
+        - 'reference-stores/nuxt'
+        - 'starters/gatsby'
+        - 'starters/next'
         - 'starters/nuxt'
     validations:
       required: true
@@ -78,7 +86,7 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: Shell
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,9 +9,11 @@ body:
       label: Project
       description: Which project does this suggestion apply to?
       options:
+        - 'packages/gatsby-source-nacelle'
+        - 'packages/sanity-plugin-nacelle-input'
+        - 'packages/shopify-cart'
         - 'packages/shopify-checkout'
         - 'packages/vue'
-        - 'starters/nuxt'
         - 'Something else :)'
       multiple: true
     validations:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ENG-6843/shopify-cart-1.0.0
     paths:
       - 'packages/**'
 

--- a/packages/shopify-cart/.env.example
+++ b/packages/shopify-cart/.env.example
@@ -1,2 +1,4 @@
+# NOTE: these environment variables are used
+# only for type generation with GraphQL Codegen.
 SHOPIFY_SHOP_ID=""
 SHOPIFY_STOREFRONT_ACCESS_TOKEN=""

--- a/packages/shopify-cart/tsconfig.production.json
+++ b/packages/shopify-cart/tsconfig.production.json
@@ -1,26 +1,5 @@
 {
-  "compilerOptions": {
-    "rootDir": ".",
-    "strict": true,
-    "target": "ES2020",
-    "allowJs": true,
-    "module": "ES2020",
-    "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
-    "isolatedModules": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "declaration": true,
-    "declarationDir": "dist",
-    "emitDeclarationOnly": true,
-    "useDefineForClassFields": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
-  },
+  "extends": "./tsconfig.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "__tests__"]
 }

--- a/reference-stores/gatsby/package.json
+++ b/reference-stores/gatsby/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^15.13.1",
     "@nacelle/gatsby-source-nacelle": "^9.1.0",
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/shopify-checkout": "^0.0.11",
     "@nacelle/storefront-sdk": "^1.5.1",
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/reference-stores/next/package.json
+++ b/reference-stores/next/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^15.11.1",
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/shopify-checkout": "^0.1.0",
     "@nacelle/storefront-sdk": "^1.1.1",
     "fuse.js": "^6.5.3",

--- a/reference-stores/nuxt/package.json
+++ b/reference-stores/nuxt/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^15.11.1",
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/storefront-sdk": "^1.0.3",
     "core-js": "^3.19.3",
     "fuse.js": "^6.5.3",

--- a/starters/gatsby/package.json
+++ b/starters/gatsby/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nacelle/gatsby-source-nacelle": "^9.1.0",
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/storefront-sdk": "^1.1.2",
     "gatsby": "^4.14.0",
     "gatsby-plugin-image": "^2.14.0",

--- a/starters/next/package.json
+++ b/starters/next/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/storefront-sdk": "^1.0.3",
     "idb-keyval": "^6.2.0",
     "next": "^12.3.1",

--- a/starters/nuxt/package.json
+++ b/starters/nuxt/package.json
@@ -12,7 +12,7 @@
     "lintfix": "npm run lint:js -- --fix"
   },
   "dependencies": {
-    "@nacelle/shopify-cart": "^1.0.0-beta.0",
+    "@nacelle/shopify-cart": "^1.0.0-beta.2",
     "@nacelle/storefront-sdk": "^1.0.3",
     "core-js": "^3.19.3",
     "fuse.js": "^6.5.3",


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-8014](https://nacelle.atlassian.net/browse/ENG-8014) / supports #278.

## What is this pull request doing?

- Exits [changesets prerelease mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md).
- Removes [`ENG-6843/shopify-cart-1.0.0`](https://github.com/getnacelle/nacelle-js/tree/ENG-6843/shopify-cart-1.0.0) from the list of branches that `.github/workflows/release.yml` will run on in response to a `push`.
- Updates our GitHub Issues templates to include `packages/shopify-cart` (some other updates were made here...these were quite out-of-date).
- Updates `packages/shopify-cart`'s TypeScript production config to extend the base config. This reduces the number of settings we need to think about and reduces opportunities for configs to become out-of-sync.
- Bumps `@nacelle/shopify-cart` versions to the latest `@beta` version across starters and reference stores.

## How to Test

1. Check out the `ENG-8014-prepare-shopify-cart-for-1.0.0-publish` branch.
2. In the monorepo root, run `npm run version` to preview the changes that changesets will make when #278 is merged. In addition to generating the `1.0.0` changelog for `packages/shopify-cart`, the version of `@nacelle/shopify-cart` in the `package.json`s of the starters and reference stores should be `1.0.0`:

![ENG-8014-prepare-shopify-cart-for-1 0 0-publish branch unstaged changes after npm run version](https://user-images.githubusercontent.com/5732000/207199357-538ec445-53bc-4cdc-a28c-851314f3987a.png)
