### PR TITLE
test(commerce-queries): clean up tests by disabling APQ

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -52,7 +52,8 @@ const client = new ClientWithCommerceQueries({
 	fetchClient: mockedFetch as (
 		input: RequestInfo | URL,
 		init?: RequestInit | undefined
-	) => Promise<Response>
+	) => Promise<Response>,
+	advancedOptions: { enableApq: false }
 });
 
 it('does not error when composed with the `StorefrontClient` class', () => {
@@ -83,23 +84,13 @@ describe('spaceProperties', () => {
 	});
 
 	it('fetches `spaceProperties` with the appropriate query', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch
-			.mockResolvedValueOnce(
-				getFetchPayload({
-					errors: [
-						{
-							message: 'PersistedQueryNotFound',
-							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-						}
-					]
-				})
-			)
-			.mockResolvedValueOnce(getFetchPayload({ data: SpacePropertiesResult }));
+		mockedFetch.mockResolvedValueOnce(
+			getFetchPayload({ data: SpacePropertiesResult })
+		);
 
 		await client.spaceProperties();
 
-		expect(mockedFetch).toHaveBeenCalledTimes(2);
+		expect(mockedFetch).toHaveBeenCalledOnce();
 		expect(mockedFetch).toHaveBeenCalledWith(
 			storefrontEndpoint,
 			expect.objectContaining({
@@ -138,23 +129,13 @@ describe('navigation', () => {
 	});
 
 	it('fetches `navigation` with the appropriate query', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch
-			.mockResolvedValueOnce(
-				getFetchPayload({
-					errors: [
-						{
-							message: 'PersistedQueryNotFound',
-							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-						}
-					]
-				})
-			)
-			.mockResolvedValueOnce(getFetchPayload({ data: NavigationResult }));
+		mockedFetch.mockResolvedValueOnce(
+			getFetchPayload({ data: NavigationResult })
+		);
 
 		await client.navigation({ groupId: 'groupId' });
 
-		expect(mockedFetch).toHaveBeenCalledTimes(2);
+		expect(mockedFetch).toHaveBeenCalledOnce();
 		expect(mockedFetch).toHaveBeenCalledWith(
 			storefrontEndpoint,
 			expect.objectContaining({
@@ -193,17 +174,6 @@ describe('content', () => {
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
 		await client.content({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -223,18 +193,6 @@ describe('content', () => {
 	});
 
 	it('should pass parameters including the `handles` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.content({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -254,17 +212,6 @@ describe('content', () => {
 	});
 
 	it('should only include `nacelleEntryIds` if both `nacelleEntryIds` & `handles` are passed', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
 		await client.content({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -296,14 +243,9 @@ describe('content', () => {
 			},
 			maxReturnedEntries: 2
 		});
-		// since apq doesn't hash variables, can just get variables param off the url instead of mocking an apq error and getting it from the body.
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 2 } });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { filter: { first: 2 } } });
 		mockedFetch.mockClear();
 		await client.content({
 			advancedOptions: {
@@ -312,12 +254,12 @@ describe('content', () => {
 			maxReturnedEntries: 10
 		});
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 5 } });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({
+			variables: {
+				filter: { first: 5 }
+			}
+		});
 		expect(mockedFetch).toBeCalledTimes(1);
 	});
 
@@ -404,18 +346,6 @@ describe('products', () => {
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.products({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -435,18 +365,6 @@ describe('products', () => {
 	});
 
 	it('should pass parameters including the `handles` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.products({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -466,18 +384,6 @@ describe('products', () => {
 	});
 
 	it('should only include `nacelleEntryIds` if both `nacelleEntryIds` & `handles` are passed', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.products({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -511,12 +417,8 @@ describe('products', () => {
 		});
 		// since apq doesn't hash variables, can just get variables param off the url instead of mocking an apq error and getting it from the body.
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 2 } });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { filter: { first: 2 } } });
 		mockedFetch.mockClear();
 		await client.products({
 			advancedOptions: {
@@ -525,13 +427,9 @@ describe('products', () => {
 			maxReturnedEntries: 10
 		});
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 5 } });
-		expect(mockedFetch).toBeCalledTimes(1);
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { filter: { first: 5 } } });
+		expect(mockedFetch).toHaveBeenCalledOnce();
 	});
 
 	it('should return edges if `edgesToNodes` is `false`', async () => {
@@ -622,18 +520,6 @@ describe('productCollections', () => {
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.productCollections({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -653,18 +539,6 @@ describe('productCollections', () => {
 	});
 
 	it('should pass parameters including the `handles` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.productCollections({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -684,18 +558,6 @@ describe('productCollections', () => {
 	});
 
 	it('should pass parameters including the `maxReturnedEntriesPerCollection` as variables', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.productCollections({
 			maxReturnedEntries: 2,
 			maxReturnedEntriesPerCollection: 5
@@ -713,18 +575,6 @@ describe('productCollections', () => {
 	});
 
 	it('should only include `nacelleEntryIds` if both `nacelleEntryIds` & `handles` are passed', async () => {
-		// mock a persisted query not found error so we can get a post request sent so it's easier to inspect
-		mockedFetch.mockResolvedValueOnce(
-			getFetchPayload({
-				errors: [
-					{
-						message: 'PersistedQueryNotFound',
-						extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-					}
-				]
-			})
-		);
-
 		await client.productCollections({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -756,14 +606,9 @@ describe('productCollections', () => {
 			},
 			maxReturnedEntries: 2
 		});
-		// since apq doesn't hash variables, can just get variables param off the url instead of mocking an apq error and getting it from the body.
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 2 } });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { filter: { first: 2 } } });
 		mockedFetch.mockClear();
 		await client.productCollections({
 			advancedOptions: {
@@ -772,12 +617,8 @@ describe('productCollections', () => {
 			maxReturnedEntries: 10
 		});
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ filter: { first: 5 } });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { filter: { first: 5 } } });
 		expect(mockedFetch).toBeCalledTimes(1);
 	});
 
@@ -863,19 +704,6 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('should pass parameters including the collectionEntry as variables', async () => {
-		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(
-				getFetchPayload({
-					errors: [
-						{
-							message: 'PersistedQueryNotFound',
-							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-						}
-					]
-				})
-			)
-		);
 		await client.productCollectionEntries({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -899,19 +727,6 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('should pass parameters including the handle as variables', async () => {
-		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(
-				getFetchPayload({
-					errors: [
-						{
-							message: 'PersistedQueryNotFound',
-							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-						}
-					]
-				})
-			)
-		);
 		await client.productCollectionEntries({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -933,19 +748,6 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('should only include nacelleEntryIds if both collectionEntryId & handle are passed', async () => {
-		// mock a persisted query not found error so we can get a post request  sent so it's easier to inspect
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(
-				getFetchPayload({
-					errors: [
-						{
-							message: 'PersistedQueryNotFound',
-							extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' }
-						}
-					]
-				})
-			)
-		);
 		await client.productCollectionEntries({
 			advancedOptions: {
 				entriesPerPage: 5
@@ -988,14 +790,9 @@ describe('productCollectionEntries', () => {
 			},
 			maxReturnedEntries: 2
 		});
-		// since apq doesn't hash variables, can just get variables param off the url instead of mocking an apq error and getting it from the body.
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ entriesFirst: 2 });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { entriesFirst: 2 } });
 		mockedFetch.mockClear();
 		await client.productCollectionEntries({
 			collectionEntryId: 'abcdefg_1',
@@ -1005,12 +802,8 @@ describe('productCollectionEntries', () => {
 			maxReturnedEntries: 10
 		});
 		expect(
-			JSON.parse(
-				new URL(mockedFetch.mock.lastCall![0] as URL | string).searchParams.get(
-					'variables'
-				) ?? ''
-			)
-		).toMatchObject({ entriesFirst: 5 });
+			JSON.parse(mockedFetch.mock.lastCall![1]?.body?.toString() ?? '')
+		).toMatchObject({ variables: { entriesFirst: 5 } });
 		expect(mockedFetch).toBeCalledTimes(1);
 	});
 


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8659](https://nacelle.atlassian.net/browse/ENG-8659) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

- cleans up the tests to run with APQ disabled. This makes it easier to inspect the args passed to the `fetch` function without needing to send an error response or parse the url. 
<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

## How to Test

1. Checkout this branch
2. Run `npm run coverage` all tests should pass with 100% coverage
<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [x] Updated the `README.md` with documentation changes (if applicable).


[ENG-8659]: https://nacelle.atlassian.net/browse/ENG-8659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ