### PR TITLE
chore(ENG-8934): update package-lock files after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NACELLE_NPMJS_TOKEN }}
 
+      - name: Update and commit lockfiles
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          lerna run --parallel lockfile:update
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -a -m "chore(publish): [skip ci] Update lockfiles"
+
+      - name: Commit lockfile changes
+        if: steps.changesets.outputs.published == 'true'
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
       - name: Shopify Checkout - npm run test:coverage
         if: steps.changes.outputs.shopify-checkout == 'true'
         run: npm run test:coverage


### PR DESCRIPTION
@NWRichmond following your details outlined [here](https://nacelle.atlassian.net/browse/ENG-8930), the release workflow has been updated to:

- run `lerna run --parallel lockfile:update`
- commit the changes back to the existing `ref` branch using the github actions bot user.
- push the changes back to the `ref` target