### PR TITLE
build: skip lockfile updates when versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           commit: 'build: version packages'
           title: 'build: version packages'
-          version: npm run version
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:


### PR DESCRIPTION
## Why are these changes introduced?

Our **Release** workflows have been failing in the `ENG-8179/storefront-sdk-2.0` branch. For example: https://github.com/getnacelle/nacelle-js/actions/runs/4257668429/jobs/7408059052

```
nacelle/commerce-queries-plugin: npm ERR! code ETARGET
@nacelle/commerce-queries-plugin: npm ERR! notarget No matching version found for @nacelle/storefront-sdk@^2.0.0-beta.2.
@nacelle/commerce-queries-plugin: npm ERR! notarget In most cases you or one of your dependencies are requesting
@nacelle/commerce-queries-plugin: npm ERR! notarget a package version that doesn't exist.
@nacelle/commerce-queries-plugin: npm ERR! A complete log of this run can be found in:
@nacelle/commerce-queries-plugin: npm ERR!     /home/runner/.npm/_logs/2023-02-23T23_14_47_031Z-debug-0.log
lerna ERR! npm run lockfile:update exited 1 in '@nacelle/commerce-queries-plugin'
lerna ERR! npm run lockfile:update stdout:

> @nacelle/commerce-queries-plugin@1.0.0-beta.1 lockfile:update
> npm i --package-lock-only

lerna ERR! npm run lockfile:update stderr:
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @nacelle/storefront-sdk@^2.0.0-beta.2.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

The problem is that we are prematurely attempting to update package lockfiles. Rather than trying to update package lockfiles alongside `changesets version`, we should instead update lockfiles only after packages have been published.

## What is this pull request doing?

This PR updates our **Release** workflow to skip lockfile updates in the versioning and publishing process. This is a temporary measure that will allow us to release packages, at the expense of requiring that we update lockfiles ourselves via `lerna run --parallel lockfile:update` after packages have been published. This is a temporary situation until we can pursue a more robust pipeline.

## Next steps

[changesets/action](https://github.com/changesets/action) outputs a published boolean “to indicate whether a publishing is happened or not," so maybe we could leverage this in our Release workflow to conditionally run `lerna run --parallel lockfile:update` if packages have actually been published. We would also need something like https://github.com/ad-m/github-push-action to handle the action of commiting lockfile changes to the target branch.

We have a ticket to capture this next step: [ENG-8930](https://nacelle.atlassian.net/browse/ENG-8930)

[ENG-8930]: https://nacelle.atlassian.net/browse/ENG-8930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ