### PR TITLE
chore: rename commerce query outputs

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -38,12 +38,12 @@
 	"exports": {
 		".": {
 			"types": "./dist/types/index.d.ts",
-			"import": "./dist/nacelle-storefront-sdk-plugin-commerce-queries.js",
-			"require": "./dist/nacelle-storefront-sdk-plugin-commerce-queries.umd.cjs"
+			"import": "./dist/nacelle-commerce-queries-plugin.js",
+			"require": "./dist/nacelle-commerce-queries-plugin.umd.cjs"
 		}
 	},
-	"main": "./dist/nacelle-storefront-sdk-plugin-commerce-queries.umd.cjs",
-	"module": "./dist/nacelle-storefront-sdk-plugin-commerce-queries.js",
+	"main": "./dist/nacelle-commerce-queries-plugin.umd.cjs",
+	"module": "./dist/nacelle-commerce-queries-plugin.js",
 	"types": "./dist/types/index.d.ts",
 	"sideEffects": false,
 	"directories": {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, it, beforeEach, describe, vi, expectTypeOf } from 'vitest';
-import { commerceQueriesPlugin } from './index.js';
+import { CommerceQueries } from './index.js';
 import { StorefrontClient } from '@nacelle/storefront-sdk';
 import getFetchPayload from '../__mocks__/utils/getFetchPayload.js';
 import SpacePropertiesResult from '../__mocks__/gql/spaceProperties.js';
@@ -46,7 +46,7 @@ const storefrontEndpoint =
 
 const mockedFetch: Mock<mockRequestArgs, Promise<Response>> = vi.fn();
 
-const ClientWithCommerceQueries = commerceQueriesPlugin(StorefrontClient);
+const ClientWithCommerceQueries = CommerceQueries(StorefrontClient);
 const client = new ClientWithCommerceQueries({
 	storefrontEndpoint,
 	fetchClient: mockedFetch as (

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.ts
@@ -68,7 +68,7 @@ export interface FetchCollectionEntriesMethodParams {
 	advancedOptions?: FetchMethodAdvancedParams;
 }
 
-function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
+function CommerceQueries<TBase extends WithStorefrontQuery & WithConfig>(
 	Base: TBase
 ) {
 	return class CommerceQueries extends Base {
@@ -378,8 +378,8 @@ function commerceQueriesPlugin<TBase extends WithStorefrontQuery & WithConfig>(
 	};
 }
 
-export {
-	commerceQueriesPlugin,
+export { CommerceQueries };
+export type {
 	Content,
 	ContentEdge,
 	ContentFilterInput,

--- a/packages/storefront-sdk-plugins/commerce-queries/vite.config.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/vite.config.ts
@@ -7,7 +7,7 @@ export const config: UserConfig = {
 	build: {
 		lib: {
 			entry: path.resolve(__dirname, 'src', 'index.ts'),
-			fileName: 'nacelle-storefront-sdk-plugin-commerce-queries',
+			fileName: 'nacelle-commerce-queries-plugin',
 			name: 'NacelleStorefrontSdkPluginCommerceQueries'
 		},
 		sourcemap: true,


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-8958](https://nacelle.atlassian.net/browse/ENG-8958)

> Rename export of Commerce Queries plugin

- The Commerce Queries Plugin package name was changed in #337, but the build output filenames weren't changed alongside the package name.
- We wanted to rename the named export for clarity.

## What is this pull request doing?

1. Renamed the named export from `commerceQueriesPlugin` to `CommerceQueries`.
2. Renames the files generated by the Commerce Query Plugin's `build` script.

## How to Test

1. Check out the `chore/rename-commerce-query-outputs` branch.
3. Navigate to `packages/storefront-sdk-plugins/commerce-queries`.
4. `npm run build`
5. `ls dist/` - all files should be named `nacelle-storefront-sdk-plugin-commerce-queries`.
6. `npm run coverage` - all tests should pass with 100% coverage.

If you want to go the extra mile, you can test `@nacelle/commerce-queries-plugin` in a project with `npm link`. When I did that, I found that everything continued to work as expected:

![vite demo commerce queries plugin chore:rename-commerce-query-outputs branch](https://user-images.githubusercontent.com/5732000/222491531-8eabf281-7999-4f08-8716-095fc118127c.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.


[ENG-8958]: https://nacelle.atlassian.net/browse/ENG-8958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ