### PR TITLE
fix: externalize dependencies

### DIFF
--- a/packages/storefront-sdk/vite.config.ts
+++ b/packages/storefront-sdk/vite.config.ts
@@ -15,10 +15,17 @@ export const config: UserConfig = {
 		sourcemap: true,
 		target: 'es2022',
 		rollupOptions: {
-			external: ['@urql/core', 'graphql'],
+			external: [
+				'@urql/core',
+				'@urql/exchange-persisted-fetch',
+				'@urql/exchange-retry',
+				'graphql'
+			],
 			output: {
 				globals: {
 					'@urql/core': 'Urql',
+					'@urql/exchange-persisted-fetch': 'UrqlExchangePersistedFetch',
+					'@urql/exchange-retry': 'UrqlExchangeRetry',
 					graphql: 'Graphql'
 				}
 			}


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Fixes [ENG-8711](https://nacelle.atlassian.net/browse/ENG-8711) <!-- link to Jira ticket if one exists -->

> Nuxt 2 throws webpack warnings and errors when using the sdk v2 transpiled

The ticket describes a webpack warning in Nuxt 2 projects using `@nacelle/storefront-sdk@1.0.0-beta.1`:

> WARNING in [file] [line]:[column-range]
> Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

When we inspect the Storefront SDK's bundled code, we can find the `new Function("require")` that the warning refers to:

![nuxt 2 webpack 4 warning require function](https://user-images.githubusercontent.com/5732000/221106217-61debcd0-f47f-4611-969f-484dce62835a.png)

This code is from `@urql/exchange-persisted-fetch`: https://github.com/urql-graphql/urql/blob/34f83b14af9531f0335cd1c9d9fa3bfc8a6835a1/exchanges/persisted-fetch/src/sha256.ts#L19

Recognizing this made it clear that `@urql/exchange-persisted-fetch` was being unexpectedly bundled in the `@nacelle/storefront-sdk` code. This was also the case for `@urql/exchange-retry`.

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

This PR externalizes some dependencies that were being included in the `@nacelle/storefront-sdk` bundle. This fixes the issue described above.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the [`test-storefront-sdk-v2-with-nuxt-2`](https://github.com/getnacelle/test-storefront-sdk-v2-with-nuxt-2) project's main branch.
2. `npm i && npm run dev` - you should see the error message described in the ticket (in the console).
3. Check out the `ENG-8711-externalize-dependencies` branch of `nacelle-js`.
4. Navigate to `packages/storefront-sdk`.
5. `npm run build`.
6. Use `npm link`/`npm link -S @nacelle/storefront-sdk` to link `packages/storefront-sdk` to the [`test-storefront-sdk-v2-with-nuxt-2`](https://github.com/getnacelle/test-storefront-sdk-v2-with-nuxt-2) project.
7. When running `npm run dev` again, there should be no "Critical dependency" warnings.

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.

[ENG-8711]: https://nacelle.atlassian.net/browse/ENG-8711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ