### PR TITLE
fix: install sdk in commerce query type issue

### DIFF
--- a/.changeset/nine-taxis-fetch.md
+++ b/.changeset/nine-taxis-fetch.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/commerce-queries-plugin': patch
+---
+
+Updates types to avoid TypeScript errors during the build process

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -5,7 +5,6 @@ import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
 import type {
 	Client as UrqlClient,
 	TypedDocumentNode,
-	AnyVariables,
 	CombinedError,
 	Exchange
 } from '@urql/core';
@@ -32,7 +31,10 @@ export interface StorefrontResponse<QueryDocumentType> {
 	data?: QueryDocumentType;
 }
 
-export interface QueryParams<QData, QVariables extends AnyVariables> {
+export interface QueryParams<
+	QData,
+	QVariables extends Record<string, unknown> | undefined
+> {
 	/** GraphQL query */
 	query: TypedDocumentNode<QData, QVariables> | DocumentNode | string;
 
@@ -263,8 +265,12 @@ export class StorefrontClient {
 	 * 	variables: queryVariables
 	 * });
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	query<QData = any, QVariables extends AnyVariables = any>({
+	query<
+		/* eslint-disable @typescript-eslint/no-explicit-any */
+		QData = any,
+		QVariables extends Record<string, unknown> | undefined = any
+		/* eslint-enable @typescript-eslint/no-explicit-any */
+	>({
 		query,
 		variables
 	}: QueryParams<QData, QVariables>): Promise<StorefrontResponse<QData>> {

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -27,4 +27,3 @@ export { fetchExchange } from '@urql/core';
 export * from './types/plugins.js';
 export type { StorefrontResponse, QueryParams } from './client/index.js';
 export type { StorefrontConfig } from './types/config.js';
-export type { AnyVariables } from '@urql/core';


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9169](https://nacelle.atlassian.net/browse/ENG-9169) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

To correct an issue with types that prevented the commerce query plugin from building when installing the SDK rather than using symlinking

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

- Replaces `AnyVariables` in the Storefront SDK's query method with an inline type: `Record<string, unknown> | undefined`


## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

### In the SDK
- `npm run build`
- copy the `dist` folder

### In the Commerce Query plugin
- navigate to `node_modules/@nacelle/storefront-sdk`
- delete the `dist` folder and replace it with the one from the current SDK build


## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [ ] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [ ] Updated the `README.md` with documentation changes (if applicable).


[ENG-9169]: https://nacelle.atlassian.net/browse/ENG-9169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ