### PR TITLE
fix: use conditional types to avoid assertions

### DIFF
--- a/.changeset/lazy-foxes-fetch.md
+++ b/.changeset/lazy-foxes-fetch.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk-plugin-commerce-queries': patch
+---
+
+In TypeScript projects, the `.content`, `.products`, `.productCollections`, and `.productCollectionEntries` methods no longer require type assertions on their return values. The type will be inferred based on the value of `params.edgesToNodes`.

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -65,6 +65,7 @@ it('does not error when composed with the `StorefrontClient` class', () => {
 it('adds the expected methods to the `StorefrontClient` class', () => {
 	expect(typeof client.content).toBe('function');
 	expect(typeof client.navigation).toBe('function');
+	expect(typeof client.productCollectionEntries).toBe('function');
 	expect(typeof client.productCollections).toBe('function');
 	expect(typeof client.products).toBe('function');
 	expect(typeof client.spaceProperties).toBe('function');
@@ -160,13 +161,19 @@ describe('navigation', () => {
 describe('content', () => {
 	beforeEach(() => {
 		mockedFetch.mockRestore();
-		mockedFetch.mockResolvedValue(getFetchPayload(mockUnpaginatedContent));
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload(mockUnpaginatedContent))
+		);
 	});
 
 	it('returns data of the expected type', async () => {
-		const data = await client.content();
+		const defaultData = await client.content();
+		const explicitNodesData = await client.content({ edgesToNodes: true });
+		const explicitEdgesData = await client.content({ edgesToNodes: false });
 
-		expectTypeOf(data).toMatchTypeOf<Content[] | ContentEdge[]>();
+		expectTypeOf(defaultData).toMatchTypeOf<Content[]>();
+		expectTypeOf(explicitNodesData).toMatchTypeOf<Content[]>();
+		expectTypeOf(explicitEdgesData).toMatchTypeOf<ContentEdge[]>();
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
@@ -334,13 +341,19 @@ describe('content', () => {
 describe('products', () => {
 	beforeEach(() => {
 		mockedFetch.mockRestore();
-		mockedFetch.mockResolvedValue(getFetchPayload(mockUnpaginatedProduct));
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload(mockUnpaginatedProduct))
+		);
 	});
 
 	it('returns data of the expected type', async () => {
-		const data = await client.products();
+		const defaultData = await client.products();
+		const explicitNodesData = await client.products({ edgesToNodes: true });
+		const explicitEdgesData = await client.products({ edgesToNodes: false });
 
-		expectTypeOf(data).toMatchTypeOf<Product[] | ProductEdge[]>();
+		expectTypeOf(defaultData).toMatchTypeOf<Product[]>();
+		expectTypeOf(explicitNodesData).toMatchTypeOf<Product[]>();
+		expectTypeOf(explicitEdgesData).toMatchTypeOf<ProductEdge[]>();
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
@@ -506,17 +519,23 @@ describe('products', () => {
 describe('productCollections', () => {
 	beforeEach(() => {
 		mockedFetch.mockRestore();
-		mockedFetch.mockResolvedValue(
-			getFetchPayload(mockUnpaginatedProductCollection)
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(getFetchPayload(mockUnpaginatedProductCollection))
 		);
 	});
 
 	it('returns data of the expected type', async () => {
-		const data = await client.productCollections();
+		const defaultData = await client.productCollections();
+		const explicitNodesData = await client.productCollections({
+			edgesToNodes: true
+		});
+		const explicitEdgesData = await client.productCollections({
+			edgesToNodes: false
+		});
 
-		expectTypeOf(data).toMatchTypeOf<
-			ProductCollection[] | ProductCollectionEdge[]
-		>();
+		expectTypeOf(defaultData).toMatchTypeOf<ProductCollection[]>();
+		expectTypeOf(explicitNodesData).toMatchTypeOf<ProductCollection[]>();
+		expectTypeOf(explicitEdgesData).toMatchTypeOf<ProductCollectionEdge[]>();
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
@@ -825,8 +844,8 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('should return empty array if no collection is found', async () => {
-		mockedFetch.mockImplementation(() =>
-			Promise.resolve(getFetchPayload(mockEmptyProductCollectionEntries))
+		mockedFetch.mockResolvedValueOnce(
+			getFetchPayload(mockEmptyProductCollectionEntries)
 		);
 
 		const response = await client.productCollectionEntries();
@@ -835,15 +854,16 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('should fetch until hasNextPage = false if maxReturnedEntries=-1', async () => {
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(getFetchPayload(mockPaginatedProductCollectionEntries))
-		);
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(getFetchPayload(mockPaginatedProductCollectionEntries))
-		);
-		mockedFetch.mockImplementationOnce(() =>
-			Promise.resolve(getFetchPayload(mockPaginatedProductCollectionEntries))
-		);
+		mockedFetch
+			.mockResolvedValueOnce(
+				getFetchPayload(mockPaginatedProductCollectionEntries)
+			)
+			.mockResolvedValueOnce(
+				getFetchPayload(mockPaginatedProductCollectionEntries)
+			)
+			.mockResolvedValueOnce(
+				getFetchPayload(mockPaginatedProductCollectionEntries)
+			);
 
 		const response = await client.productCollectionEntries({
 			collectionEntryId: 'abcdefg_1',
@@ -883,13 +903,11 @@ describe('productCollectionEntries', () => {
 
 	it('should throw an error if one of the requests errors', async () => {
 		mockedFetch
-			.mockImplementationOnce(() =>
-				Promise.resolve(getFetchPayload(mockPaginatedProductCollectionEntries))
+			.mockResolvedValueOnce(
+				getFetchPayload(mockPaginatedProductCollectionEntries)
 			)
-			.mockImplementationOnce(() =>
-				Promise.resolve(
-					getFetchPayload({ error: { message: 'GraphQL error' } })
-				)
+			.mockResolvedValueOnce(
+				getFetchPayload({ error: { message: 'GraphQL error' } })
 			);
 		await expect(
 			client.productCollectionEntries({
@@ -901,8 +919,16 @@ describe('productCollectionEntries', () => {
 	});
 
 	it('returns data of the expected type', async () => {
-		const data = await client.productCollectionEntries();
+		const defaultData = await client.productCollectionEntries();
+		const explicitNodesData = await client.productCollectionEntries({
+			edgesToNodes: true
+		});
+		const explicitEdgesData = await client.productCollectionEntries({
+			edgesToNodes: false
+		});
 
-		expectTypeOf(data).toMatchTypeOf<Product[] | ProductEdge[]>();
+		expectTypeOf(defaultData).toMatchTypeOf<Product[]>();
+		expectTypeOf(explicitNodesData).toMatchTypeOf<Product[]>();
+		expectTypeOf(explicitEdgesData).toMatchTypeOf<ProductEdge[]>();
 	});
 });

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -28,6 +28,12 @@ import type {
 	ProductFilterInput,
 	SpaceProperties
 } from './types/storefront.js';
+import type {
+	ContentResponse,
+	ProductsResponse,
+	ProductCollectionsResponse,
+	ProductCollectionEntriesResponse
+} from './types/relay.js';
 
 export interface CommerceQueriesParams {
 	nacelleEntryIds?: string[];
@@ -107,9 +113,9 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 		readonly #defaultMaxReturnedEntries = -1;
 		readonly #defaultPageFetchLimit = 50;
 
-		async content(
-			params?: FetchContentMethodParams
-		): Promise<Content[] | ContentEdge[]> {
+		async content<Params extends FetchContentMethodParams>(
+			params?: Params
+		): Promise<ContentResponse<Params>> {
 			const {
 				cursor,
 				nacelleEntryIds,
@@ -156,13 +162,15 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 				ContentFilterInput
 			>(this, 'allContent', filter, maxReturnedEntries, edgesToNodes);
 
-			return await (this as unknown as StorefrontClient)['applyAfter'](
+			return (await (this as unknown as StorefrontClient)['applyAfter'](
 				'content',
 				responseData
-			);
+			)) as ContentResponse<Params>;
 		}
 
-		async products(params?: CommerceQueriesParams) {
+		async products<Params extends CommerceQueriesParams>(
+			params?: Params
+		): Promise<ProductsResponse<Params>> {
 			const {
 				cursor,
 				nacelleEntryIds,
@@ -207,12 +215,14 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 				ProductFilterInput
 			>(this, 'allProducts', filter, maxReturnedEntries, edgesToNodes);
 
-			return await (this as unknown as StorefrontClient)['applyAfter'](
+			return (await (this as unknown as StorefrontClient)['applyAfter'](
 				'products',
 				responseData
-			);
+			)) as ProductsResponse<Params>;
 		}
-		async productCollections(params?: FetchProductCollectionsMethodParams) {
+		async productCollections<
+			Params extends FetchProductCollectionsMethodParams
+		>(params?: Params): Promise<ProductCollectionsResponse<Params>> {
 			const {
 				cursor,
 				nacelleEntryIds,
@@ -266,14 +276,14 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 				maxReturnedEntriesPerCollection
 			);
 
-			return await (this as unknown as StorefrontClient)['applyAfter'](
+			return (await (this as unknown as StorefrontClient)['applyAfter'](
 				'productCollections',
 				responseData
-			);
+			)) as ProductCollectionsResponse<Params>;
 		}
-		async productCollectionEntries(
-			params?: FetchCollectionEntriesMethodParams
-		): Promise<Product[] | ProductEdge[]> {
+		async productCollectionEntries<
+			Params extends FetchCollectionEntriesMethodParams
+		>(params?: Params): Promise<ProductCollectionEntriesResponse<Params>> {
 			const {
 				collectionEntryId,
 				handle,
@@ -360,10 +370,10 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 				}
 			} while (keepFetching);
 
-			return await (this as unknown as StorefrontClient)['applyAfter'](
+			return (await (this as unknown as StorefrontClient)['applyAfter'](
 				'productCollectionEntries',
 				allEntries
-			);
+			)) as ProductCollectionEntriesResponse<Params>;
 		}
 	};
 }

--- a/packages/storefront-sdk-plugins/commerce-queries/src/types/relay.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/types/relay.ts
@@ -1,0 +1,41 @@
+import type { CommerceQueriesParams } from '../index.js';
+import type {
+	Content,
+	ContentEdge,
+	Product,
+	ProductCollection,
+	ProductCollectionEdge,
+	ProductEdge
+} from './storefront.js';
+
+export type EdgesToNodesParam = Pick<CommerceQueriesParams, 'edgesToNodes'>;
+
+/**
+ * By default, Commerce Queries methods should return node types
+ * if `edgesToNodes` is either not specified, or is explicitly set
+ * to `true`. If `edgesToNodes` is explicitly set to `false`, then
+ * the methods should return edge types.
+ */
+export type RelayResponse<
+	Params extends EdgesToNodesParam,
+	NodeType extends Content | Product | ProductCollection,
+	EdgeType extends ContentEdge | ProductEdge | ProductCollectionEdge
+> = Params extends { edgesToNodes: false } ? EdgeType[] : NodeType[];
+
+export type ContentResponse<Params extends EdgesToNodesParam> = RelayResponse<
+	Params,
+	Content,
+	ContentEdge
+>;
+
+export type ProductsResponse<Params extends EdgesToNodesParam> = RelayResponse<
+	Params,
+	Product,
+	ProductEdge
+>;
+
+export type ProductCollectionsResponse<Params extends EdgesToNodesParam> =
+	RelayResponse<Params, ProductCollection, ProductCollectionEdge>;
+
+export type ProductCollectionEntriesResponse<Params extends EdgesToNodesParam> =
+	RelayResponse<Params, Product, ProductEdge>;


### PR DESCRIPTION
## Why are these changes introduced?

Fixes [ENG-8882](https://nacelle.atlassian.net/browse/ENG-8882) <!-- link to Jira ticket if one exists -->

> Commerce queries methods aren't narrowing to a single return type

The `.content`, `.products`, `.productCollections`, and `.productCollectionEntries` methods should be narrowing their return types to a single type, depending on the value of `params.edgesToNodes`.

By narrowing from `Thing[] | ThingEdge[]` to either `Thing[]` or `ThingEdge[]` automatically, we save TypeScript developers from needing to assert the correct type.

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

- Adds [conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) to return `Thing[]` when `edgesToNodes` is `true` (which it is, by default) and `ThingEdge[]` when `edgesToNodes` is explicitly set to `false`.
- Updates tests to validate the types when `params.edgesToNodes` is unset, set to `true`, or set to `false`.
- Miscellaneous refactors to tests to improve consistency.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-8882-commerce-queries-methods-type-narrowing` branch.
2. Navigate to `packages/storefront-sdk-plugins/commerce-queries`.
3. `npm run coverage` - all tests should pass with 100% coverage:

![commerce queries plugin ENG-8882-commerce-queries-methods-type-narrowing branch all tests passing](https://user-images.githubusercontent.com/5732000/220796113-02fcc922-0803-414e-82a2-ee7a1bbc3a21.png)


## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-8882]: https://nacelle.atlassian.net/browse/ENG-8882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ