### PR TITLE
fix: set preview query param

### DIFF
--- a/.changeset/rotten-monkeys-switch.md
+++ b/.changeset/rotten-monkeys-switch.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Fixed an issue that prevented the Storefront SDK from entering preview mode when initializing the client with a `previewToken`.

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -543,30 +543,18 @@ describe('the `query` method', () => {
 	});
 });
 
-it('can initialize with preview token', () => {
+it('sets the expected header and query param when initialized with a `previewToken`', () => {
+	const myPreviewToken = 'xxx';
 	const client = new StorefrontClient({
 		storefrontEndpoint,
-		previewToken: 'xxx'
-	});
-	expect(client).toBeInstanceOf(StorefrontClient);
-});
-
-it('`setConfig` sets preview data', () => {
-	const client = new StorefrontClient({
-		storefrontEndpoint,
-		locale: 'en-US'
+		previewToken: myPreviewToken
 	});
 
-	expect(client.setConfig({ previewToken: 'xxx' })).toStrictEqual({
-		endpoint:
-			'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id?preview=true',
-		previewToken: 'xxx'
-	});
-	expect(client.setConfig({})).toStrictEqual({
-		endpoint:
-			'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id',
-		previewToken: undefined
-	});
+	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
+
+	expect(previewToken).toBe(myPreviewToken);
+	const storefrontEndpointUrl = new URL(endpoint);
+	expect(storefrontEndpointUrl.searchParams.get('preview')).toBe('true');
 });
 
 it('`getConfig` retrieves config', () => {
@@ -585,6 +573,35 @@ it('`getConfig` retrieves config', () => {
 			enableApq: true
 		}
 	});
+});
+
+it('sets the `previewToken` and query param when a `previewToken` is supplied to `setConfig`', () => {
+	const client = new StorefrontClient({
+		storefrontEndpoint,
+		locale: 'en-US'
+	});
+
+	const myPreviewToken = 'xxx';
+	client.setConfig({ previewToken: myPreviewToken });
+	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
+
+	expect(previewToken).toBe(myPreviewToken);
+	expect(new URL(endpoint).searchParams.get('preview')).toBe('true');
+});
+
+it('unsets the `previewToken` and query param when `setConfig` is called with `previewToken: null`', () => {
+	const client = new StorefrontClient({
+		storefrontEndpoint,
+		locale: 'en-US'
+	});
+
+	const myPreviewToken = 'xxx';
+	client.setConfig({ previewToken: myPreviewToken });
+	client.setConfig({ previewToken: null });
+	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
+
+	expect(previewToken).toBe(undefined);
+	expect(new URL(endpoint).searchParams.get('preview')).toBe(null);
 });
 
 it('makes requests with APQ enabled when `advancedOptions.enableApq is unset', async () => {

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -83,18 +83,21 @@ export class StorefrontClient {
 			throw new Error(errorMessages.missingEndpoint);
 		}
 
+		const storefrontEndpointUrl = new URL(params.storefrontEndpoint);
+		let headers = {};
+
+		if (params.previewToken) {
+			headers = { 'x-nacelle-space-token': params.previewToken };
+			storefrontEndpointUrl.searchParams.set('preview', 'true');
+		}
+
 		this.#config = {
 			fetchClient: params.fetchClient ?? globalThis.fetch,
-			storefrontEndpoint: params.storefrontEndpoint,
+			storefrontEndpoint: storefrontEndpointUrl.toString(),
 			previewToken: params.previewToken,
 			locale: params.locale ?? 'en-US',
 			advancedOptions: { enableApq: true, ...(params.advancedOptions ?? {}) }
 		};
-
-		let headers = {};
-		if (this.#config.previewToken) {
-			headers = { 'x-nacelle-space-token': this.#config.previewToken };
-		}
 
 		this.#graphqlClient = createClient({
 			url: this.#config.storefrontEndpoint,
@@ -157,14 +160,14 @@ export class StorefrontClient {
 			currentEndpoint.searchParams.delete('preview');
 		}
 
+		this.#config.storefrontEndpoint = currentEndpoint.toString();
+
 		if (setConfigParams.advancedOptions) {
 			this.#config.advancedOptions = {
 				...this.#config.advancedOptions,
 				...setConfigParams.advancedOptions
 			};
 		}
-
-		this.#config.storefrontEndpoint = currentEndpoint.toString();
 
 		this.#graphqlClient = createClient({
 			url: this.#config.storefrontEndpoint,


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Fixes [ENG-8179](https://nacelle.atlassian.net/browse/ENG-8179) <!-- link to Jira ticket if one exists -->

> Storefront SDK doesn't set the `preview` query param when initialized with a `previewToken`

## What is this pull request doing?

1. Ensures that `preview=true` is set on the `storefrontEndpoint` when the Storefront SDK is initialized with a `previewToken`.
2. Refactors tests for clarity/accuracy.

## How to Test

1. Check out the `ENG-9130/storefront-sdk-preview-query-param` branch.
2. Navigate to `packages/storefront-sdk`
3. `npm run build` - it should build without errors.
4. `npm run coverage` - it all tests should pass with 100% coverage:

![ENG-9130:storefront-sdk-preview-query-param branch all tests pasing](https://user-images.githubusercontent.com/5732000/225747047-64ee6cd5-1036-45b5-b028-4a356a6ba5cc.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-8179]: https://nacelle.atlassian.net/browse/ENG-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ