### PR TITLE
feat: add basic storefront client

### DIFF
--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.0.0-beta.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@urql/core": "^3.1.1",
 				"graphql": "^16.6.0"
 			},
 			"devDependencies": {
@@ -3138,6 +3139,17 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@urql/core": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"dependencies": {
+				"wonka": "^6.1.2"
+			},
+			"peerDependencies": {
+				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
@@ -8715,6 +8727,11 @@
 			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
 			"dev": true
 		},
+		"node_modules/wonka": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+			"integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -11185,6 +11202,14 @@
 			"requires": {
 				"@typescript-eslint/types": "5.47.0",
 				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@urql/core": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"requires": {
+				"wonka": "^6.1.2"
 			}
 		},
 		"@vitest/coverage-c8": {
@@ -15367,6 +15392,11 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
 			"dev": true
+		},
+		"wonka": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
+			"integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -63,6 +63,7 @@
 		"vitest": "^0.26.1"
 	},
 	"dependencies": {
+		"@urql/core": "^3.1.1",
 		"graphql": "^16.6.0"
 	}
 }

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+import { StorefrontClient } from './index.js';
+
+const storefrontEndpoint =
+	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
+
+it('can initialize', () => {
+	expect(() => new StorefrontClient({ storefrontEndpoint })).not.toThrow();
+	const client = new StorefrontClient({ storefrontEndpoint });
+	expect(client).toBeInstanceOf(StorefrontClient);
+});

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -3,10 +3,10 @@ import type { Client as UrqlClient } from '@urql/core';
 import type { StorefrontClientParams } from '../index.js';
 
 export class StorefrontClient {
-	private readonly graphqlClient: UrqlClient;
+	readonly #graphqlClient: UrqlClient;
 
 	constructor(params: StorefrontClientParams) {
-		this.graphqlClient = createClient({
+		this.#graphqlClient = createClient({
 			url: params.storefrontEndpoint,
 			fetch: params.fetchClient ?? globalThis.fetch
 		});
@@ -14,6 +14,6 @@ export class StorefrontClient {
 
 	// NEW METHODS GO HERE :)
 	placeholder() {
-		return this.graphqlClient.query('', {}).toPromise();
+		return this.#graphqlClient.query('', {}).toPromise();
 	}
 }

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@urql/core';
+import type { Client as UrqlClient } from '@urql/core';
+import type { StorefrontClientParams } from '../index.js';
+
+export class StorefrontClient {
+	private readonly graphqlClient: UrqlClient;
+
+	constructor(params: StorefrontClientParams) {
+		this.graphqlClient = createClient({
+			url: params.storefrontEndpoint,
+			fetch: params.fetchClient ?? globalThis.fetch
+		});
+	}
+
+	// NEW METHODS GO HERE :)
+	placeholder() {
+		return this.graphqlClient.query('', {}).toPromise();
+	}
+}

--- a/packages/storefront-sdk/src/index.test.ts
+++ b/packages/storefront-sdk/src/index.test.ts
@@ -1,6 +1,17 @@
 import { expect, it } from 'vitest';
-import placeholder from '.';
+import { Storefront } from './index.js';
+import errorMessages from './utils/errorMessages.js';
+import type { StorefrontClientParams } from './index.js';
 
-it('placeholder test', () => {
-	expect(placeholder()).toEqual({});
+const storefrontEndpoint =
+	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
+
+it('throws an error if the client is initialized without required parameters', () => {
+	expect(() => Storefront({} as StorefrontClientParams)).toThrowError(
+		errorMessages.missingEndpoint
+	);
+});
+
+it('can be correctly initialized when the required parameters are supplied', () => {
+	expect(() => Storefront({ storefrontEndpoint })).not.toThrow();
 });

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,7 +1,18 @@
-function placeholder(): object {
-	console.log('placeholder');
+import { StorefrontClient } from './client/index.js';
+import { errorMessages } from './utils/index.js';
 
-	return {};
+export interface StorefrontClientParams {
+	/** Nacelle Storefront GraphQL Endpoint. This can be retrieved from the Nacelle Dashboard. */
+	storefrontEndpoint: string;
+
+	/** Optional fetch implementation. If not supplied, the Storefront SDK will use `globalThis.fetch`. */
+	fetchClient?: typeof globalThis.fetch;
 }
 
-export default placeholder;
+export function Storefront(params: StorefrontClientParams) {
+	if (!params?.storefrontEndpoint) {
+		throw new Error(errorMessages.missingEndpoint);
+	}
+
+	return new StorefrontClient(params);
+}

--- a/packages/storefront-sdk/src/utils/errorMessages.ts
+++ b/packages/storefront-sdk/src/utils/errorMessages.ts
@@ -1,0 +1,6 @@
+const errorMessages = {
+	missingEndpoint:
+		'@nacelle/storefront-sdk must be initialized with a `storefrontEndpoint`.'
+} as const;
+
+export default errorMessages;

--- a/packages/storefront-sdk/src/utils/index.ts
+++ b/packages/storefront-sdk/src/utils/index.ts
@@ -1,0 +1,9 @@
+// NOTE: @index directives are for the 'Generate Index' VSCode Extension (jayfong.generate-index)
+//  once the 'Generate Index' extension is installed,
+//  open the command palette with Command+Shift+P / Ctrl+Shift+P,
+//  then search for & select 'Generate Index'
+
+// EXPORT UTILS
+// @index('./!(*.spec).ts', (f, _) => `export { default as ${_.camelCase(f.name)} } from '${f.path}.js';`)
+export { default as errorMessages } from './errorMessages.js';
+// @endindex

--- a/packages/storefront-sdk/tsconfig.json
+++ b/packages/storefront-sdk/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"rootDir": ".",
 		"strict": true,
-		"target": "ES2021",
+		"target": "ES2022",
 		"allowJs": true,
 		"lib": ["ESNext", "DOM"],
 		"module": "Node16",

--- a/packages/storefront-sdk/vite.config.ts
+++ b/packages/storefront-sdk/vite.config.ts
@@ -13,7 +13,7 @@ export const config: UserConfig = {
 			name: 'NacelleStorefrontSdk'
 		},
 		sourcemap: true,
-		target: 'es2021'
+		target: 'es2022'
 	},
 	plugins: [],
 	test: {


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-8318](https://nacelle.atlassian.net/browse/ENG-8318)

> Scaffold the createStorefrontClient function and StorefrontClient class

## What is this pull request doing?

This PR adds a basic implementation of the `Storefront` client creation function and a `StorefrontClient` class that encapsulates both the public API and private implementation details.

## How to Test

1. Check out the `ENG-8318-storefront-client-scaffolding` branch.
2. Navigate to `packages/storefront-sdk`.
3. `npm run build` - it should create `dist/nacelle-storefront-sdk.js` and `dist/nacelle-storefront-sdk.umd.cjs` without errors.
4. `npm run coverage` - all tests should pass with 100% coverage.

![Storefront SDK all test passing with 100 percent coverage ENG-8318-storefront-client-scaffolding branch](https://user-images.githubusercontent.com/5732000/210022549-fa8ba1be-a5b1-4df6-96fd-9849655a922e.png)

## Testing checklist

- [x] You can follow your own "How to Test" instructions and get the expected result.