### PR TITLE
chore: enables pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,26 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "contentful-rich-text": "1.0.5",
+    "flash-sale": "0.1.1",
+    "next-preview": "0.1.3",
+    "nuxt-2-composition-api": "0.0.18",
+    "@nacelle/nuxt-3-starter-example": "0.0.1",
+    "shopify-accounts": "0.1.1",
+    "svelte-starter": "0.0.2",
+    "@nacelle/gatsby-source-nacelle": "9.1.0",
+    "@nacelle/sanity-plugin-nacelle-input": "0.1.1",
+    "@nacelle/shopify-cart": "1.0.0",
+    "@nacelle/shopify-checkout": "0.1.2",
+    "@nacelle/storefront-sdk": "1.8.0",
+    "@nacelle/vue": "0.0.16",
+    "nacelle-reference-store-gatsby": "1.0.1",
+    "nacelle-next-reference-store": "0.1.4",
+    "nuxt-reference-store": "1.0.6",
+    "gatsby-starter": "0.2.2",
+    "next-starter": "0.1.4",
+    "nuxt-starter": "1.0.8"
+  },
+  "changesets": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ENG-8179/storefront-sdk-2.0
     paths:
       - 'packages/**'
 

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "@nacelle/storefront-sdk-v2",
-	"version": "2.0.0",
+	"name": "@nacelle/storefront-sdk",
+	"version": "1.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@nacelle/storefront-sdk-v2",
-			"version": "2.0.0",
+			"name": "@nacelle/storefront-sdk",
+			"version": "1.8.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
@@ -23,7 +23,7 @@
 				"vitest": "^0.26.1"
 			},
 			"engines": {
-				"node": ">=14.14 <19",
+				"node": ">=16.11",
 				"npm": ">=7"
 			}
 		},

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nacelle/storefront-sdk",
-	"version": "2.0.0",
+	"version": "1.8.0",
 	"type": "module",
 	"author": "Nacelle Inc.",
 	"license": "Apache-2.0",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-8285](https://nacelle.atlassian.net/browse/ENG-8285) - sets up pre-release mode for sdk work <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

- Allows us to publish `2.0.0-beta` releases of the storefront sdk as we engage in work. This will allow us to use it in our regression tests.
- A subsequent PR to `main` will configure the `release` action to run on pushes to this branch, similar to what we did for Shopify Cart

## How to Test

1. Run `npm run changeset version` from the repo root
2. Should have a message about being in pre-release mode
