### PR TITLE
feat: adds trace id to error messages

### DIFF
--- a/.changeset/stale-cherries-compare.md
+++ b/.changeset/stale-cherries-compare.md
@@ -2,4 +2,4 @@
 '@nacelle/storefront-sdk': minor
 ---
 
-Adds a trace id to the `error` key in the response. This trace id should be included in any support requests
+Adds a trace id to the `error` key in the response. This trace id should be included in any support requests.

--- a/.changeset/stale-cherries-compare.md
+++ b/.changeset/stale-cherries-compare.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': minor
+---
+
+Adds a trace id to the `error` key in the response. This trace id should be included in any support requests

--- a/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
+++ b/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
@@ -1,11 +1,16 @@
 function getFetchPayload(
 	data: object,
-	responseOptions: { status: number } = {
+	responseOptions: { status: number; headers?: { [key: string]: string } } = {
 		status: 200
 	}
 ): Response {
 	const headers = new Headers();
 	headers.append('content-type', 'application/json');
+	if (responseOptions.headers) {
+		for (const [key, value] of Object.entries(responseOptions.headers)) {
+			headers.append(key, value);
+		}
+	}
 	return new Response(JSON.stringify({ ...data }), {
 		headers,
 		...responseOptions

--- a/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
+++ b/packages/storefront-sdk/__mocks__/utils/getFetchPayload.ts
@@ -1,6 +1,6 @@
 function getFetchPayload(
 	data: object,
-	responseOptions: { status: number; headers?: { [key: string]: string } } = {
+	responseOptions: { status: number; headers?: Record<string, string> } = {
 		status: 200
 	}
 ): Response {

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nacelle/storefront-sdk",
-	"version": "2.0.0-beta.0",
+	"version": "2.0.0-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nacelle/storefront-sdk",
-			"version": "2.0.0-beta.0",
+			"version": "2.0.0-beta.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@urql/core": "^3.1.1",

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -1,4 +1,5 @@
 import { gql } from '@urql/core';
+import { GraphQLError } from 'graphql';
 import {
 	afterEach,
 	beforeEach,
@@ -22,7 +23,6 @@ import type {
 	SpaceProperties
 } from '../types/storefront.js';
 import type { StorefrontConfig } from '../types/config.js';
-import { GraphQLError } from 'graphql';
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -288,7 +288,7 @@ export class StorefrontClient {
 						'x-amzn-trace-id'
 					);
 					if (traceHeader) {
-						error.message = `${error.message}\nTrace ID: ${traceHeader}. Please include this Trace ID in support requests`;
+						error.message = `${error.message}\nTrace ID: ${traceHeader}. Please include this Trace ID in support requests.`;
 					}
 				}
 				return { data, error };

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -282,6 +282,17 @@ export class StorefrontClient {
 		return this.#graphqlClient
 			.query(query, variables as QVariables)
 			.toPromise()
+			.then(({ data, error }) => {
+				if (error) {
+					const traceHeader = (error.response as Response)?.headers?.get(
+						'x-amzn-trace-id'
+					);
+					if (traceHeader) {
+						error.message = `${error.message}\nTrace ID: ${traceHeader}. Please include this Trace ID in support requests`;
+					}
+				}
+				return { data, error };
+			})
 			.then(({ data, error }) => this.applyAfter('query', { data, error }));
 	}
 }


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8370](https://nacelle.atlassian.net/browse/ENG-8370) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

- Adds the `x-amzn-trace-id` to the `response.error.message` field in the query response. This will allow users to provide info for datadog traces if they need to reach out for support.
<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

## How to Test

1. Checkout this branch `mdarrik/ENG-8370-add-x-amzn-trace-id-to-errors`
2. Navigate to `packages/storefront-sdk`
3. Run `npm run coverage` - typechecking should pass and test coverage should be 100%
4. Run `npm run build` -  should build successfully
5. Use `npm link` to link to this build of the sdk in a test project. Run an invalid query. The `error.message` field should include `Trace Id: <trace-id>`.
6. (Optional) Use `npm link @nacelle/storefront-sdk` in the `packages/storefront-sdk-plugins/commerce-queries` folder. Then run `npm run test` all of the tests in that repo should continue to pass.

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [x] Updated the `README.md` with documentation changes (if applicable).


[ENG-8370]: https://nacelle.atlassian.net/browse/ENG-8370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ