### PR TITLE
feat: implement the `after` method

### DIFF
--- a/.changeset/sour-rivers-jam.md
+++ b/.changeset/sour-rivers-jam.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': minor
+---
+
+The `.after` method offers callback deletion and an improved TypeScript experience. Callbacks can now be registered with a `callbackId`. To delete a callback, provide `null` as the callback value, along with the `callbackId` of the callback you'd like to delete. In TypeScript projects, the `.after` method's `method` argument provides autocomplete with all of the possible values. After specifying the `method`, the `.after` method's `callback` argument is aware of the type signature that's specific to the `method` of interest.

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -29,7 +29,7 @@
 				"prettier": "2.8.1",
 				"typescript": "^4.9.3",
 				"vite": "^4.0.2",
-				"vitest": "^0.26.1"
+				"vitest": "^0.26.3"
 			},
 			"engines": {
 				"node": ">=16.11",
@@ -8565,9 +8565,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.1.tgz",
-			"integrity": "sha512-5FJSKZZJz48zFRKHE55WyevZe61hLMQEsqGn+ungfd60kxEztFybZ3yG9ToGFtOWNCCy7Vn5EVuXD8bdeHOSdw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
+			"integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",
@@ -8588,9 +8588,9 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.1.tgz",
-			"integrity": "sha512-qTLRnjYmjmJpHlLUtErxtlRqGCe8WItFhGXKklpWivu7CLP9KXN9iTezROe+vf51Kb+BB/fzxK6fUG9DvFGL5Q==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
+			"integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
 			"dev": true,
 			"dependencies": {
 				"@types/chai": "^4.3.4",
@@ -8607,7 +8607,7 @@
 				"tinypool": "^0.3.0",
 				"tinyspy": "^1.0.2",
 				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.26.1"
+				"vite-node": "0.26.3"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
@@ -15284,9 +15284,9 @@
 			}
 		},
 		"vite-node": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.1.tgz",
-			"integrity": "sha512-5FJSKZZJz48zFRKHE55WyevZe61hLMQEsqGn+ungfd60kxEztFybZ3yG9ToGFtOWNCCy7Vn5EVuXD8bdeHOSdw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
+			"integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.3.4",
@@ -15298,9 +15298,9 @@
 			}
 		},
 		"vitest": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.1.tgz",
-			"integrity": "sha512-qTLRnjYmjmJpHlLUtErxtlRqGCe8WItFhGXKklpWivu7CLP9KXN9iTezROe+vf51Kb+BB/fzxK6fUG9DvFGL5Q==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
+			"integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
 			"dev": true,
 			"requires": {
 				"@types/chai": "^4.3.4",
@@ -15317,7 +15317,7 @@
 				"tinypool": "^0.3.0",
 				"tinyspy": "^1.0.2",
 				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.26.1"
+				"vite-node": "0.26.3"
 			}
 		},
 		"wcwidth": {

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -63,7 +63,7 @@
 		"prettier": "2.8.1",
 		"typescript": "^4.9.3",
 		"vite": "^4.0.2",
-		"vitest": "^0.26.1"
+		"vitest": "^0.26.3"
 	},
 	"dependencies": {
 		"@urql/core": "^3.1.1",

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -1,9 +1,24 @@
 import { gql } from '@urql/core';
-import { expect, it, vi, beforeEach, expectTypeOf, describe } from 'vitest';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	expectTypeOf,
+	it,
+	vi
+} from 'vitest';
 import { StorefrontClient } from './index.js';
 import { NavigationDocument } from '../types/storefront.js';
 import getFetchPayload from '../../__mocks__/utils/getFetchPayload.js';
 import NavigationResult from '../../__mocks__/gql/navigation.js';
+import { errorMessages, isProductArray } from '../utils/index.js';
+import type {
+	NavigationGroup,
+	Product,
+	ProductEdge,
+	SpaceProperties
+} from '../types/storefront.js';
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
@@ -120,5 +135,175 @@ describe('query', () => {
 				?.toString()
 				.includes(JSON.stringify(variables))
 		).toBeTruthy();
+	});
+});
+
+describe('the `after` method', () => {
+	let client = new StorefrontClient({ storefrontEndpoint });
+
+	afterEach(() => {
+		client = new StorefrontClient({ storefrontEndpoint });
+	});
+
+	it('exists on the client instance', () => {
+		expect(typeof client.after).toBe('function');
+	});
+
+	it('throws the expected error when an invalid `method` is supplied', () => {
+		expect(() =>
+			client.after('spaceProperties', (x: SpaceProperties) => x)
+		).not.toThrow();
+
+		const notQuiteSpaceProperties = 'spåçe prøpertîés';
+		expect(() =>
+			client.after(
+				notQuiteSpaceProperties as 'spaceProperties',
+				(x: SpaceProperties) => x
+			)
+		).toThrowError(errorMessages.afterMethodInvalid(notQuiteSpaceProperties));
+	});
+
+	it('throws the expected error when an invalid `callback` is supplied', () => {
+		const validCallback = (x: SpaceProperties) => x;
+		const notCallback = { message: '🙀' };
+
+		expect(() =>
+			client.after(
+				'spaceProperties',
+				notCallback as unknown as typeof validCallback
+			)
+		).toThrowError(errorMessages.afterMethodCallbackInvalid(notCallback));
+	});
+
+	it('throws the expected error when an invalid `callbackId` is supplied', () => {
+		expect(() =>
+			client.after(
+				'spaceProperties',
+				(x: SpaceProperties) => x,
+				true as unknown as string
+			)
+		).toThrowError(errorMessages.afterMethodCallbackIdInvalid(true));
+	});
+
+	it('adds a callback to `this.#afterSubscriptions`', () => {
+		const callback = (x: SpaceProperties) => x;
+		client.after('spaceProperties', callback);
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			spaceProperties: {
+				'spaceProperties::0': callback
+			}
+		});
+	});
+
+	it('allows callbacks to operate on arrays of data without type assertions', () => {
+		// NOTE: The noteable exception to "without type assertions" is when the
+		// method is capable of returning more than one type, as is the case for
+		// the `.products`, `.content`, etc. methods. To avoid errors when their
+		// `.after` callbacks run, users will need to either stick  to a single
+		// format (either edges or nodes) or write their `.after` callbacks to be
+		// capable of dealing with either edges or nodes.
+		const navigationCallback = (navigation: NavigationGroup[]) => {
+			return navigation.map((group, idx) => ({
+				...group,
+				groupId: `group ${idx}`
+			}));
+		};
+
+		client.after('navigation', navigationCallback);
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			navigation: {
+				'navigation::0': navigationCallback
+			}
+		});
+	});
+
+	it('registers a callback with the provided `callbackId`', () => {
+		const callback = (x: SpaceProperties) => x;
+		client.after('spaceProperties', callback, 'mySpacePropertiesCallback');
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			spaceProperties: {
+				mySpacePropertiesCallback: callback
+			}
+		});
+	});
+
+	it('rewrites callbacks when supplied an already-registered combination of `method` + `callbackId`', () => {
+		const callbackA = (
+			input: Product[] | ProductEdge[]
+		): Product[] | ProductEdge[] => input;
+		const callbackB = (
+			input: Product[] | ProductEdge[]
+		): Product[] | ProductEdge[] => {
+			if (isProductArray(input)) {
+				return input.map((product) => ({
+					...product,
+					tags: ['On Sale']
+				}));
+			}
+
+			return input.map((edge) => ({
+				...edge,
+				node: {
+					...edge.node,
+					tags: ['On Sale']
+				}
+			}));
+		};
+		client.after('products', callbackA, 'cb');
+		client.after('productCollectionEntries', callbackA, 'cb');
+		client.after('products', callbackB, 'cb');
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			products: {
+				cb: callbackB
+			},
+			productCollectionEntries: {
+				cb: callbackA
+			}
+		});
+	});
+
+	it('deletes callbacks by `callbackId` when a `null` value is supplied as the `callback`', () => {
+		const callback = <T>(x: T) => x;
+		client.after('navigation', callback, 'temporary-callback');
+		client.after('navigation', callback, 'persistent-callback');
+		client.after('spaceProperties', callback, 'persistent-callback');
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			navigation: {
+				'temporary-callback': callback,
+				'persistent-callback': callback
+			},
+			spaceProperties: {
+				'persistent-callback': callback
+			}
+		});
+
+		client.after('navigation', null, 'temporary-callback');
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			navigation: {
+				'persistent-callback': callback
+			},
+			spaceProperties: {
+				'persistent-callback': callback
+			}
+		});
+	});
+
+	it('does not allow `this.#afterSubscriptions` to be mutated outside of the `after` method', () => {
+		expect(() => {
+			(
+				client as { afterSubscriptions: typeof client.afterSubscriptions }
+			).afterSubscriptions = {
+				spaceProperties: {
+					// eslint-disable-next-line @typescript-eslint/no-unused-vars
+					'nefarious-callback': <T>(_x: T) => '🥸' as unknown as T
+				}
+			};
+		}).toThrow();
 	});
 });

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -13,6 +13,8 @@ import { NavigationDocument } from '../types/storefront.js';
 import getFetchPayload from '../../__mocks__/utils/getFetchPayload.js';
 import NavigationResult from '../../__mocks__/gql/navigation.js';
 import { errorMessages, isProductArray } from '../utils/index.js';
+import type { StorefrontResponse } from './index.js';
+import type { AfterCallback } from '../types/after.js';
 import type {
 	NavigationGroup,
 	Product,
@@ -38,103 +40,6 @@ describe('create client', () => {
 		expect(() => new StorefrontClient({ storefrontEndpoint })).not.toThrow();
 		const client = new StorefrontClient({ storefrontEndpoint });
 		expect(client).toBeInstanceOf(StorefrontClient);
-	});
-});
-
-describe('query', () => {
-	beforeEach(() => mockedFetch.mockRestore());
-
-	it('can use a string for a query', async () => {
-		mockedFetch.mockImplementation(() =>
-			Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }))
-		);
-		const query = '{query {allContent {id}}}';
-		const response = await client.query({ query });
-		expect(response).toBeTruthy();
-		expect(response.data).toBeTruthy();
-		expect(response.error).toBeFalsy();
-		expect(mockedFetch).toHaveBeenCalledOnce();
-	});
-
-	it('can take a gql tagged template literal for a query', async () => {
-		mockedFetch.mockImplementation(() => {
-			return Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }));
-		});
-		const query = gql`
-			query allContent {
-				allContent {
-					id
-				}
-			}
-		`;
-		const result = await client.query({ query });
-		expect(result).toBeTruthy();
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const { data, error } = result;
-		expect(data).toBeTruthy();
-		expect(error).toBeFalsy();
-		expect(mockedFetch).toHaveBeenCalledOnce();
-	});
-
-	it('can use TypedDocumentNodes', async () => {
-		mockedFetch.mockImplementation(() =>
-			Promise.resolve(getFetchPayload({ data: NavigationResult }))
-		);
-		const variables = { filter: { groupId: 'abc' } };
-		const result = await client.query({
-			query: NavigationDocument,
-			variables
-		});
-
-		const { data, error } = result;
-
-		expect(data).toBeTruthy();
-		expect(error).toBeFalsy();
-		expectTypeOf(data!).toMatchTypeOf(NavigationResult);
-	});
-
-	it('takes a stringified object for variables', async () => {
-		mockedFetch.mockImplementation(() =>
-			Promise.resolve(getFetchPayload({ data: NavigationResult }))
-		);
-		const query = gql`
-			query allContent {
-				allContent {
-					id
-				}
-			}
-		`;
-		const variables = JSON.stringify({ test: 'hi' });
-		const result = await client.query({ query, variables });
-		expect(result.data).toBeTruthy();
-		expect(result.error).toBeFalsy();
-		expect(
-			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
-				?.toString()
-				.includes(JSON.stringify(variables))
-		).toBeTruthy();
-	});
-
-	it('takes an object for variables', async () => {
-		mockedFetch.mockImplementation(() =>
-			Promise.resolve(getFetchPayload({ data: NavigationResult }))
-		);
-		const query = gql`
-			query allContent {
-				allContent {
-					id
-				}
-			}
-		`;
-		const variables = { test: 'hi' };
-		const result = await client.query({ query, variables });
-		expect(result.data).toBeTruthy();
-		expect(result.error).toBeFalsy();
-		expect(
-			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
-				?.toString()
-				.includes(JSON.stringify(variables))
-		).toBeTruthy();
 	});
 });
 
@@ -305,5 +210,217 @@ describe('the `after` method', () => {
 				}
 			};
 		}).toThrow();
+	});
+});
+
+describe('the `query` method', () => {
+	beforeEach(() => mockedFetch.mockRestore());
+
+	it('can use a string for a query', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }))
+		);
+		const query = '{ query { allContent { id } } }';
+		const response = await client.query({ query });
+		expect(response).toBeTruthy();
+		expect(response.data).toBeTruthy();
+		expect(response.error).toBeFalsy();
+		expect(mockedFetch).toHaveBeenCalledOnce();
+	});
+
+	it('can take a gql tagged template literal for a query', async () => {
+		mockedFetch.mockImplementationOnce(() => {
+			return Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }));
+		});
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const result = await client.query({ query });
+		expect(result).toBeTruthy();
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const { data, error } = result;
+		expect(data).toBeTruthy();
+		expect(error).toBeFalsy();
+		expect(mockedFetch).toHaveBeenCalledOnce();
+	});
+
+	it('can use TypedDocumentNodes', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const variables = { filter: { groupId: 'abc' } };
+		const result = await client.query({
+			query: NavigationDocument,
+			variables
+		});
+
+		const { data, error } = result;
+
+		expect(data).toBeTruthy();
+		expect(error).toBeFalsy();
+		expectTypeOf(data!).toMatchTypeOf(NavigationResult);
+	});
+
+	it('takes a stringified object for variables', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const variables = JSON.stringify({ test: 'hi' });
+		const result = await client.query({ query, variables });
+		expect(result.data).toBeTruthy();
+		expect(result.error).toBeFalsy();
+		expect(
+			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
+				?.toString()
+				.includes(JSON.stringify(variables))
+		).toBeTruthy();
+	});
+
+	it('takes an object for variables', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+		const query = gql`
+			query allContent {
+				allContent {
+					id
+				}
+			}
+		`;
+		const variables = { test: 'hi' };
+		const result = await client.query({ query, variables });
+		expect(result.data).toBeTruthy();
+		expect(result.error).toBeFalsy();
+		expect(
+			(mockedFetch.mock.lastCall as mockRequestArgs)[1]?.body
+				?.toString()
+				.includes(JSON.stringify(variables))
+		).toBeTruthy();
+	});
+
+	it('applies callbacks registered with the `.after` method', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload({ data: NavigationResult }))
+		);
+
+		const queryCallback = vi.fn(
+			(response: StorefrontResponse<{ navigation: NavigationGroup[] }>) => {
+				return {
+					...response,
+					data: {
+						...response.data,
+						navigation: {
+							...response.data?.navigation.map((navGroup) => ({
+								...navGroup,
+								groupId: 'new-group-id'
+							}))
+						}
+					}
+				};
+			}
+		);
+
+		client.after(
+			'query',
+			queryCallback as AfterCallback<
+				StorefrontResponse<{ navigation: NavigationGroup[] }>
+			>
+		);
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			query: {
+				'query::0': queryCallback
+			}
+		});
+
+		const query = gql`
+			query allContent {
+				navigation {
+					groupId
+				}
+			}
+		`;
+
+		const { data } = await client.query<{ navigation: NavigationGroup[] }>({
+			query
+		});
+
+		expect(data?.navigation[0]).toStrictEqual({ groupId: 'new-group-id' });
+
+		// cleanup
+		client.after('query', null, 'query::0');
+	});
+
+	it('can support legacy error handling with `.after`', async () => {
+		client.after('query', null, 'query::0');
+		const errorMessage = 'Not enough complexity points available.';
+
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(
+				getFetchPayload({
+					errors: [
+						{
+							message: errorMessage,
+							path: ['allContent'],
+							extensions: {
+								requestedQueryCost: 1000,
+								throttleStatus: {
+									totalCapacity: 10000,
+									currentCapacity: 0,
+									emptyRate: 17
+								},
+								code: 'COMPLEXITY_ERROR',
+								nacelleErrorId: 'Root=1-631bd95c-56b459876e5466fc16ef20c5'
+							}
+						}
+					]
+				})
+			)
+		);
+
+		const queryCallback = vi.fn((response: StorefrontResponse<unknown>) => {
+			if (response.error) {
+				throw new Error(response.error.message);
+			}
+
+			return response.data;
+		});
+
+		client.after(
+			'query',
+			queryCallback as AfterCallback<StorefrontResponse<unknown>>
+		);
+
+		expect(client.afterSubscriptions).toStrictEqual({
+			query: {
+				'query::0': queryCallback
+			}
+		});
+
+		const query = gql`
+			query allContent {
+				allContent {
+					edges {
+						cursor
+					}
+				}
+			}
+		`;
+
+		await expect(client.query({ query })).rejects.toThrow(errorMessage);
+
+		// cleanup
+		client.after('query', null, 'query::0');
 	});
 });

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -15,11 +15,18 @@ import type {
 	DataFetchingMethodName,
 	MethodData
 } from '../types/after.js';
-import type { Content } from '../types/storefront.js';
 
 export interface StorefrontResponse<QueryDocumentType> {
 	error?: CombinedError;
 	data?: QueryDocumentType;
+}
+
+export interface QueryParams<QData, QVariables extends AnyVariables> {
+	/** GraphQL query */
+	query: TypedDocumentNode<QData, QVariables> | DocumentNode | string;
+
+	/** GraphQL query variables */
+	variables?: QVariables | string;
 }
 
 export class StorefrontClient {
@@ -121,14 +128,10 @@ export class StorefrontClient {
 	query<QData = any, QVariables extends AnyVariables = any>({
 		query,
 		variables
-	}: {
-		query: TypedDocumentNode<QData, QVariables> | DocumentNode | string;
-		variables?: QVariables | string;
-	}): Promise<StorefrontResponse<QData>> {
+	}: QueryParams<QData, QVariables>): Promise<StorefrontResponse<QData>> {
 		return this.#graphqlClient
 			.query(query, variables as QVariables)
 			.toPromise()
-			.then(({ data, error }) => ({ data, error }));
+			.then(({ data, error }) => this.applyAfter('query', { data, error }));
 	}
-	/* c8 ignore stop */
 }

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@urql/core';
+import { errorMessages, dataFetchingMethods } from '../utils/index.js';
 import type {
 	Client as UrqlClient,
 	TypedDocumentNode,
@@ -7,6 +8,14 @@ import type {
 } from '@urql/core';
 import type { DocumentNode } from 'graphql';
 import type { StorefrontClientParams } from '../index.js';
+import type {
+	AfterCallback,
+	AfterCallbackWithId,
+	AfterSubscriptions,
+	DataFetchingMethodName,
+	MethodData
+} from '../types/after.js';
+import type { Content } from '../types/storefront.js';
 
 export interface StorefrontResponse<QueryDocumentType> {
 	error?: CombinedError;
@@ -15,12 +24,97 @@ export interface StorefrontResponse<QueryDocumentType> {
 
 export class StorefrontClient {
 	readonly #graphqlClient: UrqlClient;
+	readonly #afterSubscriptions: AfterSubscriptions<DataFetchingMethodName>;
 
 	constructor(params: StorefrontClientParams) {
 		this.#graphqlClient = createClient({
 			url: params.storefrontEndpoint,
 			fetch: params.fetchClient ?? globalThis.fetch
 		});
+		this.#afterSubscriptions = {};
+	}
+
+	/**
+	 * TODO: Remove this and refactor `.after` tests once the `.getConfig` method is available.
+	 * Once we have access to `.getConfig`, we can just:
+	 * ```
+	 * const { afterSubscriptions } = client.getConfig();
+	 * ```
+	 */
+	get afterSubscriptions() {
+		return this.#afterSubscriptions;
+	}
+
+	/**
+	 * Register a callback function that gets applied to the return value of a data-fetching method. When a callback is registered, it is applied every time the data-fetching method runs.
+	 * @param method The method to apply the `callback` to. Possible values: `'content'`, `'navigation'`, `'products'`, `'productCollections'`, `'productCollectionEntries'`, `'query'`, and `'spaceProperties'`.
+	 * @param callback The callback that gets applied to the data returned by the `method` of interest.
+	 * @param callbackId Optional ID. If not provided, an ID will be assigned. A `callback` will be overwritten if a new `callback` is registered to the same `method` with the same `callbackId`.
+	 */
+	after<MethodName extends DataFetchingMethodName>(
+		method: MethodName,
+		callback: AfterCallback<MethodData[MethodName]> | null,
+		callbackId?: string
+	) {
+		if (!dataFetchingMethods.includes(method)) {
+			throw new Error(errorMessages.afterMethodInvalid(method));
+		}
+
+		if (
+			typeof callback === 'undefined' ||
+			(typeof callback !== 'function' && callback !== null)
+		) {
+			throw new Error(errorMessages.afterMethodCallbackInvalid(callback));
+		}
+
+		if (typeof callbackId !== 'undefined' && typeof callbackId !== 'string') {
+			throw new Error(errorMessages.afterMethodCallbackIdInvalid(callbackId));
+		}
+
+		let methodSubscriptions = this.#afterSubscriptions[method];
+
+		if (typeof methodSubscriptions === 'undefined') {
+			methodSubscriptions = this.#afterSubscriptions[method] = {};
+		}
+
+		const id =
+			callbackId ?? `${method}::${Object.values(methodSubscriptions).length}`;
+
+		if (typeof callback === 'function') {
+			(methodSubscriptions as unknown as AfterCallbackWithId<MethodName>)[id] =
+				callback;
+		} else if (callback === null) {
+			delete methodSubscriptions[id];
+		}
+	}
+
+	/**
+	 * Apply the `afterSubscriptions` to a method of interest.
+	 * @param method The method of interest. Possible values: `'content'`, `'navigation'`, `'products'`, `'productCollections'`, `'productCollectionEntries'`, `'query'`, and `'spaceProperties'`.
+	 * @param response The data returned by the method of interest.
+	 * @returns Data that has possibly been transformed by the callback functions registered to the method of interest.
+	 *
+	 * @example
+	 * const navigationData = await this.query({ query: navigationQuery });
+	 * const navigationDataResult = await this.applyAfter('navigation', navigationData);
+	 */
+	private async applyAfter<
+		M extends DataFetchingMethodName,
+		T extends MethodData[M]
+	>(method: M, response: T): Promise<T> {
+		const subscriptionsForMethod = this.#afterSubscriptions[method];
+
+		if (typeof subscriptionsForMethod === 'undefined') {
+			return response;
+		}
+
+		let result = response;
+
+		for (const callback of Object.values(subscriptionsForMethod)) {
+			result = (await callback(result)) as T;
+		}
+
+		return result;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,4 +130,5 @@ export class StorefrontClient {
 			.toPromise()
 			.then(({ data, error }) => ({ data, error }));
 	}
+	/* c8 ignore stop */
 }

--- a/packages/storefront-sdk/src/index.test.ts
+++ b/packages/storefront-sdk/src/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest';
 import { Storefront } from './index.js';
-import errorMessages from './utils/errorMessages.js';
+import { errorMessages } from './utils/index.js';
 import type { StorefrontClientParams } from './index.js';
 
 const storefrontEndpoint =

--- a/packages/storefront-sdk/src/types/after.ts
+++ b/packages/storefront-sdk/src/types/after.ts
@@ -1,0 +1,37 @@
+import type {
+	SpaceProperties,
+	Product,
+	Content,
+	ContentEdge,
+	NavigationGroup,
+	ProductEdge,
+	ProductCollection,
+	ProductCollectionEdge
+} from './storefront.js';
+import type { dataFetchingMethods } from '../utils/index.js';
+
+export type DataFetchingMethodName = typeof dataFetchingMethods[number];
+
+export type AfterCallback<T> = (responseObj: T) => Promise<T> | T;
+
+export type MethodData = {
+	products: Product[] | ProductEdge[];
+	productCollections: ProductCollection[] | ProductCollectionEdge[];
+	productCollectionEntries: Product[] | ProductEdge[];
+	content: Content[] | ContentEdge[];
+	navigation: NavigationGroup[];
+	spaceProperties: SpaceProperties;
+	query: Record<string, unknown> | Array<Record<string, unknown>>;
+};
+
+export type AfterCallbackWithId<MethodName extends DataFetchingMethodName> = {
+	[id: string]: AfterCallback<MethodData[MethodName]>;
+};
+
+export type MethodCallbacks<MethodName extends DataFetchingMethodName> = Record<
+	MethodName,
+	AfterCallbackWithId<MethodName>
+>;
+
+export type AfterSubscriptions<MethodName extends DataFetchingMethodName> =
+	Partial<Record<MethodName, AfterCallbackWithId<MethodName>>>;

--- a/packages/storefront-sdk/src/types/after.ts
+++ b/packages/storefront-sdk/src/types/after.ts
@@ -9,6 +9,7 @@ import type {
 	ProductCollectionEdge
 } from './storefront.js';
 import type { dataFetchingMethods } from '../utils/index.js';
+import type { StorefrontResponse } from '../client/index.js';
 
 export type DataFetchingMethodName = typeof dataFetchingMethods[number];
 
@@ -21,7 +22,8 @@ export type MethodData = {
 	content: Content[] | ContentEdge[];
 	navigation: NavigationGroup[];
 	spaceProperties: SpaceProperties;
-	query: Record<string, unknown> | Array<Record<string, unknown>>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	query: StorefrontResponse<any>;
 };
 
 export type AfterCallbackWithId<MethodName extends DataFetchingMethodName> = {

--- a/packages/storefront-sdk/src/utils/constants.ts
+++ b/packages/storefront-sdk/src/utils/constants.ts
@@ -1,0 +1,9 @@
+export const dataFetchingMethods = [
+	'content',
+	'navigation',
+	'products',
+	'productCollections',
+	'productCollectionEntries',
+	'query',
+	'spaceProperties'
+] as const;

--- a/packages/storefront-sdk/src/utils/errorMessages.ts
+++ b/packages/storefront-sdk/src/utils/errorMessages.ts
@@ -1,6 +1,40 @@
-const errorMessages = {
-	missingEndpoint:
-		'@nacelle/storefront-sdk must be initialized with a `storefrontEndpoint`.'
-} as const;
+import { dataFetchingMethods } from '../utils/index.js';
 
-export default errorMessages;
+function unexpectedInputMessage(
+	/** The name of the method where the unexpected input was provided */
+	methodName: string,
+
+	/** A quick description of what the expected input is */
+	expectedInputDescription: string,
+
+	/** The actual input that was received */
+	received: unknown
+): string {
+	return `[@nacelle/storefront-sdk|${methodName} method] ${expectedInputDescription}. Received: ${JSON.stringify(
+		received
+	)}.
+	}`;
+}
+
+export const errorMessages = {
+	missingEndpoint:
+		"@nacelle/storefront-sdk must be initialized with a 'storefrontEndpoint'.",
+	afterMethodInvalid: (received: unknown) =>
+		unexpectedInputMessage(
+			'after',
+			`valid 'method' names are: ${dataFetchingMethods.join(', ')}.`,
+			received
+		),
+	afterMethodCallbackIdInvalid: (received: unknown) =>
+		unexpectedInputMessage(
+			'after',
+			'callback IDs are expected to be strings',
+			received
+		),
+	afterMethodCallbackInvalid: (received: unknown) =>
+		unexpectedInputMessage(
+			'after',
+			'provided callbacks are expected to be functions or null',
+			received
+		)
+} as const;

--- a/packages/storefront-sdk/src/utils/identity.ts
+++ b/packages/storefront-sdk/src/utils/identity.ts
@@ -1,0 +1,70 @@
+import type {
+	Content,
+	ContentEdge,
+	NodeEdge,
+	Product,
+	ProductCollection,
+	ProductCollectionEdge,
+	ProductEdge
+} from '../types/storefront.js';
+
+// TODO: Determine if these identity utils should only be used
+// internally (e.g. in tests) or if they are useful enough to
+// justify exporting them in the package bundle. If we export
+// them, we should add unit tests.
+
+/* c8 ignore start */
+const isObject = (input: unknown): input is Record<string, unknown> =>
+	typeof input === 'object' && input !== null && !Array.isArray(input);
+
+export const isContent = (input: unknown): input is Content =>
+	isObject(input) && 'type' in input && 'type' in input && 'handle' in input;
+
+export const isProduct = (input: unknown): input is Product =>
+	isObject(input) &&
+	'variants' in input &&
+	Array.isArray((input as Product).variants);
+
+export const isProductCollection = (
+	input: unknown
+): input is ProductCollection =>
+	isObject(input) &&
+	'productConnection' in input &&
+	isProductEdgeArray((input as ProductCollection).productConnection?.edges);
+
+const isEdge = (input: unknown): input is NodeEdge =>
+	isObject(input) && 'cursor' in input && 'node' in input;
+
+export const isContentEdge = (input: unknown): input is ContentEdge =>
+	isEdge(input) && isContent(input.node);
+
+export const isProductEdge = (input: unknown): input is ProductEdge =>
+	isEdge(input) && isProduct(input.node);
+
+export const isProductCollectionEdge = (
+	input: unknown
+): input is ProductCollectionEdge =>
+	isEdge(input) && isProductCollection(input.node);
+
+export const isContentArray = (input: unknown[]): input is Content[] =>
+	Array.isArray(input) && input.every((x) => isContent(x));
+
+export const isContentEdgeArray = (input: unknown[]): input is ContentEdge[] =>
+	Array.isArray(input) && input.every((x) => isContentEdge(x));
+
+export const isProductArray = (input: unknown[]): input is Product[] =>
+	Array.isArray(input) && input.every((x) => isProduct(x));
+
+export const isProductEdgeArray = (input: unknown[]): input is ProductEdge[] =>
+	Array.isArray(input) && input.every((x) => isProductEdge(x));
+
+export const isProductCollectionArray = (
+	input: unknown
+): input is ProductCollection[] =>
+	Array.isArray(input) && input.every((x) => isProductCollection(x));
+
+export const isProductCollectionEdgeArray = (
+	input: unknown
+): input is ProductCollectionEdge[] =>
+	Array.isArray(input) && input.every((x) => isProductCollectionEdge(x));
+/* c8 ignore stop */

--- a/packages/storefront-sdk/src/utils/index.ts
+++ b/packages/storefront-sdk/src/utils/index.ts
@@ -4,6 +4,8 @@
 //  then search for & select 'Generate Index'
 
 // EXPORT UTILS
-// @index('./!(*.spec).ts', (f, _) => `export { default as ${_.camelCase(f.name)} } from '${f.path}.js';`)
-export { default as errorMessages } from './errorMessages.js';
+// @index('./!(*.spec).ts', (f, _) => `export * from '${f.path}.js';`)
+export * from './constants.js';
+export * from './errorMessages.js';
+export * from './identity.js';
 // @endindex


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8320](https://nacelle.atlassian.net/browse/ENG-8320) <!-- link to Jira ticket if one exists -->

> Implement the after method

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

This PR implements`@nacelle/storefront-sdk`'s [`.after`](https://docs.nacelle.com/docs/javascript-storefront-sdk#transforming-the-responses-of-sdk-methods) method.

This particular implementation introduces some non-breaking changes.

### Callbacks are registered by ID & deletable

In `@nacelle/storefront-sdk@1.x`, callbacks registered with the `.after` method were not deletable. This PR changes how callbacks are stored - rather than an array, callbacks are stored in an object that is namespaced by method. If the user provides an optional `callbackId`, we use that as the key. Otherwise, the key takes the form:

```ts
`${methodName}::${n}`
```

where `n` is the current number of callbacks registered to a particular method.

Storing callbacks this way allows them to be deleted. Users can delete a callback by calling the `.after` method with the `callbackId` of interest + `callback: null`:

```ts
// Register a callback
client.data.after(
  'spaceProperties',
  (data: SpaceProperties) => data,
  'myCallback'
);

// Delete the callback
client.data.after('spaceProperties', null, 'myCallback');
```

### The type for the `callback` supplied to `.after` reacts to the `method` name

Unlike `@nacelle/storefront-sdk@1.x`, the `.after` method implementation in this PR provides strong typing for the `callback` supplied to `.after`. The type is determined based on the `method` name provided to `.after`. For example:

https://user-images.githubusercontent.com/5732000/210666640-ba365c6b-5412-4827-bb7f-e15c75b4d6c5.mov

### Other improvements

The `method` supplied to `.after` is a string union of methods instead of a `string`. This gives a nice autocomplete experience in VSCode when using TypeScript.

### Next steps and open questions

- After #307 is merged, we can add unit tests for `applyAfter`.
- As noted in the comments, there are a handful of places that will likely need revision after we have a clearer concept of the plugin system and whether data-fetching methods other than `.query` will be provided via plugins.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-8320-after-method` branch.
2. Navigate to `packages/storefront-sdk`.
3. `npm run build` - the package should build without errors.
4. `npm run coverage` - all tests should pass, and the only uncovered lines should be for the `applyAfter` method. I think it makes sense for this method to be tested with `.query`, as follow-up to this PR and #307.

![ENG-8320-after-method branch all tests passing some lines not covered in src:client:index](https://user-images.githubusercontent.com/5732000/210631153-ebf88e76-76cd-4332-8e9f-90ee7c5dc7d5.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.


[ENG-8320]: https://nacelle.atlassian.net/browse/ENG-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-8320]: https://nacelle.atlassian.net/browse/ENG-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-8320]: https://nacelle.atlassian.net/browse/ENG-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ