### PR TITLE
chore: adds TSdocs to `setConfig` and `getConfig`

### DIFF
--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -115,7 +115,7 @@ export class StorefrontClient {
 
 	/**
 	 * Turn preview mode on or off by setting a `previewToken` to the SDK config. The `previewToken` can be found in the dashboard .
-	 * @param setConfigParams an object containing the `previewToken` property, supply a dashboard preview token to turn preview mode on, or `null` to turn it off.
+	 * @param setConfigParams an object containing the `previewToken` property, supply a dashboard preview token to turn preview mode on and `null` or an empty object to turn it off.
 	 */
 	setConfig(setConfigParams: SetConfigParams): SetConfigResponse {
 		const currentEndpoint = new URL(this.#config.storefrontEndpoint);

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -102,7 +102,7 @@ export class StorefrontClient {
 	}
 
 	/**
-	 * @returns an object containing the configuration properties: `storefrontEndpoint`, `previewToken`, `locale` and `afterSubscriptions`
+	 * @returns an object containing the Storefront SDK configuration parameters: `storefrontEndpoint`, `previewToken`, `locale` and `afterSubscriptions`.
 	 */
 	getConfig(): StorefrontConfig {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -114,8 +114,20 @@ export class StorefrontClient {
 	}
 
 	/**
-	 * Turn preview mode on or off by setting a `previewToken` to the SDK config. The `previewToken` can be found in the dashboard .
-	 * @param setConfigParams an object containing the `previewToken` property, supply a dashboard preview token to turn preview mode on and `null` or an empty object to turn it off.
+	 * Turn preview mode on or off on-the-fly by setting a `previewToken` in the SDK config. The `previewToken` can be generated in the Nacelle Dashboard.
+	 * @param setConfigParams an object containing the `previewToken` property. Providing a value of `null`, `undefined`, or an empty string will disable preview mode.
+	 *
+	 * @example
+	 * Enable preview mode by providing a `previewToken`:
+	 * ```
+	 * client.setConfig({ previewToken: '<my-nacelle-preview-token>' });
+	 * ```
+	 *
+	 * @example
+	 * Disable preview mode by providing `previewToken: null`:
+	 * ```
+	 * client.setConfig({ previewToken: null });
+	 * ```
 	 */
 	setConfig(setConfigParams: SetConfigParams): SetConfigResponse {
 		const currentEndpoint = new URL(this.#config.storefrontEndpoint);

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -101,6 +101,9 @@ export class StorefrontClient {
 		this.#afterSubscriptions = {};
 	}
 
+	/**
+	 * @returns an object containing the configuration properties: `storefrontEndpoint`, `previewToken`, `locale` and `afterSubscriptions`
+	 */
 	getConfig(): StorefrontConfig {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { fetchClient, ...rest } = this.#config;
@@ -110,6 +113,10 @@ export class StorefrontClient {
 		};
 	}
 
+	/**
+	 * Turn preview mode on or off by setting a `previewToken` to the SDK config. The `previewToken` can be found in the dashboard .
+	 * @param setConfigParams an object containing the `previewToken` property, supply a dashboard preview token to turn preview mode on, or `null` to turn it off.
+	 */
 	setConfig(setConfigParams: SetConfigParams): SetConfigResponse {
 		const currentEndpoint = new URL(this.#config.storefrontEndpoint);
 


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8410](https://nacelle.atlassian.net/browse/ENG-8410) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

Provide helpful TSDoc documentation for the `setConfig` & `getConfig` methods

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

Adds TSDoc comments to `setConfig` & `getConfig` methods

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

In `nacelle-js`:
- `git checkout ENG-8410/config-ts-doc`
- `cd packages/storefront-sdk`
- `npm run build && npm link`

In a test project:
- `npm link @nacelle/storefront-sdk`
- Instantiate a client and check if the TSdocs are showing when calling `setConfig` & `getConfig`


<img width="566" alt="Screen Shot 2023-01-13 at 3 18 08 PM" src="https://user-images.githubusercontent.com/25146108/212421241-bd37899a-3eb7-45d8-aa64-d133702c3afb.png">
<img width="595" alt="Screen Shot 2023-01-13 at 3 19 51 PM" src="https://user-images.githubusercontent.com/25146108/212421243-ef4d1aa7-5cbd-430e-8a48-bb9d8f1339d6.png">




## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [ ] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [ ] Updated the `README.md` with documentation changes (if applicable).


[ENG-8410]: https://nacelle.atlassian.net/browse/ENG-8410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ