### PR TITLE
feat: add v2 query method using urql

### DIFF
--- a/.changeset/twenty-timers-taste.md
+++ b/.changeset/twenty-timers-taste.md
@@ -1,0 +1,18 @@
+---
+'@nacelle/storefront-sdk': major
+---
+
+Improves the `.query` method.
+
+- Adds support for tagged template literals via the `gql` helper function
+- Adds support for `TypedDocumentNodes` for strongly typed queries/responses. [More info on `TypedDocumentNodes` and how to use them](https://github.com/dotansimha/graphql-typed-document-node#how-to-use).
+- Returns `{data,error}` so errors can be handled in code instead of throwing on errors. For users wanting to get the data directly and throw on response errors, can use an `after` method like this: 
+ ```js
+ sdkClient.after('query', (response)  => {
+    if(response.error) {
+        throw new Error(response)
+    } else {
+        return response.data
+    }
+ })
+ ```

--- a/packages/storefront-sdk/.eslintrc.cjs
+++ b/packages/storefront-sdk/.eslintrc.cjs
@@ -42,6 +42,7 @@ module.exports = {
 		'node_modules',
 		'.prettierrc',
 		'build',
-		'dist'
+		'dist',
+		'coverage'
 	]
 };

--- a/packages/storefront-sdk/__mocks__/gql/navigation.ts
+++ b/packages/storefront-sdk/__mocks__/gql/navigation.ts
@@ -1,0 +1,11 @@
+import type { NavigationQuery } from '../../src/types/storefront.js';
+
+const NavigationResult: NavigationQuery = {
+	navigation: [
+		{
+			groupId: 'group-id'
+		}
+	]
+};
+
+export default NavigationResult;

--- a/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
+++ b/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
@@ -1,0 +1,14 @@
+function getFetchPayload(
+	data: object,
+	responseOptions: { status: number } = {
+		status: 200
+	}
+): Response {
+	const headers = new Headers();
+	headers.append('content-type', 'application/json');
+	return new Response(JSON.stringify({ ...data }), {
+		headers,
+		...responseOptions
+	});
+}
+export default getFetchPayload;

--- a/packages/storefront-sdk/codegen.yml
+++ b/packages/storefront-sdk/codegen.yml
@@ -6,5 +6,6 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+      - typed-document-node
     config:
       enumsAsTypes: true

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -14,8 +14,10 @@
 			},
 			"devDependencies": {
 				"@graphql-codegen/cli": "2.16.1",
+				"@graphql-codegen/typed-document-node": "^2.3.11",
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
+				"@graphql-typed-document-node/core": "^3.1.1",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -1692,12 +1694,12 @@
 			"dev": true
 		},
 		"node_modules/@graphql-codegen/plugin-helpers": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.1.tgz",
-			"integrity": "sha512-+V1WK4DUhejVSbkZrAsyv9gA4oQABVrtEUkT7vWq7gSf7Ln6OEM59lDUDsjp5wpLPTBIDJANbAe3qEd+iCB3Ow==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "^8.8.0",
+				"@graphql-tools/utils": "^9.0.0",
 				"change-case-all": "1.0.15",
 				"common-tags": "1.8.2",
 				"import-from": "4.0.0",
@@ -1706,6 +1708,18 @@
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
@@ -1729,6 +1743,61 @@
 			}
 		},
 		"node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/typed-document-node": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.11.tgz",
+			"integrity": "sha512-+Wab2cBWJFftREy/M/lim6gN61P8Tb5hH5J+tS/UBY6KSya3+vuuTzLPOyvcVguRqFMWQaTGOHONFXRKUmWnwQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^3.1.2",
+				"@graphql-codegen/visitor-plugin-common": "2.13.6",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/visitor-plugin-common": {
+			"version": "2.13.6",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.6.tgz",
+			"integrity": "sha512-jDxbS8CZIu3KPqku1NzkVkCvPy4UUxhmtRz+yyG3W6go/3hq/VG/yx3ljhI7jYT08W9yaFCUzczimS9fM+Qanw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^3.1.2",
+				"@graphql-tools/optimize": "^1.3.0",
+				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
+				"@graphql-tools/utils": "^9.0.0",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"dependency-graph": "^0.11.0",
+				"graphql-tag": "^2.11.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-tools/utils": {
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
@@ -2405,9 +2474,9 @@
 			"dev": true
 		},
 		"node_modules/@graphql-tools/prisma-loader": {
-			"version": "7.2.48",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.48.tgz",
-			"integrity": "sha512-9Opf6E7bOf30BstCWMxwMR7JKQtSTGDtiWLCYtmRBggyZX+bJs6hUguOG+z8jEUxNsFWL6zx5uG4pn8bxpn8iw==",
+			"version": "7.2.49",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.49.tgz",
+			"integrity": "sha512-RIvrEAoKHdR7KaOUQRpZYxFRF+lfxH4MFeErjBA9z/BpL7Iv5QyfIOgFRE8i3E2eToMqDPzEg7RHha2hXBssug==",
 			"dev": true,
 			"dependencies": {
 				"@graphql-tools/url-loader": "7.16.28",
@@ -2424,7 +2493,7 @@
 				"isomorphic-fetch": "^3.0.0",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^8.5.1",
+				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
@@ -6307,9 +6376,9 @@
 			}
 		},
 		"node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -6334,34 +6403,19 @@
 			}
 		},
 		"node_modules/jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+			"integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
 			"dev": true,
 			"dependencies": {
 				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
+				"lodash": "^4.17.21",
 				"ms": "^2.1.1",
-				"semver": "^5.6.0"
+				"semver": "^7.3.8"
 			},
 			"engines": {
-				"node": ">=4",
-				"npm": ">=1.4.28"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
+				"node": ">=12",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/jwa": {
@@ -6464,52 +6518,10 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -9984,12 +9996,12 @@
 			}
 		},
 		"@graphql-codegen/plugin-helpers": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.1.tgz",
-			"integrity": "sha512-+V1WK4DUhejVSbkZrAsyv9gA4oQABVrtEUkT7vWq7gSf7Ln6OEM59lDUDsjp5wpLPTBIDJANbAe3qEd+iCB3Ow==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "^8.8.0",
+				"@graphql-tools/utils": "^9.0.0",
 				"change-case-all": "1.0.15",
 				"common-tags": "1.8.2",
 				"import-from": "4.0.0",
@@ -9997,6 +10009,15 @@
 				"tslib": "~2.4.0"
 			},
 			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.3",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
 				"tslib": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -10016,6 +10037,54 @@
 				"tslib": "~2.4.0"
 			},
 			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+					"dev": true
+				}
+			}
+		},
+		"@graphql-codegen/typed-document-node": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.11.tgz",
+			"integrity": "sha512-+Wab2cBWJFftREy/M/lim6gN61P8Tb5hH5J+tS/UBY6KSya3+vuuTzLPOyvcVguRqFMWQaTGOHONFXRKUmWnwQ==",
+			"dev": true,
+			"requires": {
+				"@graphql-codegen/plugin-helpers": "^3.1.2",
+				"@graphql-codegen/visitor-plugin-common": "2.13.6",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"tslib": "~2.4.0"
+			},
+			"dependencies": {
+				"@graphql-codegen/visitor-plugin-common": {
+					"version": "2.13.6",
+					"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.6.tgz",
+					"integrity": "sha512-jDxbS8CZIu3KPqku1NzkVkCvPy4UUxhmtRz+yyG3W6go/3hq/VG/yx3ljhI7jYT08W9yaFCUzczimS9fM+Qanw==",
+					"dev": true,
+					"requires": {
+						"@graphql-codegen/plugin-helpers": "^3.1.2",
+						"@graphql-tools/optimize": "^1.3.0",
+						"@graphql-tools/relay-operation-optimizer": "^6.5.0",
+						"@graphql-tools/utils": "^9.0.0",
+						"auto-bind": "~4.0.0",
+						"change-case-all": "1.0.15",
+						"dependency-graph": "^0.11.0",
+						"graphql-tag": "^2.11.0",
+						"parse-filepath": "^1.0.2",
+						"tslib": "~2.4.0"
+					}
+				},
+				"@graphql-tools/utils": {
+					"version": "9.1.3",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
+					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
 				"tslib": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -10618,9 +10687,9 @@
 			}
 		},
 		"@graphql-tools/prisma-loader": {
-			"version": "7.2.48",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.48.tgz",
-			"integrity": "sha512-9Opf6E7bOf30BstCWMxwMR7JKQtSTGDtiWLCYtmRBggyZX+bJs6hUguOG+z8jEUxNsFWL6zx5uG4pn8bxpn8iw==",
+			"version": "7.2.49",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.49.tgz",
+			"integrity": "sha512-RIvrEAoKHdR7KaOUQRpZYxFRF+lfxH4MFeErjBA9z/BpL7Iv5QyfIOgFRE8i3E2eToMqDPzEg7RHha2hXBssug==",
 			"dev": true,
 			"requires": {
 				"@graphql-tools/url-loader": "7.16.28",
@@ -10637,7 +10706,7 @@
 				"isomorphic-fetch": "^3.0.0",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^8.5.1",
+				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
@@ -13586,9 +13655,9 @@
 			}
 		},
 		"json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
@@ -13607,29 +13676,15 @@
 			"dev": true
 		},
 		"jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+			"integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
 			"dev": true,
 			"requires": {
 				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
+				"lodash": "^4.17.21",
 				"ms": "^2.1.1",
-				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"semver": "^7.3.8"
 			}
 		},
 		"jwa": {
@@ -13706,52 +13761,10 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
-		"lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"log-symbols": {

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -13,9 +13,7 @@
 		"build": "vite build && tsc --project tsconfig.production.json && mv dist/src dist/types",
 		"preview": "vite preview",
 		"precommit": "lint-staged",
-		"test": "vitest",
-		"coverage": "vitest run --coverage",
-		"codegen": "graphql-codegen-esm --config codegen.yml && prettier --write src/types/storefront.ts",
+		"codegen": "graphql-codegen-esm --config codegen.yml && prettier --write src/types/storefront.ts && eslint src/types/storefront.ts --fix",
 		"lockfile:update": "npm i --package-lock-only"
 	},
 	"homepage": "https://github.com/getnacelle/nacelle-js/tree/main/packages/storefront-sdk#readme",
@@ -47,8 +45,10 @@
 	},
 	"devDependencies": {
 		"@graphql-codegen/cli": "2.16.1",
+		"@graphql-codegen/typed-document-node": "^2.3.11",
 		"@graphql-codegen/typescript": "2.8.5",
 		"@graphql-codegen/typescript-operations": "^2.5.10",
+		"@graphql-typed-document-node/core": "^3.1.1",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",
 		"@vitest/coverage-c8": "^0.26.0",
@@ -65,5 +65,8 @@
 	"dependencies": {
 		"@urql/core": "^3.1.1",
 		"graphql": "^16.6.0"
+	},
+	"volta": {
+		"node": "18.12.1"
 	}
 }

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -13,6 +13,9 @@
 		"build": "vite build && tsc --project tsconfig.production.json && mv dist/src dist/types",
 		"preview": "vite preview",
 		"precommit": "lint-staged",
+		"test": "vitest",
+		"coverage": "vitest typecheck --run && vitest --run",
+		"test:typecheck": "vitest typecheck",
 		"codegen": "graphql-codegen-esm --config codegen.yml && prettier --write src/types/storefront.ts && eslint src/types/storefront.ts --fix",
 		"lockfile:update": "npm i --package-lock-only"
 	},

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -1,11 +1,124 @@
-import { expect, it } from 'vitest';
+import { gql } from '@urql/core';
+import { expect, it, vi, beforeEach, expectTypeOf, describe } from 'vitest';
 import { StorefrontClient } from './index.js';
+import { NavigationDocument } from '../types/storefront.js';
+import getFetchPayload from '../../__mocks__/utils/getFetchPayload.js';
+import NavigationResult from '../../__mocks__/gql/navigation.js';
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
 
-it('can initialize', () => {
-	expect(() => new StorefrontClient({ storefrontEndpoint })).not.toThrow();
-	const client = new StorefrontClient({ storefrontEndpoint });
-	expect(client).toBeInstanceOf(StorefrontClient);
+const mockedFetch = vi.fn();
+type mockRequestArgs = [RequestInfo | URL, RequestInit | undefined];
+const client = new StorefrontClient({
+	storefrontEndpoint: 'http://localhost:5000',
+	fetchClient: mockedFetch as (
+		input: RequestInfo | URL,
+		init?: RequestInit | undefined
+	) => Promise<Response>
+});
+
+describe('create client', () => {
+	it('can initialize', () => {
+		expect(() => new StorefrontClient({ storefrontEndpoint })).not.toThrow();
+		const client = new StorefrontClient({ storefrontEndpoint });
+		expect(client).toBeInstanceOf(StorefrontClient);
+	});
+});
+
+describe('query', () => {
+	beforeEach(() => mockedFetch.mockRestore());
+
+	it('can use a string for a query', async () => {
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }))
+		);
+		const query = '{query {allContent {id}}}';
+		const response = await client.query({ query });
+		expect(response).toBeTruthy();
+		expect(response.data).toBeTruthy();
+		expect(response.error).toBeFalsy();
+		expect(mockedFetch).toHaveBeenCalledOnce();
+	});
+
+	it('can take a gql tagged template literal for a query', async () => {
+		mockedFetch.mockImplementation(() => {
+			return Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }));
+		});
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const result = await client.query({ query });
+		expect(result).toBeTruthy();
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const { data, error } = result;
+		expect(data).toBeTruthy();
+		expect(error).toBeFalsy();
+		expect(mockedFetch).toHaveBeenCalledOnce();
+	});
+
+	it('can use TypedDocumentNodes', async () => {
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const variables = { filter: { groupId: 'abc' } };
+		const result = await client.query({
+			query: NavigationDocument,
+			variables
+		});
+
+		const { data, error } = result;
+
+		expect(data).toBeTruthy();
+		expect(error).toBeFalsy();
+		expectTypeOf(data!).toMatchTypeOf(NavigationResult);
+	});
+
+	it('takes a stringified object for variables', async () => {
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const variables = JSON.stringify({ test: 'hi' });
+		const result = await client.query({ query, variables });
+		expect(result.data).toBeTruthy();
+		expect(result.error).toBeFalsy();
+		expect(
+			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
+				?.toString()
+				.includes(JSON.stringify(variables))
+		).toBeTruthy();
+	});
+
+	it('takes an object for variables', async () => {
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const variables = { test: 'hi' };
+		const result = await client.query({ query, variables });
+		expect(result.data).toBeTruthy();
+		expect(result.error).toBeFalsy();
+		expect(
+			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
+				?.toString()
+				.includes(JSON.stringify(variables))
+		).toBeTruthy();
+	});
 });

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -23,6 +23,7 @@ export class StorefrontClient {
 		});
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	query<QData = any, QVariables extends AnyVariables = any>({
 		query,
 		variables

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -34,6 +34,6 @@ export class StorefrontClient {
 		return this.#graphqlClient
 			.query(query, variables as QVariables)
 			.toPromise()
-			.then((res) => ({ data: res.data, error: res.error }));
+			.then(({ data, error }) => ({ data, error }));
 	}
 }

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,6 +1,17 @@
 import { createClient } from '@urql/core';
-import type { Client as UrqlClient } from '@urql/core';
+import type {
+	Client as UrqlClient,
+	TypedDocumentNode,
+	AnyVariables,
+	CombinedError
+} from '@urql/core';
+import type { DocumentNode } from 'graphql';
 import type { StorefrontClientParams } from '../index.js';
+
+export interface StorefrontResponse<QueryDocumentType> {
+	error?: CombinedError;
+	data?: QueryDocumentType;
+}
 
 export class StorefrontClient {
 	readonly #graphqlClient: UrqlClient;
@@ -12,8 +23,16 @@ export class StorefrontClient {
 		});
 	}
 
-	// NEW METHODS GO HERE :)
-	placeholder() {
-		return this.#graphqlClient.query('', {}).toPromise();
+	query<QData = any, QVariables extends AnyVariables = any>({
+		query,
+		variables
+	}: {
+		query: TypedDocumentNode<QData, QVariables> | DocumentNode | string;
+		variables?: QVariables | string;
+	}): Promise<StorefrontResponse<QData>> {
+		return this.#graphqlClient
+			.query(query, variables as QVariables)
+			.toPromise()
+			.then((res) => ({ data: res.data, error: res.error }));
 	}
 }

--- a/packages/storefront-sdk/src/types/storefront.ts
+++ b/packages/storefront-sdk/src/types/storefront.ts
@@ -1,3 +1,4 @@
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -913,3 +914,183 @@ export type NavigationQuery = {
 		}> | null;
 	}>;
 };
+
+export const NavigationItem_NavigationItemFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NavigationItem_navigationItem' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'NavigationGroupItem' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'url' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'properties' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					}
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<NavigationItem_NavigationItemFragment, unknown>;
+export const NavigationDocument = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'OperationDefinition',
+			operation: 'query',
+			name: { kind: 'Name', value: 'Navigation' },
+			variableDefinitions: [
+				{
+					kind: 'VariableDefinition',
+					variable: {
+						kind: 'Variable',
+						name: { kind: 'Name', value: 'filter' }
+					},
+					type: {
+						kind: 'NamedType',
+						name: { kind: 'Name', value: 'NavigationFilterInput' }
+					}
+				}
+			],
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'navigation' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'filter' },
+								value: {
+									kind: 'Variable',
+									name: { kind: 'Name', value: 'filter' }
+								}
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'groupId' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'updatedBy' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'items' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'FragmentSpread',
+												name: {
+													kind: 'Name',
+													value: 'NavigationItem_navigationItem'
+												}
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'items' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{
+															kind: 'FragmentSpread',
+															name: {
+																kind: 'Name',
+																value: 'NavigationItem_navigationItem'
+															}
+														},
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'items' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{
+																		kind: 'FragmentSpread',
+																		name: {
+																			kind: 'Name',
+																			value: 'NavigationItem_navigationItem'
+																		}
+																	},
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'items' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{
+																					kind: 'FragmentSpread',
+																					name: {
+																						kind: 'Name',
+																						value:
+																							'NavigationItem_navigationItem'
+																					}
+																				},
+																				{
+																					kind: 'Field',
+																					name: {
+																						kind: 'Name',
+																						value: 'items'
+																					},
+																					selectionSet: {
+																						kind: 'SelectionSet',
+																						selections: [
+																							{
+																								kind: 'FragmentSpread',
+																								name: {
+																									kind: 'Name',
+																									value:
+																										'NavigationItem_navigationItem'
+																								}
+																							}
+																						]
+																					}
+																				}
+																			]
+																		}
+																	}
+																]
+															}
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		...NavigationItem_NavigationItemFragmentDoc.definitions
+	]
+} as unknown as DocumentNode<NavigationQuery, NavigationQueryVariables>;

--- a/packages/storefront-sdk/tsconfig.json
+++ b/packages/storefront-sdk/tsconfig.json
@@ -21,6 +21,6 @@
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true
 	},
-	"include": ["src", "vite.config.ts"],
+	"include": ["**/*.ts", "vite.config.ts"],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/storefront-sdk/vite.config.ts
+++ b/packages/storefront-sdk/vite.config.ts
@@ -23,7 +23,10 @@ export const config: UserConfig = {
 			reportsDirectory: 'coverage',
 			reporter: ['text', 'lcov']
 		},
-		environment: 'jsdom'
+		environment: 'jsdom',
+		typecheck: {
+			include: ['**/*.test.ts']
+		}
 	}
 };
 


### PR DESCRIPTION
- feat: configure typed-document-node generation
- test: configure vitest typechecking
- test: configure request mocks
- feat: adds v2 query method
- docs: adds changeset for query method changes

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## WHY are these changes introduced?

Addresses [ENG-8327](https://nacelle.atlassian.net/browse/ENG-8327) - Adds the `.query` method to the v2 of the storefront-sdk. <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## WHAT is this pull request doing?

1. Adds support for TypedDocumentNodes so we can get typed query responses & users can get typed responses. Updates `codegen` to generate the typed queries from any queries we include in the sdk's `src/graphql/` folder.
2. Initializes the `query` method of the v2 sdk. Note that unlike v1, we return `{data, error}` from the method so that users can handle errors without needing to use `catch`. This is a breaking change between v1 and v2.
3. Adds infrastructure for mocking Requests including a mocked Navigation response.
4. Sets up vitest's test type checking & runs it as part of the `coverage` command. This stops us from being able to use dynamic tests like `each`, but lets us validate types in our tests.
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
## How to Test

1. Checkout this branch `mdarrik/ENG-8327-add-sdk-v2-query-method`
2. Make sure you're using Node 18 (new tests rely on )
3. Install dependencies by running `npm run bootstrap` at the root of the repo (there were dependency changes with this PR)
4. Run the tests with `npm run coverage` - the typechecking test and the coverage test should both pass
5. Build the package by running `npm run build`, should succeed
6. Test the new `coverage`
7. Test the `.query` method by running either the node repl `node` or using `npm link` and then `npm link @nacelle/storefront-sdk` and using the method in another npm project. Can use the [TypedDocumentNode instructions](https://github.com/dotansimha/graphql-typed-document-node#how-to-use) to generate typed queries/responses.

[ENG-8327]: https://nacelle.atlassian.net/browse/ENG-8327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-8327]: https://nacelle.atlassian.net/browse/ENG-8327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-8327]: https://nacelle.atlassian.net/browse/ENG-8327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ