### PR TITLE
chore: rename commerce queries plugin

### DIFF
--- a/.changeset/chilled-timers-repair.md
+++ b/.changeset/chilled-timers-repair.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': minor
+'@nacelle/commerce-queries-plugin': minor
 ---
 
 Adds a `content` method to fetch the `allContent` data. Unlike the `content` method in the `@nacelle/storefront-sdk@1.x`, this returns a result object with the signature `{ error, data }` similar to how the `query` method works in `@nacelle/storefront-sdk@2.x` to allow users more control over error handling.

--- a/.changeset/curvy-horses-cheer.md
+++ b/.changeset/curvy-horses-cheer.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': minor
+'@nacelle/commerce-queries-plugin': minor
 ---
 
 Adds the products method to fetch products from your Nacelle index

--- a/.changeset/gold-pants-whisper.md
+++ b/.changeset/gold-pants-whisper.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': patch
+'@nacelle/commerce-queries-plugin': patch
 ---
 
 Added the `productCollectionEntries` method, which fetches product entries from a Nacelle space's collection.

--- a/.changeset/lucky-eyes-occur.md
+++ b/.changeset/lucky-eyes-occur.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': patch
+'@nacelle/commerce-queries-plugin': patch
 ---
 
 Adds error handling to commerce queries & makes commerce queries return data directly instead of `{ data, error }`

--- a/.changeset/mean-weeks-begin.md
+++ b/.changeset/mean-weeks-begin.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': minor
+'@nacelle/commerce-queries-plugin': minor
 ---
 
 Added the `productCollections` method, which fetches data from a Nacelle space's collections index.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,7 +14,7 @@
     "@nacelle/shopify-cart": "1.0.0",
     "@nacelle/shopify-checkout": "0.1.2",
     "@nacelle/storefront-sdk": "1.8.0",
-    "@nacelle/storefront-sdk-plugin-commerce-queries": "0.0.0",
+    "@nacelle/commerce-queries-plugin": "0.0.0",
     "@nacelle/vue": "0.0.16",
     "nacelle-reference-store-gatsby": "1.0.1",
     "nacelle-next-reference-store": "0.1.4",

--- a/.changeset/silver-dolphins-promise.md
+++ b/.changeset/silver-dolphins-promise.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': patch
+'@nacelle/commerce-queries-plugin': patch
 ---
 
 Add `navigation` method to fetch navigation data from a Nacelle space.

--- a/.changeset/swift-snails-appear.md
+++ b/.changeset/swift-snails-appear.md
@@ -1,5 +1,5 @@
 ---
-'@nacelle/storefront-sdk-plugin-commerce-queries': patch
+'@nacelle/commerce-queries-plugin': patch
 ---
 
 Add `spaceProperties` method to fetch space properties from a Nacelle space.

--- a/packages/storefront-sdk-plugins/commerce-queries/CHANGELOG.md
+++ b/packages/storefront-sdk-plugins/commerce-queries/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @nacelle/storefront-sdk-plugin-commerce-queries
+# @nacelle/commerce-queries-plugin
 
 ## 1.0.0-beta.1
 

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "@nacelle/storefront-sdk-plugin-commerce-queries",
-	"version": "0.1.0-beta.0",
+	"name": "@nacelle/commerce-queries-plugin",
+	"version": "1.0.0-beta.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@nacelle/storefront-sdk-plugin-commerce-queries",
-			"version": "0.1.0-beta.0",
+			"name": "@nacelle/commerce-queries-plugin",
+			"version": "1.0.0-beta.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@graphql-codegen/cli": "2.16.1",
@@ -14,7 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
-				"@nacelle/storefront-sdk": "^2.0.0-beta.0",
+				"@nacelle/storefront-sdk": "^2.0.0-beta.1",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -33,7 +33,7 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": "^2.0.0-beta.0",
+				"@nacelle/storefront-sdk": "^2.0.0-beta.1",
 				"graphql": "^16.6.0"
 			}
 		},
@@ -2562,11 +2562,14 @@
 			}
 		},
 		"node_modules/@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.0.tgz",
-			"integrity": "sha512-G+VXTWfDPSt6impAFC/4igjg52+V0Adt6dz+e0KHc6J0e5xRBEWJuzkAwDA6CU8tSroOP7gy36xFzrbDtshZBw==",
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.1.tgz",
+			"integrity": "sha512-fOKMEFT7vKAd7wIEM9aG82jHuuXmrQB7gxNZXIMISoIYzTceRxKIkke3Zpo2krElD5/BVYQgX7ZnCMFdvZgHww==",
 			"dev": true,
 			"dependencies": {
+				"@urql/core": "^3.1.1",
+				"@urql/exchange-persisted-fetch": "^2.0.0",
+				"@urql/exchange-retry": "^1.0.0",
 				"graphql": "^16.6.0"
 			},
 			"engines": {
@@ -3072,6 +3075,44 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@urql/core": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"dev": true,
+			"dependencies": {
+				"wonka": "^6.1.2"
+			},
+			"peerDependencies": {
+				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@urql/exchange-persisted-fetch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.1.0.tgz",
+			"integrity": "sha512-rWNpbCskNiRjrvN5q5nnbMXI7UMrgIYv2eHSW+zFAfU8V5jf0KiQ11h1gOXyAfpNaG1mq4m0DRIPqeXg0AzQQw==",
+			"dev": true,
+			"dependencies": {
+				"@urql/core": ">=3.1.1",
+				"wonka": "^6.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@urql/exchange-retry": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
+			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
+			"dev": true,
+			"dependencies": {
+				"@urql/core": ">=3.0.0",
+				"wonka": "^6.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
@@ -8553,6 +8594,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/wonka": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.2.3.tgz",
+			"integrity": "sha512-EFOYiqDeYLXSzGYt2X3aVe9Hq1XJG+Hz/HjTRRT4dZE9q95khHl5+7pzUSXI19dbMO1/2UMrTf7JT7/7JrSQSQ==",
+			"dev": true
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -10545,11 +10592,14 @@
 			}
 		},
 		"@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.0.tgz",
-			"integrity": "sha512-G+VXTWfDPSt6impAFC/4igjg52+V0Adt6dz+e0KHc6J0e5xRBEWJuzkAwDA6CU8tSroOP7gy36xFzrbDtshZBw==",
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.1.tgz",
+			"integrity": "sha512-fOKMEFT7vKAd7wIEM9aG82jHuuXmrQB7gxNZXIMISoIYzTceRxKIkke3Zpo2krElD5/BVYQgX7ZnCMFdvZgHww==",
 			"dev": true,
 			"requires": {
+				"@urql/core": "^3.1.1",
+				"@urql/exchange-persisted-fetch": "^2.0.0",
+				"@urql/exchange-retry": "^1.0.0",
 				"graphql": "^16.6.0"
 			}
 		},
@@ -10917,6 +10967,35 @@
 			"requires": {
 				"@typescript-eslint/types": "5.48.1",
 				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@urql/core": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
+			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"dev": true,
+			"requires": {
+				"wonka": "^6.1.2"
+			}
+		},
+		"@urql/exchange-persisted-fetch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.1.0.tgz",
+			"integrity": "sha512-rWNpbCskNiRjrvN5q5nnbMXI7UMrgIYv2eHSW+zFAfU8V5jf0KiQ11h1gOXyAfpNaG1mq4m0DRIPqeXg0AzQQw==",
+			"dev": true,
+			"requires": {
+				"@urql/core": ">=3.1.1",
+				"wonka": "^6.0.0"
+			}
+		},
+		"@urql/exchange-retry": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
+			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
+			"dev": true,
+			"requires": {
+				"@urql/core": ">=3.0.0",
+				"wonka": "^6.0.0"
 			}
 		},
 		"@vitest/coverage-c8": {
@@ -14938,6 +15017,12 @@
 				"has-tostringtag": "^1.0.0",
 				"is-typed-array": "^1.1.10"
 			}
+		},
+		"wonka": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.2.3.tgz",
+			"integrity": "sha512-EFOYiqDeYLXSzGYt2X3aVe9Hq1XJG+Hz/HjTRRT4dZE9q95khHl5+7pzUSXI19dbMO1/2UMrTf7JT7/7JrSQSQ==",
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "@nacelle/storefront-sdk-plugin-commerce-queries",
-	"version": "1.0.0-beta.1",
+	"name": "@nacelle/commerce-queries-plugin",
+	"version": "1.0.0-beta.0",
 	"description": "A Nacelle Storefront SDK plugin that provides REST-style methods for fetching commerce data",
 	"type": "module",
 	"author": "Nacelle Inc.",


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

The original package name (`@nacelle/storefront-sdk-plugin-commerce-queries`) was cumbersome.

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

- Renames the package from `@nacelle/storefront-sdk-plugin-commerce-queries` to `@nacelle/commerce-queries-plugin`.
- Adjusts changesets and the `.changeset/pre.json` accordingly.

## Next steps

After this PR is merged, we can manually publish `@nacelle/commerce-queries-plugin@1.0.0-beta.0`. This will allow us to publish further `@1.0.0-beta.x` versions using our typical `changesets/action` workflow going forward.