### PR TITLE
fix: export types to decouple packages

### DIFF
--- a/.changeset/selfish-pumpkins-add.md
+++ b/.changeset/selfish-pumpkins-add.md
@@ -1,0 +1,6 @@
+---
+'@nacelle/storefront-sdk': patch
+'@nacelle/commerce-queries-plugin': patch
+---
+
+Fixed a TypeScript issue that was creating an undesirable coupling between the Storefront SDK and Commerce Queries plugin.

--- a/packages/storefront-sdk-plugins/commerce-queries/tsconfig.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"compilerOptions": {
 		"rootDir": ".",
-		"baseUrl": ".",
 		"strict": true,
 		"target": "ES2022",
 		"allowJs": true,
@@ -14,7 +13,6 @@
 		"sourceMap": true,
 		"declaration": true,
 		"declarationDir": "dist",
-		"preserveSymlinks": true,
 		"emitDeclarationOnly": true,
 		"useDefineForClassFields": true,
 		"noUnusedLocals": true,

--- a/packages/storefront-sdk-plugins/commerce-queries/tsconfig.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/tsconfig.json
@@ -2,9 +2,6 @@
 	"compilerOptions": {
 		"rootDir": ".",
 		"baseUrl": ".",
-		"paths": {
-			"@nacelle/storefront-sdk": ["../../storefront-sdk/dist/types/index.d.ts"]
-		},
 		"strict": true,
 		"target": "ES2022",
 		"allowJs": true,

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,6 +1,5 @@
 import { StorefrontClient } from './client/index.js';
 import type { StorefrontResponse, QueryParams } from './client/index.js';
-export type { StorefrontConfig } from './types/config.js';
 
 export interface StorefrontClientAdvancedOptions {
 	/**
@@ -30,3 +29,5 @@ export interface StorefrontClientParams {
 export { StorefrontClient };
 export * from './types/plugins.js';
 export type { StorefrontResponse, QueryParams };
+export type { StorefrontConfig } from './types/config.js';
+export type { AnyVariables } from '@urql/core';

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,5 +1,6 @@
 import { StorefrontClient } from './client/index.js';
 import type { StorefrontResponse, QueryParams } from './client/index.js';
+export type { StorefrontConfig } from './types/config.js';
 
 export interface StorefrontClientAdvancedOptions {
 	/**

--- a/packages/storefront-sdk/src/types/config.ts
+++ b/packages/storefront-sdk/src/types/config.ts
@@ -1,4 +1,3 @@
-import type { Maybe } from './storefront.js';
 import type {
 	StorefrontClientAdvancedOptions,
 	StorefrontClientParams
@@ -6,9 +5,10 @@ import type {
 import type { AfterSubscriptions, DataFetchingMethodName } from './after.js';
 
 export interface SetConfigParams {
-	previewToken?: Maybe<string>;
-	advancedOptions?: Maybe<StorefrontClientAdvancedOptions>;
+	previewToken?: string;
+	advancedOptions?: StorefrontClientAdvancedOptions;
 }
+
 export interface SetConfigResponse {
 	endpoint: string;
 	previewToken: string | undefined;

--- a/packages/storefront-sdk/src/types/config.ts
+++ b/packages/storefront-sdk/src/types/config.ts
@@ -5,7 +5,7 @@ import type {
 import type { AfterSubscriptions, DataFetchingMethodName } from './after.js';
 
 export interface SetConfigParams {
-	previewToken?: string;
+	previewToken?: string | null;
 	advancedOptions?: StorefrontClientAdvancedOptions;
 }
 


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8957](https://nacelle.atlassian.net/browse/ENG-8957) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

> Remove `compilerOptions.paths` from the Commerce Queries plugin's tsconfig

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

### Storefront SDK

- Simplifies types
- Exports a type that's needed to support the `WithConfig` type

### Commerce Queries Plugin

- Removes the coupling to `@nacelle/storefront-sdk` types via `compilerOptions.paths` in `tsconfig.json`
- Simplifies `tsconfig.json`

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-8957-remove-compileroptions-paths` branch
2. `npm run bootstrap` (as needed)
3. Navigate to `packages/storefront-sdk`
4. `npm run build && npm run coverage` - the package should build and all tests should pass with 100% coverage
5. Navigate to `packages/storefront-sdk-plugins/commerce-queries`
6. `npm run build && npm run coverage` - the package should build and all tests should pass with 100% coverage

If you'd like to go the extra mile, you can use the Storefront SDK and Commerce Queries plugin in a local TypeScript project via `npm link`. When I did that, I found that the project worked as expected without any errors, warnings, or other issues:

![vite demo storefront sdk with commerce queries ENG-8957-remove-compileroptions-paths branch](https://user-images.githubusercontent.com/5732000/222558973-f8ffa6a9-38a4-4cd6-b799-4f85d1e636c7.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-8957]: https://nacelle.atlassian.net/browse/ENG-8957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ