### PR TITLE
feat(commerce-queries): add content method 

### DIFF
--- a/.changeset/chilled-timers-repair.md
+++ b/.changeset/chilled-timers-repair.md
@@ -2,4 +2,4 @@
 '@nacelle/storefront-sdk-plugin-commerce-queries': minor
 ---
 
-Adds a `content` method to fetch the `allContent` data. Unlike the `content` method in the v1 sdk, this returns a result object with the signature `{error, data}` similar to how the `query` method works in the v2 sdk to allow users more control over error handling.
+Adds a `content` method to fetch the `allContent` data. Unlike the `content` method in the `@nacelle/storefront-sdk@1.x`, this returns a result object with the signature `{ error, data }` similar to how the `query` method works in `@nacelle/storefront-sdk@2.x` to allow users more control over error handling.

--- a/.changeset/chilled-timers-repair.md
+++ b/.changeset/chilled-timers-repair.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk-plugin-commerce-queries': minor
+---
+
+Adds a `content` method to fetch the `allContent` data. Unlike the `content` method in the v1 sdk, this returns a result object with the signature `{error, data}` similar to how the `query` method works in the v2 sdk to allow users more control over error handling.

--- a/.changeset/short-roses-search.md
+++ b/.changeset/short-roses-search.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': minor
+---
+
+Exposes new withConfig type that plugin authors can take advantage of to get access to the `getConfig` method of the sdk.

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/content.ts
@@ -1,0 +1,69 @@
+export const mockContentNode = {
+	createdAt: 1637098847,
+	fields: { customField: 'foobar' },
+	handle: 'nacelle-page',
+	indexedAt: 1637098847,
+	locale: 'en-us',
+	nacelleEntryId: 'abcdefg',
+	published: true,
+	sourceEntryId: 'cms-source-id-123',
+	sourceId: 'content-source-entry-id-1',
+	title: 'Mock Page',
+	type: 'page',
+	tags: ['red', 'green'],
+	updatedAt: 1637098847
+};
+
+export const mockPaginatedContent = {
+	data: {
+		allContent: {
+			pageInfo: {
+				hasNextPage: true,
+				endCursor: 'abcdefg'
+			},
+			edges: [
+				{
+					cursor: 'abcdefg',
+					node: mockContentNode
+				}
+			]
+		}
+	}
+};
+
+export const mockUnpaginatedContent = {
+	data: {
+		allContent: {
+			pageInfo: {
+				hasNextPage: false,
+				endCursor: 'abcdefg'
+			},
+			edges: [
+				{
+					cursor: 'abcdefg',
+					node: mockContentNode
+				}
+			]
+		}
+	}
+};
+
+export function buildContentResponse(
+	{ nodeCount, hasNextPage } = { nodeCount: 2, hasNextPage: false }
+) {
+	const edges = [];
+	for (let i = 0; i < nodeCount; i++) {
+		edges.push({ cursor: `abcdefg_${i}`, node: mockContentNode });
+	}
+	return {
+		data: {
+			allContent: {
+				pageInfo: {
+					hasNextPage,
+					endCursor: `abcdefg_${nodeCount - 1}`
+				},
+				edges
+			}
+		}
+	};
+}

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
@@ -1,0 +1,17 @@
+export default /* GraphQL */ `
+	fragment content_content on Content {
+		createdAt
+		fields
+		handle
+		indexedAt
+		locale
+		nacelleEntryId
+		published
+		sourceEntryId
+		sourceId
+		tags
+		title
+		type
+		updatedAt
+	}
+`;

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
@@ -1,5 +1,5 @@
 export default /* GraphQL */ `
-	fragment content_content on Content {
+	fragment Content_content on Content {
 		createdAt
 		fields
 		handle

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/index.ts
@@ -5,6 +5,7 @@
 
 // EXPORT FRAGMENTS
 // @index('./!(*.spec).ts', (f, _) => `import { default as ${_.camelCase(f.name)} } from '${f.path}.js';`)
+import { default as content } from './content.js';
 import { default as navigationItem } from './navigationItem.js';
 // @endindex
 
@@ -15,11 +16,12 @@ export type FragmentKey =
 	//  then search for & select 'Generate Index'
 
 	// @index('./!(*.spec|test).ts', (f, _, e) => `| '${_.constantCase(f.name)}'${e.isLast ? ';' : ''}`)
-	'NAVIGATION_ITEM';
+	'CONTENT' | 'NAVIGATION_ITEM';
 // @endindex
 
 const fragments: Record<FragmentKey, string> = {
 	// @index('./!(*.spec|test).ts', (f, _) => `${_.constantCase(f.name)}: ${f.name},`)
+	CONTENT: content,
 	NAVIGATION_ITEM: navigationItem
 	// @endindex
 };

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
@@ -1,0 +1,18 @@
+import fragments from '../fragments/index.js';
+export default /* GraphQL */ `
+	query allContent($filter: ContentFilterInput) {
+		allContent(filter: $filter) {
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+			edges {
+				cursor
+				node {
+					...content_content
+				}
+			}
+		}
+	}
+	${fragments.CONTENT}
+`;

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
@@ -9,7 +9,7 @@ export default /* GraphQL */ `
 			edges {
 				cursor
 				node {
-					...content_content
+					...Content_content
 				}
 			}
 		}

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -1,9 +1,18 @@
-import { expect, it, beforeEach, describe, vi } from 'vitest';
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { expect, it, afterEach, beforeEach, describe, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import commerceQueriesPlugin from './index.js';
 import { StorefrontClient } from '@nacelle/storefront-sdk';
 import getFetchPayload from '../__mocks__/utils/getFetchPayload.js';
 import SpacePropertiesResult from '../__mocks__/gql/spaceProperties.js';
 import NavigationResult from '../__mocks__/gql/navigation.js';
+import {
+	buildContentResponse,
+	mockPaginatedContent,
+	mockUnpaginatedContent
+} from '../__mocks__/gql/content.js';
+
+type mockRequestArgs = [RequestInfo | URL, RequestInit | undefined];
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
@@ -28,6 +37,7 @@ it('does not error when composed with the `StorefrontClient` class', () => {
 it('adds the expected methods to the `StorefrontClient` class', () => {
 	expect(typeof client.spaceProperties).toBe('function');
 	expect(typeof client.navigation).toBe('function');
+	expect(typeof client.content).toBe('function');
 });
 
 describe('spaceProperties', () => {
@@ -99,6 +109,209 @@ describe('navigation', () => {
 			)
 		);
 		const response = await client.navigation();
+		expect(response.error).toBeDefined();
+		expect(response.data).toBeUndefined();
+	});
+});
+
+describe('content', () => {
+	const mockedFetch: Mock<mockRequestArgs, Promise<Response>> = vi.fn(
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		(..._args) => Promise.resolve(getFetchPayload(mockUnpaginatedContent))
+	);
+	const testClientClass = commerceQueriesPlugin(StorefrontClient);
+	const testCient = new testClientClass({
+		storefrontEndpoint,
+		fetchClient: mockedFetch as (
+			input: RequestInfo | URL,
+			init?: RequestInit | undefined
+		) => Promise<Response>
+	});
+
+	afterEach(() => {
+		mockedFetch.mockRestore();
+	});
+
+	it('should pass parameters including the nacelleEntryId as variables', async () => {
+		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(
+				getFetchPayload({
+					errors: [
+						{
+							message: 'xxx',
+							extensions: { code: 'xxx' }
+						}
+					]
+				})
+			)
+		);
+		await testCient.content({
+			advancedOptions: {
+				entriesPerPage: 5
+			},
+			cursor: 'abc',
+			nacelleEntryIds: ['abcdefg_1']
+		});
+		const [url, argRequestInit]: mockRequestArgs = mockedFetch.mock.lastCall!;
+		expect(url).toBe(storefrontEndpoint);
+		expect(JSON.parse(argRequestInit?.body?.toString() ?? '')).toMatchObject({
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			query: expect.stringContaining('allContent'),
+			variables: {
+				filter: { after: 'abc', first: 5, nacelleEntryIds: ['abcdefg_1'] }
+			}
+		});
+	});
+
+	it('should pass parameters including the handles as variables', async () => {
+		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
+		await testCient.content({
+			advancedOptions: {
+				entriesPerPage: 5
+			},
+			cursor: 'abc',
+			handles: ['abcdefg']
+		});
+		const [url, argRequestInit]: mockRequestArgs = mockedFetch.mock.lastCall!;
+		expect(url).toBe(storefrontEndpoint);
+		expect(JSON.parse(argRequestInit?.body?.toString() ?? '')).toMatchObject({
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			query: expect.stringContaining('allContent'),
+			variables: {
+				filter: { after: 'abc', first: 5, handles: ['abcdefg'] }
+			}
+		});
+	});
+
+	it('should only include nacelleEntryIds if both nacelleEntryIds & handles are passed', async () => {
+		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(
+				getFetchPayload({
+					errors: [
+						{
+							message: 'PersistedQueryNotFound',
+							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
+						}
+					]
+				})
+			)
+		);
+		await testCient.content({
+			advancedOptions: {
+				entriesPerPage: 5
+			},
+			cursor: 'abc',
+			handles: ['abcdefg'],
+			nacelleEntryIds: ['abcdefg_1']
+		});
+		const [url, argRequestInit]: mockRequestArgs = mockedFetch.mock.lastCall!;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const requestBody = JSON.parse(argRequestInit?.body?.toString() ?? '');
+		expect(url).toBe(storefrontEndpoint);
+		expect(requestBody).toMatchObject({
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			query: expect.stringContaining('allContent'),
+			variables: {
+				filter: { after: 'abc', first: 5, nacelleEntryIds: ['abcdefg_1'] }
+			}
+		});
+		expect(requestBody).not.toMatchObject({
+			variables: { filter: { handles: ['abcdefg'] } }
+		});
+	});
+
+	it('should set first based on entriesPerPage and maxReturnedEntries', async () => {
+		await testCient.content({
+			advancedOptions: {
+				entriesPerPage: 5
+			},
+			maxReturnedEntries: 2
+		});
+		expect(
+			JSON.parse(
+				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
+					'variables'
+				) ?? ''
+			)
+		).toMatchObject({ filter: { first: 2 } });
+		mockedFetch.mockClear();
+		await testCient.content({
+			advancedOptions: {
+				entriesPerPage: 5
+			},
+			maxReturnedEntries: 10
+		});
+		expect(
+			JSON.parse(
+				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
+					'variables'
+				) ?? ''
+			)
+		).toMatchObject({ filter: { first: 5 } });
+		expect(mockedFetch).toBeCalledTimes(1);
+	});
+
+	it('should return edges if edgesToNodes is false', async () => {
+		const response = await testCient.content({
+			edgesToNodes: false
+		});
+
+		expect(response.data).toMatchObject(
+			mockUnpaginatedContent.data.allContent.edges
+		);
+	});
+
+	it('should fetch until hasNextPage = false if maxReturnedEntries=-1', async () => {
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload(mockPaginatedContent))
+		);
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload(mockPaginatedContent))
+		);
+		mockedFetch.mockImplementationOnce(() =>
+			Promise.resolve(getFetchPayload(mockPaginatedContent))
+		);
+
+		const response = await testCient.content({ maxReturnedEntries: -1 });
+
+		expect(mockedFetch).toBeCalledTimes(4);
+		// number of edges should be equal to 3 paginated responses + 1 unpaginated responses
+		expect(response.data!.length).toBe(
+			3 * mockPaginatedContent.data.allContent.edges.length +
+				mockUnpaginatedContent.data.allContent.edges.length
+		);
+	});
+
+	it('should stop paginating when the length is the value of maxReturnedEntries', async () => {
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(
+				getFetchPayload(
+					buildContentResponse({ nodeCount: 5, hasNextPage: true })
+				)
+			)
+		);
+
+		const response = await testCient.content({
+			maxReturnedEntries: 15
+		});
+		expect(mockedFetch).toBeCalledTimes(3);
+		expect(response.data!.length).toBe(15);
+	});
+
+	it('should return the error if one of the requests errors', async () => {
+		mockedFetch
+			.mockImplementationOnce(() =>
+				Promise.resolve(getFetchPayload(mockPaginatedContent))
+			)
+			.mockImplementationOnce(() =>
+				Promise.resolve(
+					getFetchPayload({ error: { message: 'GraphQL error' } })
+				)
+			);
+		const response = await testCient.content();
+		expect(mockedFetch).toBeCalledTimes(2);
 		expect(response.error).toBeDefined();
 		expect(response.data).toBeUndefined();
 	});

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -1,19 +1,52 @@
 import type {
 	WithStorefrontQuery,
+	WithConfig,
 	StorefrontClient,
 	StorefrontResponse
 } from '@nacelle/storefront-sdk';
 import {
 	SpacePropertiesDocument,
-	NavigationDocument
+	NavigationDocument,
+	AllContentDocument
 } from './types/storefront.js';
 import type {
 	SpaceProperties,
 	NavigationGroup,
-	NavigationFilterInput
+	NavigationFilterInput,
+	ContentFilterInput,
+	Content,
+	ContentEdge
 } from './types/storefront.js';
 
-function commerceQueriesPlugin<TBase extends WithStorefrontQuery>(Base: TBase) {
+export interface CommerceQueriesParams {
+	nacelleEntryIds?: string[];
+	handles?: string[];
+	locale?: string;
+	maxReturnedEntries?: number;
+	cursor?: string;
+	edgesToNodes?: boolean;
+	advancedOptions?: FetchMethodAdvancedParams;
+}
+export interface FetchMethodAdvancedParams {
+	entriesPerPage?: number;
+}
+
+export interface FetchContentMethodParams extends CommerceQueriesParams {
+	entryDepth?: number;
+	type?: string;
+}
+
+function dataIsNodeOrEdge<NodeType, EdgeType>(
+	data: NodeType[] | EdgeType[],
+	edgesToNodes: boolean
+): data is NodeType[] {
+	//use Array.isArray here to keep TS happy about data being defined but never used. Issue where eslint is okay with it but TS is not
+	return Array.isArray(data) && edgesToNodes;
+}
+
+function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
+	Base: TBase
+) {
 	return class CommerceQueries extends Base {
 		async spaceProperties(): Promise<StorefrontResponse<SpaceProperties>> {
 			const queryResponse = await this.query({
@@ -58,6 +91,107 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery>(Base: TBase) {
 					navigation
 				)
 			} as StorefrontResponse<Array<NavigationGroup>>;
+		}
+		readonly #defaultMaxReturnedEntries = -1;
+		readonly #defaultPageFetchLimit = 50;
+
+		async content(
+			params?: FetchContentMethodParams
+		): Promise<StorefrontResponse<Content[] | ContentEdge[]>> {
+			const {
+				cursor,
+				nacelleEntryIds,
+				handles,
+				locale = this.getConfig()?.locale,
+				maxReturnedEntries = this.#defaultMaxReturnedEntries,
+				advancedOptions,
+				edgesToNodes = true,
+				entryDepth,
+				type
+			} = params ?? {};
+
+			const first = Math.min(
+				...[
+					advancedOptions?.entriesPerPage ?? this.#defaultPageFetchLimit,
+					maxReturnedEntries
+				].filter((n) => n > 0)
+			);
+			const filter: ContentFilterInput = {
+				after: cursor,
+				locale,
+				first,
+				entryDepth,
+				type
+			};
+			// keeping with v1 sdk, only use nacelleEntryIds if both handles and nacelleEntryIds are provided
+			if (nacelleEntryIds && handles) {
+				console.warn(
+					'You have supplied both a nacelleEntryIds and handles. This method will use nacelleEntryIds for querying.'
+				);
+			}
+			if (nacelleEntryIds) {
+				filter.nacelleEntryIds = nacelleEntryIds;
+			} else {
+				filter.handles = handles;
+			}
+
+			// const responseData = await requestPaginatedData<
+			// 	this,
+			// 	Content,
+			// 	ContentEdge,
+			// 	ContentFilterInput
+			// >(
+			// 	this,
+			// 	AllContentDocument,
+			// 	'allContent',
+			// 	filter,
+			// 	maxReturnedEntries,
+			// 	edgesToNodes
+			// );
+
+			// if (responseData?.error) {
+			// 	return responseData;
+			// }
+
+			let shouldKeepFetching = true;
+			const data: Content[] | ContentEdge[] = [];
+			do {
+				const queryResponse = await this.query({
+					query: AllContentDocument,
+					variables: { filter }
+				});
+				if (queryResponse.error) {
+					// cast here because queryResponse.data should be undefined os the type doesn't actually  matter
+					return queryResponse as StorefrontResponse<ContentEdge[]>;
+				}
+				if (queryResponse.data) {
+					if (dataIsNodeOrEdge<Content, ContentEdge>(data, edgesToNodes)) {
+						data.push(
+							...queryResponse.data.allContent.edges.map((edge) => edge.node)
+						);
+					} else {
+						data.push(
+							...(queryResponse.data.allContent.edges as ContentEdge[])
+						);
+					}
+					if (
+						queryResponse.data.allContent.pageInfo.hasNextPage &&
+						(maxReturnedEntries === -1 || data.length < maxReturnedEntries)
+					) {
+						filter.after = queryResponse.data?.allContent.pageInfo.endCursor;
+					} else {
+						shouldKeepFetching = false;
+					}
+				}
+			} while (shouldKeepFetching);
+
+			return {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				data: await (this as unknown as StorefrontClient)['applyAfter'](
+					'content',
+					data
+				)
+			} as StorefrontResponse<ContentEdge[] | Content[]>;
 		}
 	};
 }

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -6,8 +6,7 @@ import type {
 } from '@nacelle/storefront-sdk';
 import {
 	SpacePropertiesDocument,
-	NavigationDocument,
-	AllContentDocument
+	NavigationDocument
 } from './types/storefront.js';
 import type {
 	SpaceProperties,
@@ -142,6 +141,7 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 			return {
 				data: await (this as unknown as StorefrontClient)['applyAfter'](
 					'content',
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					responseData.data!
 				)
 			} as StorefrontResponse<ContentEdge[] | Content[]>;

--- a/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
@@ -809,6 +809,23 @@ export type VariantContent = Node & {
 	variantEntryId?: Maybe<Scalars['ID']>;
 };
 
+export type Content_ContentFragment = {
+	__typename?: 'Content';
+	createdAt?: number | null;
+	fields?: any | null;
+	handle?: string | null;
+	indexedAt?: number | null;
+	locale?: string | null;
+	nacelleEntryId: string;
+	published?: boolean | null;
+	sourceEntryId: string;
+	sourceId: string;
+	tags: Array<string>;
+	title?: string | null;
+	type?: string | null;
+	updatedAt?: number | null;
+};
+
 export type NavigationItem_NavigationItemFragment = {
 	__typename?: 'NavigationGroupItem';
 	title: string;
@@ -823,6 +840,42 @@ export type NavigationItem_NavigationItemFragment = {
 		key: string;
 		value: string;
 	}> | null;
+};
+
+export type AllContentQueryVariables = Exact<{
+	filter?: InputMaybe<ContentFilterInput>;
+}>;
+
+export type AllContentQuery = {
+	__typename?: 'Query';
+	allContent: {
+		__typename?: 'ContentConnection';
+		pageInfo: {
+			__typename?: 'PageInfo';
+			hasNextPage: boolean;
+			endCursor: string;
+		};
+		edges: Array<{
+			__typename?: 'ContentEdge';
+			cursor: string;
+			node: {
+				__typename?: 'Content';
+				createdAt?: number | null;
+				fields?: any | null;
+				handle?: string | null;
+				indexedAt?: number | null;
+				locale?: string | null;
+				nacelleEntryId: string;
+				published?: boolean | null;
+				sourceEntryId: string;
+				sourceId: string;
+				tags: Array<string>;
+				title?: string | null;
+				type?: string | null;
+				updatedAt?: number | null;
+			};
+		}>;
+	};
 };
 
 export type NavigationQueryVariables = Exact<{
@@ -935,6 +988,37 @@ export type SpacePropertiesQuery = {
 	};
 };
 
+export const Content_ContentFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'content_content' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Content' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<Content_ContentFragment, unknown>;
 export const NavigationItem_NavigationItemFragmentDoc = {
 	kind: 'Document',
 	definitions: [
@@ -977,6 +1061,97 @@ export const NavigationItem_NavigationItemFragmentDoc = {
 		}
 	]
 } as unknown as DocumentNode<NavigationItem_NavigationItemFragment, unknown>;
+export const AllContentDocument = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'OperationDefinition',
+			operation: 'query',
+			name: { kind: 'Name', value: 'allContent' },
+			variableDefinitions: [
+				{
+					kind: 'VariableDefinition',
+					variable: {
+						kind: 'Variable',
+						name: { kind: 'Name', value: 'filter' }
+					},
+					type: {
+						kind: 'NamedType',
+						name: { kind: 'Name', value: 'ContentFilterInput' }
+					}
+				}
+			],
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'allContent' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'filter' },
+								value: {
+									kind: 'Variable',
+									name: { kind: 'Name', value: 'filter' }
+								}
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'pageInfo' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'hasNextPage' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'endCursor' }
+											}
+										]
+									}
+								},
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'edges' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'cursor' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'node' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{
+															kind: 'FragmentSpread',
+															name: { kind: 'Name', value: 'content_content' }
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		...Content_ContentFragmentDoc.definitions
+	]
+} as unknown as DocumentNode<AllContentQuery, AllContentQueryVariables>;
 export const NavigationDocument = {
 	kind: 'Document',
 	definitions: [

--- a/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
@@ -65,6 +65,7 @@ export const requestPaginatedData = async <
 			return queryResponse as StorefrontResponse<EdgeType[]>;
 		}
 		if (queryResponse.data) {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const responseData: QueryData<EdgeType> = queryResponse.data[queryName]!;
 			if (dataIsNodeOrEdge<NodeType, EdgeType>(data, edgesToNodes)) {
 				data.push(

--- a/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
@@ -1,0 +1,87 @@
+import type { StorefrontClient } from '@nacelle/storefront-sdk';
+import type { StorefrontResponse } from 'node_modules/@nacelle/storefront-sdk/dist/types/client/index.js';
+import type { InputMaybe, Content, ContentEdge } from 'src/types/storefront.js';
+import { AllContentDocument } from '../types/storefront.js';
+
+/** These are concrete unions of the different queries  */
+
+type PaginatedQueryName = 'allContent';
+
+interface QueryData<EdgeType> {
+	pageInfo: { hasNextPage: boolean; endCursor: string };
+	edges: EdgeType[];
+}
+
+type PaginatedQueryType<EdgeType> = {
+	[Property in PaginatedQueryName]?: QueryData<EdgeType>;
+};
+
+type DataNodeType = Content;
+type DataEdgeType = ContentEdge;
+
+interface paginatedFilter {
+	first?: InputMaybe<number>;
+	after?: InputMaybe<string>;
+}
+
+function dataIsNodeOrEdge<NodeType, EdgeType>(
+	data: NodeType[] | EdgeType[],
+	edgesToNodes: boolean
+): data is NodeType[] {
+	//use Array.isArray here to keep TS happy about data being defined but never used. Issue where eslint is okay with it but TS is not
+	return Array.isArray(data) && edgesToNodes;
+}
+
+function queryFromName(queryName: PaginatedQueryName) {
+	switch (queryName) {
+		case 'allContent':
+			return AllContentDocument;
+	}
+}
+
+export const requestPaginatedData = async <
+	TBase extends Pick<StorefrontClient, 'query'>,
+	NodeType extends DataNodeType,
+	EdgeType extends DataEdgeType,
+	TFilter extends paginatedFilter
+>(
+	storefrontInstance: TBase,
+	queryName: PaginatedQueryName,
+	filter: TFilter,
+	maxReturnedEntries: number,
+	edgesToNodes: boolean
+) => {
+	let shouldKeepFetching = true;
+	const queryToUse = queryFromName(queryName);
+	const data: NodeType[] | EdgeType[] = [];
+	do {
+		// cast to an abstract type to make TS happy with access via queryResponse.data[queryName] since we know that the query chosen is guaranteed to have a field `queryName` but there's not a good way to handle that.
+		const queryResponse = (await storefrontInstance.query({
+			query: queryToUse,
+			variables: { filter }
+		})) as unknown as StorefrontResponse<PaginatedQueryType<EdgeType>>;
+		if (queryResponse.error) {
+			// cast here because queryResponse.data should be undefined so the type of data doesn't actually  matter
+			return queryResponse as StorefrontResponse<EdgeType[]>;
+		}
+		if (queryResponse.data) {
+			const responseData: QueryData<EdgeType> = queryResponse.data[queryName]!;
+			if (dataIsNodeOrEdge<NodeType, EdgeType>(data, edgesToNodes)) {
+				data.push(
+					...(responseData.edges.map((edge) => edge.node) as NodeType[])
+				);
+			} else {
+				data.push(...responseData.edges);
+			}
+			if (
+				responseData?.pageInfo?.hasNextPage &&
+				(maxReturnedEntries === -1 || data.length < maxReturnedEntries)
+			) {
+				filter.after = responseData.pageInfo.endCursor;
+			} else {
+				shouldKeepFetching = false;
+			}
+		}
+	} while (shouldKeepFetching);
+	return { data } as StorefrontResponse<typeof data>;
+};

--- a/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
@@ -1,5 +1,7 @@
-import type { StorefrontClient } from '@nacelle/storefront-sdk';
-import type { StorefrontResponse } from 'node_modules/@nacelle/storefront-sdk/dist/types/client/index.js';
+import type {
+	StorefrontClient,
+	StorefrontResponse
+} from '@nacelle/storefront-sdk';
 import type { InputMaybe, Content, ContentEdge } from 'src/types/storefront.js';
 import { AllContentDocument } from '../types/storefront.js';
 
@@ -64,8 +66,7 @@ export const requestPaginatedData = async <
 			variables: { filter }
 		})) as unknown as StorefrontResponse<PaginatedQueryType<EdgeType>>;
 		if (queryResponse.error) {
-			// cast here because queryResponse.data should be undefined so the type of data doesn't actually  matter
-			return queryResponse as StorefrontResponse<EdgeType[]>;
+			return { error: queryResponse.error };
 		}
 		if (queryResponse.data) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/utils/requestPaginatedData.ts
@@ -3,8 +3,7 @@ import type { StorefrontResponse } from 'node_modules/@nacelle/storefront-sdk/di
 import type { InputMaybe, Content, ContentEdge } from 'src/types/storefront.js';
 import { AllContentDocument } from '../types/storefront.js';
 
-/** These are concrete unions of the different queries  */
-
+/** These are concrete unions of the different query names. As new paginated queries are added, they should be added to this union.*/
 type PaginatedQueryName = 'allContent';
 
 interface QueryData<EdgeType> {
@@ -16,7 +15,9 @@ type PaginatedQueryType<EdgeType> = {
 	[Property in PaginatedQueryName]?: QueryData<EdgeType>;
 };
 
+/** Kinds of Node types that the paginated methods can return. As new queries are added, their corresponding Node types should be added here. */
 type DataNodeType = Content;
+/** Kinds of Node types that the paginated methods can return. As new queries are added, their corresponding Node types should be added here. */
 type DataEdgeType = ContentEdge;
 
 interface paginatedFilter {
@@ -32,6 +33,7 @@ function dataIsNodeOrEdge<NodeType, EdgeType>(
 	return Array.isArray(data) && edgesToNodes;
 }
 
+/** Returns the query based on the queryName. As new queries are added, they should be added to this switch case block. This helps us be confident that the query will have the correct key based on the queryName passed to the pagination function */
 function queryFromName(queryName: PaginatedQueryName) {
 	switch (queryName) {
 		case 'allContent':
@@ -39,6 +41,7 @@ function queryFromName(queryName: PaginatedQueryName) {
 	}
 }
 
+/** Makes paginated requests to the storefront api so that the method can return multiple "pages" of data in a single method call.  */
 export const requestPaginatedData = async <
 	TBase extends Pick<StorefrontClient, 'query'>,
 	NodeType extends DataNodeType,

--- a/packages/storefront-sdk-plugins/commerce-queries/vite.config.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/vite.config.ts
@@ -20,12 +20,14 @@ export const config: UserConfig = {
 			include: ['src/**/*.ts'],
 			provider: 'c8',
 			reportsDirectory: 'coverage',
-			reporter: ['text', 'lcov']
+			reporter: ['text', 'lcov'],
+			exclude: ['src/types/storefront.ts', '**/*.test.ts', 'node_modules/**']
 		},
 		environment: 'jsdom',
 		typecheck: {
 			include: ['**/*.test.ts']
-		}
+		},
+		setupFiles: ['vitest.setup.ts']
 	}
 };
 

--- a/packages/storefront-sdk-plugins/commerce-queries/vitest.setup.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/vitest.setup.ts
@@ -1,0 +1,7 @@
+import crypto from 'node:crypto';
+
+Object.defineProperty(global.self, 'crypto', {
+	value: {
+		subtle: crypto.webcrypto.subtle
+	}
+});

--- a/packages/storefront-sdk/src/types/plugins.ts
+++ b/packages/storefront-sdk/src/types/plugins.ts
@@ -5,3 +5,6 @@ export type StorefrontClientDerivative<T extends Partial<StorefrontClient>> =
 export type WithStorefrontQuery = StorefrontClientDerivative<
 	Pick<StorefrontClient, 'query'>
 >;
+export type WithConfig = StorefrontClientDerivative<
+	Pick<StorefrontClient, 'getConfig'>
+>;


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8321](https://nacelle.atlassian.net/browse/ENG-8321) - adds a content method to the commerce query plugin <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

1. Adds a `withConfig` type to the plugin types in the Storefront sdk to enable getting access to the config in plugins
2. Updates `applyAfter` to be protected instead of private so it's more accessible in the plugins
3. Adds the content method to the plugin
4. Adds a fetchPaginatedData method so that other paginated functions can reuse the same logic

## How to Test

1. Navigate to `packages/storefront-sdk` and run `npm run build && npm link`
2. Navigate to `packages/storefront-sdk-plugin/commerce-queries` and run `npm link @nacelle/storefront-sdk`
3. Build with `npm run build` - should build successfully
5. Test with `npm run test` - all tests should pass
6. Typecheck with `npm run test:typecheck -- --run` - tests and code should all be correctly typed

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-8321]: https://nacelle.atlassian.net/browse/ENG-8321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ