### PR TITLE
feat: add advanced option to control APQ

### DIFF
--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -2,6 +2,14 @@ import { StorefrontClient } from './client/index.js';
 import { errorMessages } from './utils/index.js';
 import type { StorefrontResponse } from './client/index.js';
 
+export interface StorefrontClientAdvancedOptions {
+	/**
+	 * Controls whether or not Automatic Persisted Queries should be enabled when making requests. This is enabled by default and allows Nacelle to provide improved performance for repeated queries.
+	 * @defaultvalue true
+	 */
+	enableApq?: boolean;
+}
+
 export interface StorefrontClientParams {
 	/** Nacelle Storefront GraphQL Endpoint. This can be retrieved from the Nacelle Dashboard. */
 	storefrontEndpoint: string;
@@ -14,6 +22,9 @@ export interface StorefrontClientParams {
 
 	/** Optional fetch implementation. If not supplied, the Storefront SDK will use `globalThis.fetch`. */
 	fetchClient?: typeof globalThis.fetch;
+
+	/** Advanced options for configuring the Storefront SDK. These default to the recommended settings for most users. */
+	advancedOptions?: StorefrontClientAdvancedOptions;
 }
 
 export function Storefront(params: StorefrontClientParams) {

--- a/packages/storefront-sdk/src/types/config.ts
+++ b/packages/storefront-sdk/src/types/config.ts
@@ -1,9 +1,13 @@
 import type { Maybe } from './storefront.js';
-import type { StorefrontClientParams } from '../index.js';
+import type {
+	StorefrontClientAdvancedOptions,
+	StorefrontClientParams
+} from '../index.js';
 import type { AfterSubscriptions, DataFetchingMethodName } from './after.js';
 
 export interface SetConfigParams {
 	previewToken?: Maybe<string>;
+	advancedOptions?: Maybe<StorefrontClientAdvancedOptions>;
 }
 export interface SetConfigResponse {
 	endpoint: string;


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8432](https://nacelle.atlassian.net/browse/ENG-8432) - provides power users the ability to disable APQ requests. <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

1. Adds `advancedOptions` key to `StorefrontParams` with `enableApq` key
2. Adds same `advancedOptions` to `setConfig` so users can disable APQ on already initialized storefront
3. Excludes `persistedFetchExchange` from the exchanges array if the new `enableApq` option is false
4. Adds tests for the `enableApq` behavior  

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

## How to Test

1. Checkout this branch `mdarrik/ENG-8432-add-option-to-disable-apq`
2. Run `npm run build` - build should succeed
3. Run `npm run coverage` - vite typecheck and all tests should pass with 100% coverage
4. (Optional) - use `npm link` with the Storefront SDK. When `enableApq` is false, should see only post requests to the storefront API & when `enableApq` is true, should see APQ get requests. 

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [x] Updated the `README.md` with documentation changes (if applicable).


[ENG-8432]: https://nacelle.atlassian.net/browse/ENG-8432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ