### PR TITLE
feat: accept `exchanges` in initialization params

### DIFF
--- a/.changeset/modern-pillows-peel.md
+++ b/.changeset/modern-pillows-peel.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': major
+---
+
+Adds an `exchanges` property to the Storefront SDK's initialization parameters. This new parameter allows Storefront SDK users to explicitly specify custom urql exchanges. All exchanges used by the Storefront SDK's urql client are now exported individually and as a pre-configured array of `defaultExchanges`. The `setConfig` parameter no longer allows APQ functionality to be changed on-the-fly. APQ can only be disabled by explicitly excluding the `persistedFetchExchange` in the exchanges array provided to the `exchanges` initialization parameter.

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -173,22 +173,13 @@ export class StorefrontClient {
 		}
 
 		this.#config.storefrontEndpoint = currentEndpoint.toString();
-
-		if (setConfigParams.advancedOptions) {
-			this.#config.advancedOptions = {
-				...this.#config.advancedOptions,
-				...setConfigParams.advancedOptions
-			};
-		}
-
 		this.#graphqlClient = createClient({
 			url: this.#config.storefrontEndpoint,
 			fetch: this.#config.fetchClient,
-			fetchOptions: {
-				headers
-			},
+			fetchOptions: { headers },
 			exchanges: this.#config.exchanges
 		});
+
 		return {
 			endpoint: this.#config.storefrontEndpoint,
 			previewToken: this.#config.previewToken

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -82,15 +82,18 @@ export const defaultExchanges: Exchange[] = [
 	fetchExchange
 ];
 
+interface StorefrontClientConfig {
+	exchanges: Exchange[];
+	fetchClient: typeof globalThis.fetch;
+	storefrontEndpoint: string;
+	previewToken: string | undefined;
+	locale: string;
+	advancedOptions: StorefrontClientAdvancedOptions;
+}
+
 export class StorefrontClient {
 	#graphqlClient: UrqlClient;
-	#config: {
-		fetchClient: typeof globalThis.fetch;
-		storefrontEndpoint: string;
-		previewToken: string | undefined;
-		locale: string;
-		advancedOptions: StorefrontClientAdvancedOptions;
-	};
+	#config: StorefrontClientConfig;
 	readonly #afterSubscriptions: AfterSubscriptions;
 	constructor(params: StorefrontClientParams) {
 		if (!params?.storefrontEndpoint) {
@@ -106,6 +109,7 @@ export class StorefrontClient {
 		}
 
 		this.#config = {
+			exchanges: params.exchanges ?? defaultExchanges,
 			fetchClient: params.fetchClient ?? globalThis.fetch,
 			storefrontEndpoint: storefrontEndpointUrl.toString(),
 			previewToken: params.previewToken,
@@ -119,7 +123,7 @@ export class StorefrontClient {
 			fetchOptions: {
 				headers
 			},
-			exchanges: defaultExchanges
+			exchanges: this.#config.exchanges
 		});
 		this.#afterSubscriptions = {};
 	}
@@ -128,11 +132,13 @@ export class StorefrontClient {
 	 * @returns an object containing the Storefront SDK configuration parameters: `storefrontEndpoint`, `previewToken`, `locale` and `afterSubscriptions`.
 	 */
 	getConfig(): StorefrontConfig {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { fetchClient, ...rest } = this.#config;
+		const { locale, previewToken, storefrontEndpoint } = this.#config;
+
 		return {
-			...rest,
-			afterSubscriptions: this.#afterSubscriptions
+			afterSubscriptions: this.#afterSubscriptions,
+			locale,
+			previewToken,
+			storefrontEndpoint
 		};
 	}
 
@@ -181,7 +187,7 @@ export class StorefrontClient {
 			fetchOptions: {
 				headers
 			},
-			exchanges: defaultExchanges
+			exchanges: this.#config.exchanges
 		});
 		return {
 			endpoint: this.#config.storefrontEndpoint,

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,6 +1,6 @@
 import { createClient, dedupExchange, fetchExchange } from '@urql/core';
 import { retryExchange as urqlRetryExchange } from '@urql/exchange-retry';
-import { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
+import { persistedFetchExchange as urqlPersistedFetchExchange } from '@urql/exchange-persisted-fetch';
 import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
 import type {
 	Client as UrqlClient,
@@ -69,6 +69,19 @@ export const retryExchange = urqlRetryExchange({
 	}
 });
 
+export const persistedFetchExchange = urqlPersistedFetchExchange({
+	preferGetForPersistedQueries: true
+});
+
+export const defaultExchanges: Exchange[] = [
+	// NOTE: the order of these exchanges matters!
+	// see the urql Exchanges docs for details.
+	dedupExchange,
+	retryExchange,
+	persistedFetchExchange,
+	fetchExchange
+];
+
 export class StorefrontClient {
 	#graphqlClient: UrqlClient;
 	#config: {
@@ -107,15 +120,7 @@ export class StorefrontClient {
 			fetchOptions: {
 				headers
 			},
-			exchanges: [
-				dedupExchange,
-				this.#retryExchange,
-				// only include persistedFetchExchange if `enableApq` is true
-				...(this.#config.advancedOptions.enableApq
-					? [persistedFetchExchange({ preferGetForPersistedQueries: true })]
-					: []),
-				fetchExchange
-			]
+			exchanges: defaultExchanges
 		});
 		this.#afterSubscriptions = {};
 	}
@@ -177,15 +182,7 @@ export class StorefrontClient {
 			fetchOptions: {
 				headers
 			},
-			exchanges: [
-				dedupExchange,
-				this.#retryExchange,
-				// only include persistedFetchExchange if `enableApq` is true
-				...(this.#config.advancedOptions.enableApq
-					? [persistedFetchExchange({ preferGetForPersistedQueries: true })]
-					: []),
-				fetchExchange
-			]
+			exchanges: defaultExchanges
 		});
 		return {
 			endpoint: this.#config.storefrontEndpoint,

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -92,7 +92,6 @@ export class StorefrontClient {
 		advancedOptions: StorefrontClientAdvancedOptions;
 	};
 	readonly #afterSubscriptions: AfterSubscriptions;
-	readonly #retryExchange: Exchange = retryExchange;
 	constructor(params: StorefrontClientParams) {
 		if (!params?.storefrontEndpoint) {
 			throw new Error(errorMessages.missingEndpoint);

--- a/packages/storefront-sdk/src/index.test.ts
+++ b/packages/storefront-sdk/src/index.test.ts
@@ -1,5 +1,12 @@
 import { expect, it } from 'vitest';
-import { StorefrontClient } from './index.js';
+import {
+	StorefrontClient,
+	dedupExchange,
+	defaultExchanges,
+	fetchExchange,
+	persistedFetchExchange,
+	retryExchange
+} from './index.js';
 import { errorMessages } from './utils/index.js';
 import type { StorefrontClientParams } from './index.js';
 
@@ -20,4 +27,18 @@ it('returns a `StorefrontClient` instance', () => {
 	const client = new StorefrontClient({ storefrontEndpoint });
 
 	expect(client).toBeInstanceOf(StorefrontClient);
+});
+
+it('exports the expected exchanges', () => {
+	expect(typeof dedupExchange).toBe('function');
+	expect(typeof fetchExchange).toBe('function');
+	expect(typeof persistedFetchExchange).toBe('function');
+	expect(typeof retryExchange).toBe('function');
+	expect(Array.isArray(defaultExchanges)).toBe(true);
+	expect(defaultExchanges).toStrictEqual([
+		dedupExchange,
+		retryExchange,
+		persistedFetchExchange,
+		fetchExchange
+	]);
 });

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,3 +1,5 @@
+import type { Exchange } from '@urql/core';
+
 export interface StorefrontClientAdvancedOptions {
 	/**
 	 * Controls whether or not Automatic Persisted Queries should be enabled when making requests. This is enabled by default and allows Nacelle to provide improved performance for repeated queries.
@@ -18,6 +20,9 @@ export interface StorefrontClientParams {
 
 	/** A custom fetch implementation. If not supplied, the Storefront SDK will use `globalThis.fetch`. */
 	fetchClient?: typeof globalThis.fetch;
+
+	/** Custom urql exchanges. If not provided, the client will use the `defaultExchanges` exported by the Storefront SDK. */
+	exchanges?: Exchange[];
 
 	/** Advanced options for configuring the Storefront SDK. These default to the recommended settings for most users. */
 	advancedOptions?: StorefrontClientAdvancedOptions;

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -1,6 +1,3 @@
-import { StorefrontClient } from './client/index.js';
-import type { StorefrontResponse, QueryParams } from './client/index.js';
-
 export interface StorefrontClientAdvancedOptions {
 	/**
 	 * Controls whether or not Automatic Persisted Queries should be enabled when making requests. This is enabled by default and allows Nacelle to provide improved performance for repeated queries.
@@ -19,15 +16,17 @@ export interface StorefrontClientParams {
 	/** An IETF locale string, e.g. 'en-US'.  */
 	locale?: string;
 
-	/** Optional fetch implementation. If not supplied, the Storefront SDK will use `globalThis.fetch`. */
+	/** A custom fetch implementation. If not supplied, the Storefront SDK will use `globalThis.fetch`. */
 	fetchClient?: typeof globalThis.fetch;
 
 	/** Advanced options for configuring the Storefront SDK. These default to the recommended settings for most users. */
 	advancedOptions?: StorefrontClientAdvancedOptions;
 }
 
-export { StorefrontClient };
+export { StorefrontClient, retryExchange } from './client/index.js';
+export { dedupExchange, fetchExchange } from '@urql/core';
+export { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
 export * from './types/plugins.js';
-export type { StorefrontResponse, QueryParams };
+export type { StorefrontResponse, QueryParams } from './client/index.js';
 export type { StorefrontConfig } from './types/config.js';
 export type { AnyVariables } from '@urql/core';

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -23,9 +23,13 @@ export interface StorefrontClientParams {
 	advancedOptions?: StorefrontClientAdvancedOptions;
 }
 
-export { StorefrontClient, retryExchange } from './client/index.js';
+export {
+	defaultExchanges,
+	persistedFetchExchange,
+	retryExchange,
+	StorefrontClient
+} from './client/index.js';
 export { dedupExchange, fetchExchange } from '@urql/core';
-export { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
 export * from './types/plugins.js';
 export type { StorefrontResponse, QueryParams } from './client/index.js';
 export type { StorefrontConfig } from './types/config.js';

--- a/packages/storefront-sdk/src/types/config.ts
+++ b/packages/storefront-sdk/src/types/config.ts
@@ -14,6 +14,7 @@ export interface SetConfigResponse {
 	previewToken: string | undefined;
 }
 
-export interface StorefrontConfig extends StorefrontClientParams {
+export interface StorefrontConfig
+	extends Omit<StorefrontClientParams, 'exchanges'> {
 	afterSubscriptions?: AfterSubscriptions;
 }


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8872](https://nacelle.atlassian.net/browse/ENG-8872) <!-- link to Jira ticket if one exists -->

> Allow developers to supply urql exchanges via an `exchanges` parameter

## What is this pull request doing?

This PR allows Storefront SDK users to supply [`exchanges`](https://formidable.com/open-source/urql/docs/architecture/#the-client-and-exchanges) in the `StorefrontClientParams`.

## How to Test

1. Check out the `ENG-8872/exchanges-param` branch
2. Navigate to the `packages/storefront-sdk` directory
3. `npm run build` - the package should build without errors
4. `npm run coverage` - all tests should pass with 100% coverage

![storefront sdk ENG-8872:exchanges-param branch all tests passing with 100% coverage](https://user-images.githubusercontent.com/5732000/234034514-a136d682-6341-445c-84ca-7f0186b525a1.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-8872]: https://nacelle.atlassian.net/browse/ENG-8872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ