### PR TITLE
fix: preview token header

### DIFF
--- a/.changeset/silent-meals-push.md
+++ b/.changeset/silent-meals-push.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Fixed an issue with header names that was preventing the Storefront SDK from entering preview mode.

--- a/packages/storefront-sdk/src/client/createClient.test.ts
+++ b/packages/storefront-sdk/src/client/createClient.test.ts
@@ -6,7 +6,6 @@ vi.mock('@urql/core');
 
 const storefrontEndpoint =
 	'https://storefront.api.nacelle.com/graphql/v1/spaces/my-space-id';
-const previewToken = 'xxx';
 
 describe('`createClient`', () => {
 	beforeEach(() => {
@@ -14,12 +13,10 @@ describe('`createClient`', () => {
 	});
 
 	it('calls `createClient` with the expected params', () => {
-		const client = new StorefrontClient({
-			storefrontEndpoint,
-			locale: 'en-US'
-		});
-		client.setConfig({});
+		const client = new StorefrontClient({ storefrontEndpoint });
+		expect(createClient).toHaveBeenCalledTimes(1);
 
+		client.setConfig({});
 		expect(createClient).toHaveBeenCalledTimes(2);
 		expect(createClient).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -27,26 +24,6 @@ describe('`createClient`', () => {
 				fetch: globalThis.fetch,
 				fetchOptions: {
 					headers: {}
-				}
-			})
-		);
-	});
-
-	it('calls `createClient` with the expected params when `preview` is true', () => {
-		const client = new StorefrontClient({
-			storefrontEndpoint,
-			locale: 'en-US',
-			previewToken
-		});
-		client.setConfig({ previewToken });
-
-		expect(createClient).toHaveBeenCalledTimes(2);
-		expect(createClient).toHaveBeenCalledWith(
-			expect.objectContaining({
-				url: storefrontEndpoint + '?preview=true',
-				fetch: globalThis.fetch,
-				fetchOptions: {
-					headers: { 'x-nacelle-space-token': previewToken }
 				}
 			})
 		);

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -626,19 +626,19 @@ it('sets the `previewToken`, query param, and header when a `previewToken` is su
 });
 
 it('unsets the `previewToken`, query param, and header when `setConfig` is called with `previewToken: null`', async () => {
+	const myPreviewToken = 'xxx';
 	const client = new StorefrontClient({
 		storefrontEndpoint,
-		locale: 'en-US',
+		previewToken: myPreviewToken,
 		fetchClient: mockedFetch as (
 			input: RequestInfo | URL,
 			init?: RequestInit | undefined
 		) => Promise<Response>
 	});
+	expect(client.getConfig().previewToken).toBe(myPreviewToken);
 
-	client.setConfig({ previewToken: 'xxx' });
 	client.setConfig({ previewToken: null });
 	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
-
 	expect(previewToken).toBe(undefined);
 	expect(new URL(endpoint).searchParams.get('preview')).toBe(null);
 

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -13,7 +13,7 @@ import { StorefrontClient, retryStatusCodes } from './index.js';
 import { NavigationDocument } from '../../__mocks__/gql/operations.js';
 import getFetchPayload from '../../__mocks__/utils/getFetchPayload.js';
 import NavigationResult from '../../__mocks__/gql/navigation.js';
-import { errorMessages } from '../utils/index.js';
+import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
 import type { StorefrontResponse } from './index.js';
 import type {
 	NavigationGroup,
@@ -543,18 +543,36 @@ describe('the `query` method', () => {
 	});
 });
 
-it('sets the expected header and query param when initialized with a `previewToken`', () => {
+it('sets the expected header and query param when initialized with a `previewToken`', async () => {
+	mockedFetch.mockImplementationOnce(() => {
+		return Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }));
+	});
+
 	const myPreviewToken = 'xxx';
 	const client = new StorefrontClient({
 		storefrontEndpoint,
-		previewToken: myPreviewToken
+		previewToken: myPreviewToken,
+		fetchClient: mockedFetch as (
+			input: RequestInfo | URL,
+			init?: RequestInit | undefined
+		) => Promise<Response>
 	});
 
 	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
-
 	expect(previewToken).toBe(myPreviewToken);
+
 	const storefrontEndpointUrl = new URL(endpoint);
 	expect(storefrontEndpointUrl.searchParams.get('preview')).toBe('true');
+
+	await client.query({
+		query: `query { allContent { edges { node { nacelleEntryId } } } }`
+	});
+	expect(mockedFetch.mock.lastCall).not.toBeUndefined();
+	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
+	const requestHeaders = lastFetch[1]?.headers as HeadersInit & {
+		[X_NACELLE_PREVIEW_TOKEN]?: string;
+	};
+	expect(requestHeaders[X_NACELLE_PREVIEW_TOKEN]).toBe(myPreviewToken);
 });
 
 it('`getConfig` retrieves config', () => {
@@ -575,33 +593,64 @@ it('`getConfig` retrieves config', () => {
 	});
 });
 
-it('sets the `previewToken` and query param when a `previewToken` is supplied to `setConfig`', () => {
-	const client = new StorefrontClient({
-		storefrontEndpoint,
-		locale: 'en-US'
+it('sets the `previewToken`, query param, and header when a `previewToken` is supplied to `setConfig`', async () => {
+	mockedFetch.mockImplementationOnce(() => {
+		return Promise.resolve(getFetchPayload({ data: { allContent: '{}' } }));
 	});
 
 	const myPreviewToken = 'xxx';
+	const client = new StorefrontClient({
+		storefrontEndpoint,
+		locale: 'en-US',
+		fetchClient: mockedFetch as (
+			input: RequestInfo | URL,
+			init?: RequestInit | undefined
+		) => Promise<Response>
+	});
+
 	client.setConfig({ previewToken: myPreviewToken });
 	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
 
 	expect(previewToken).toBe(myPreviewToken);
 	expect(new URL(endpoint).searchParams.get('preview')).toBe('true');
+
+	await client.query({
+		query: `query { allContent { edges { node { nacelleEntryId } } } }`
+	});
+	expect(mockedFetch.mock.lastCall).not.toBeUndefined();
+	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
+	const requestHeaders = lastFetch[1]?.headers as HeadersInit & {
+		[X_NACELLE_PREVIEW_TOKEN]?: string;
+	};
+	expect(requestHeaders[X_NACELLE_PREVIEW_TOKEN]).toBe(myPreviewToken);
 });
 
-it('unsets the `previewToken` and query param when `setConfig` is called with `previewToken: null`', () => {
+it('unsets the `previewToken`, query param, and header when `setConfig` is called with `previewToken: null`', async () => {
 	const client = new StorefrontClient({
 		storefrontEndpoint,
-		locale: 'en-US'
+		locale: 'en-US',
+		fetchClient: mockedFetch as (
+			input: RequestInfo | URL,
+			init?: RequestInit | undefined
+		) => Promise<Response>
 	});
 
-	const myPreviewToken = 'xxx';
-	client.setConfig({ previewToken: myPreviewToken });
+	client.setConfig({ previewToken: 'xxx' });
 	client.setConfig({ previewToken: null });
 	const { previewToken, storefrontEndpoint: endpoint } = client.getConfig();
 
 	expect(previewToken).toBe(undefined);
 	expect(new URL(endpoint).searchParams.get('preview')).toBe(null);
+
+	await client.query({
+		query: `query { allContent { edges { node { nacelleEntryId } } } }`
+	});
+	expect(mockedFetch.mock.lastCall).not.toBeUndefined();
+	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
+	const requestHeaders = lastFetch[1]?.headers as HeadersInit & {
+		[X_NACELLE_PREVIEW_TOKEN]?: string;
+	};
+	expect(requestHeaders[X_NACELLE_PREVIEW_TOKEN]).toBeUndefined();
 });
 
 it('makes requests with APQ enabled when `advancedOptions.enableApq is unset', async () => {
@@ -612,7 +661,6 @@ it('makes requests with APQ enabled when `advancedOptions.enableApq is unset', a
 			init?: RequestInit | undefined
 		) => Promise<Response>
 	});
-	mockedFetch.mockRestore();
 	mockedFetch.mockImplementationOnce(() =>
 		Promise.resolve(getFetchPayload({ data: NavigationResult }))
 	);
@@ -630,7 +678,6 @@ it('makes requests with APQ enabled when `advancedOptions.enableApq is unset', a
 });
 
 it('makes requests with APQ disabled when `advancedOptions.enableApq` is false', async () => {
-	mockedFetch.mockRestore();
 	mockedFetch.mockImplementationOnce(() =>
 		Promise.resolve(getFetchPayload({ data: NavigationResult }))
 	);
@@ -642,6 +689,7 @@ it('makes requests with APQ disabled when `advancedOptions.enableApq` is false',
 
 	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
 	expect(lastFetch[0]).toEqual(storefrontEndpoint);
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	expect(JSON.parse(lastFetch[1]!.body!.toString())).toMatchObject(
 		expect.objectContaining({
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -688,7 +736,6 @@ it('disables APQ when `advancedOptions.enableAPQ` is set to false in `setConfig`
 		advancedOptions: { enableApq: true }
 	});
 	client.setConfig({ advancedOptions: { enableApq: false } });
-	mockedFetch.mockRestore();
 	mockedFetch.mockImplementationOnce(() =>
 		Promise.resolve(getFetchPayload({ data: NavigationResult }))
 	);
@@ -700,6 +747,7 @@ it('disables APQ when `advancedOptions.enableAPQ` is set to false in `setConfig`
 
 	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
 	expect(lastFetch[0]).toEqual(storefrontEndpoint);
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	expect(JSON.parse(lastFetch[1]!.body!.toString())).toMatchObject(
 		expect.objectContaining({
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,7 +1,7 @@
 import { createClient, dedupExchange, fetchExchange } from '@urql/core';
 import { retryExchange } from '@urql/exchange-retry';
 import { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
-import { errorMessages } from '../utils/index.js';
+import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
 import type {
 	Client as UrqlClient,
 	TypedDocumentNode,
@@ -87,7 +87,7 @@ export class StorefrontClient {
 		let headers = {};
 
 		if (params.previewToken) {
-			headers = { 'x-nacelle-space-token': params.previewToken };
+			headers = { [X_NACELLE_PREVIEW_TOKEN]: params.previewToken };
 			storefrontEndpointUrl.searchParams.set('preview', 'true');
 		}
 
@@ -154,7 +154,7 @@ export class StorefrontClient {
 		if (setConfigParams.previewToken) {
 			this.#config.previewToken = setConfigParams.previewToken;
 			currentEndpoint.searchParams.set('preview', 'true');
-			headers = { 'x-nacelle-space-token': this.#config.previewToken };
+			headers = { [X_NACELLE_PREVIEW_TOKEN]: this.#config.previewToken };
 		} else {
 			this.#config.previewToken = undefined;
 			currentEndpoint.searchParams.delete('preview');

--- a/packages/storefront-sdk/src/utils/constants.ts
+++ b/packages/storefront-sdk/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const X_NACELLE_PREVIEW_TOKEN = 'x-nacelle-preview-token';

--- a/packages/storefront-sdk/src/utils/index.ts
+++ b/packages/storefront-sdk/src/utils/index.ts
@@ -5,5 +5,6 @@
 
 // EXPORT UTILS
 // @index('./!(*.spec).ts', (f, _) => `export * from '${f.path}.js';`)
+export * from './constants.js';
 export * from './errorMessages.js';
 // @endindex


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9141](https://nacelle.atlassian.net/browse/ENG-9141) <!-- link to Jira ticket if one exists -->

> Storefront SDK uses wrong header name for preview token

#309 introduced a bug: instead of the preview token being set as [`x-nacelle-preview-token`](https://docs.nacelle.com/docs/preview-data#storefront-api), it was incorrectly set as `x-nacelle-space-token`.

## What is this pull request doing?

- Uses the correct header name to convey a Nacelle Preview Token to the Nacelle Storefront GraphQL API
- Refactors unit tests related to preview mode
  - Request headers are now tested for the correct header name and value
  - Removes a redundant test in `packages/storefront-sdk/src/client/createClient.test.ts`

## How to Test

1. Check out the `ENG-9141/fix-preview-token-header-name` branch
2. Navigate to `packages/storefront-sdk`
3. `npm run build` - the package should build without errors
4. `npm run coverage` - all tests should pass with 100% coverage

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-9141]: https://nacelle.atlassian.net/browse/ENG-9141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ