### PR TITLE
fix: do not send request variables as strings

### DIFF
--- a/.changeset/brown-dryers-refuse.md
+++ b/.changeset/brown-dryers-refuse.md
@@ -2,4 +2,4 @@
 '@nacelle/storefront-sdk': patch
 ---
 
-Updated the `query` method to always send variables as objects. Previously, the `query` method could send variables as a stringified object. This change circumvents issues related to using a combination of APQ and stringified variables in Nacelle's Storefront GraphQL.
+Updated the `query` method to always send variables to the Storefront GraphQL API as objects, even if they are supplied to the `query` method as a stringified object. This change circumvents issues related to using a combination of APQ and stringified variables in Nacelle's Storefront GraphQL.

--- a/.changeset/brown-dryers-refuse.md
+++ b/.changeset/brown-dryers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Updated the `query` method to always send variables as objects. Previously, the `query` method could send variables as a stringified object. This change circumvents issues related to using a combination of APQ and stringified variables in Nacelle's Storefront GraphQL.

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nacelle/storefront-sdk",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nacelle/storefront-sdk",
-			"version": "2.0.0-beta.3",
+			"version": "2.0.0-beta.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@urql/core": "^3.1.1",

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -281,8 +281,18 @@ export class StorefrontClient {
 		query,
 		variables
 	}: QueryParams<QData, QVariables>): Promise<StorefrontResponse<QData>> {
+		let queryVars = variables;
+
+		try {
+			if (typeof variables === 'string') {
+				queryVars = JSON.parse(variables) as QVariables;
+			}
+		} catch (err) {
+			throw new Error(`Could not parse request variables: ${err as string}`);
+		}
+
 		return this.#graphqlClient
-			.query(query, variables as QVariables)
+			.query(query, queryVars as QVariables)
 			.toPromise()
 			.then(({ data, error }) => {
 				if (error) {


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9013](https://nacelle.atlassian.net/browse/ENG-9013) <!-- link to Jira ticket if one exists -->

> Do not send request variables as strings

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

This PR:
1. Updates the Storefront SDK to ensure that `query` method requests always include `variables` in object form, rather than stringified objects. This circumvents an issue related to APQ and stringified variables.
2. Updates tests to validate (1).
3. Updates the Storefront SDK's lockfile.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-9013/do-not-send-request-variables-as-strings` branch.
2. Navigate to the `packages/storefront-sdk` directory.
3. `npm run build` - the package should build without errors.
4. `npm run coverage` - all tests should pass with 100% coverage.

When I tested this with a local Vite project (that was set up to test https://github.com/getnacelle/compatibility-connector/pull/115), I found that requests that use the `query` method were working as expected. Stringified variables were converted to objects, which resolved the earlier issue with APQ + stringified variables:

![Vite demo SDK 2 x with Compatibility Connector with collectionPage method](https://user-images.githubusercontent.com/5732000/223256155-b8b7e2cd-920f-4ec1-b8f2-22729cc588c0.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-9013]: https://nacelle.atlassian.net/browse/ENG-9013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ