### PR TITLE
feat: add `spaceProperties` method

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/index.ts
@@ -6,10 +6,12 @@
 // EXPORT QUERIES
 // @index('./!(*.spec|test).ts', (f, _) => `import { default as ${_.camelCase(f.name)} } from '${f.path}.js';`)
 import { default as navigation } from './navigation.js';
+import { default as spaceProperties } from './spaceProperties.js';
 // @endindex
 
 export default {
 	// @index('./!(*.spec|test).ts', (f, _) => `${_.constantCase(f.name)}: ${f.name},`)
-	NAVIGATION: navigation
+	NAVIGATION: navigation,
+	SPACE_PROPERTIES: spaceProperties
 	// @endindex
 };

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/spaceProperties.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/spaceProperties.ts
@@ -1,0 +1,17 @@
+const spaceQuery = `{query {
+  spaceProperties {
+    properties {
+      items {
+        key
+        value
+      }
+      namespace
+    }
+    updatedAt
+    updatedBy
+  }
+}
+}
+`;
+
+export default spaceQuery;

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -1,21 +1,45 @@
-import { expect, it } from 'vitest';
+import { expect, it, beforeEach, describe, vi } from 'vitest';
 import commerceQueriesPlugin from './index.js';
 import { StorefrontClient } from '@nacelle/storefront-sdk';
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
 
-it('does not error when composed with the `StorefrontClient` class', () => {
-	const ClientWithCommerceQueries = commerceQueriesPlugin(StorefrontClient);
+const mockedFetch = vi.fn();
 
+const ClientWithCommerceQueries = commerceQueriesPlugin(StorefrontClient);
+const client = new ClientWithCommerceQueries({
+	storefrontEndpoint,
+	fetchClient: mockedFetch as (
+		input: RequestInfo | URL,
+		init?: RequestInit | undefined
+	) => Promise<Response>
+});
+
+it('does not error when composed with the `StorefrontClient` class', () => {
 	expect(
 		() => new ClientWithCommerceQueries({ storefrontEndpoint })
 	).not.toThrow();
 });
 
 it('adds the expected methods to the `StorefrontClient` class', () => {
-	const ClientWithCommerceQueries = commerceQueriesPlugin(StorefrontClient);
-	const client = new ClientWithCommerceQueries({ storefrontEndpoint });
-
 	expect(typeof client.placeholder).toBe('function');
+	expect(typeof client.spaceProperties).toBe('function');
+});
+
+describe('spaceProperties', () => {
+	beforeEach(() => mockedFetch.mockRestore());
+
+	it('fetches `spaceProperties` with the appropriate query', async () => {
+		mockedFetch.mockImplementationOnce(() => Promise.resolve({ data: null }));
+		await client.spaceProperties();
+
+		expect(mockedFetch).toHaveBeenCalledOnce();
+		expect(mockedFetch).toHaveBeenCalledWith(
+			storefrontEndpoint,
+			expect.objectContaining({
+				body: expect.stringContaining('spaceProperties') as string
+			})
+		);
+	});
 });

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -1,8 +1,16 @@
 import type { WithStorefrontQuery } from '@nacelle/storefront-sdk';
+import type { SpaceProperties } from './types/storefront.js';
+import spaceProperties from './graphql/queries/spaceProperties.js';
 
 function commerceQueriesPlugin<TBase extends WithStorefrontQuery>(Base: TBase) {
 	return class CommerceQueries extends Base {
 		// methods will go here
+
+		async spaceProperties(): Promise<SpaceProperties> {
+			const spaceObject = await this.query({ query: spaceProperties });
+			return spaceObject as SpaceProperties;
+		}
+
 		placeholder() {
 			return null;
 		}


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8329](https://nacelle.atlassian.net/browse/ENG-8329) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

- Add the `spaceProperties` method to the commerce queries plugin

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

### Unit
- On the monorepo root `npm run bootstrap`
- Navigate to `packages/storefront-sdk-plugins/commerce-queries` 
- `npm run test` every test should pass

### Local
- In the plugin directory
- - `npm run build`
- In a local project `package.json` dependencies, add the local path to the `commerce-queries` plugin
```
"@nacelle/storefront-sdk-plugin-commerce-queries": "file: LOCAL_PATH"
```
- - `npm install`
- - In a JS/TS file, add the following code:
<img width="799" alt="Screen Shot 2023-01-18 at 9 24 07 AM" src="https://user-images.githubusercontent.com/25146108/213248571-962b43e2-2d9e-4d5b-b31e-ba987bd700e6.png">
- - Make sure the code works as expected:
<img width="319" alt="Screen Shot 2023-01-18 at 11 12 57 AM" src="https://user-images.githubusercontent.com/25146108/213249012-b1f0c1d8-a422-4beb-acdb-0916d8293794.png">




## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [ ] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [ ] Updated the `README.md` with documentation changes (if applicable).
