### PR TITLE
refactor: prefer named export; export types

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, it, beforeEach, describe, vi, expectTypeOf } from 'vitest';
-import commerceQueriesPlugin from './index.js';
+import { commerceQueriesPlugin } from './index.js';
 import { StorefrontClient } from '@nacelle/storefront-sdk';
 import getFetchPayload from '../__mocks__/utils/getFetchPayload.js';
 import SpacePropertiesResult from '../__mocks__/gql/spaceProperties.js';

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -368,4 +368,18 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 	};
 }
 
-export default commerceQueriesPlugin;
+export {
+	commerceQueriesPlugin,
+	Content,
+	ContentEdge,
+	ContentFilterInput,
+	NavigationGroup,
+	NavigationFilterInput,
+	Product,
+	ProductCollection,
+	ProductCollectionEdge,
+	ProductCollectionFilterInput,
+	ProductEdge,
+	ProductFilterInput,
+	SpaceProperties
+};


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8893](https://nacelle.atlassian.net/browse/ENG-8893) <!-- link to Jira ticket if one exists -->

> Export types and plugin as named exports

<!--
  Context about the problem that's being addressed. Use bullets or ordered lists for multiple touch points.
-->

To support TypeScript developers who will be transitioning from version `1.x` to `2.x` of `@nacelle/storefront-sdk`, we should export types associated with the Commerce Queries plugin's methods. We can leave additional Nacelle types up to the developer via GraphQL Codegen (which we will have `2.x` docs for).

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

1. Exports types used by the Commerce Queries plugin, from the commerce queries plugin.
2. Changes the Commerce Queries plugin from a default export to a named export, to prevent issues related to mixed default & named exports.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-8893-export-types-and-plugin-as-named-exports` branch.
2. Navigate to `packages/storefront-sdk-plugins/commerce-queries`.
3. `npm run build` - it should build without errors.
4. `npm run coverage` - all tests should pass with 100% coverage:

![commerce queries plugin ENG-8893-export-types-and-plugin-as-named-exports branch all tests passing](https://user-images.githubusercontent.com/5732000/220810145-8f03f06b-1f24-47be-85ce-4d2d5d3e569b.png)


## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.


[ENG-8893]: https://nacelle.atlassian.net/browse/ENG-8893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ