### PR TITLE
feat: upgrade internals to `@urql/core@4`

### DIFF
--- a/.changeset/silver-shirts-tan.md
+++ b/.changeset/silver-shirts-tan.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Upgraded the package internals to use `@urql/core` major version 4. This removes the dependency on the `graphql` package.

--- a/.changeset/twelve-rivers-bathe.md
+++ b/.changeset/twelve-rivers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/commerce-queries-plugin': patch
+---
+
+Removes `graphql` as an explicit peer dependency.

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nacelle/commerce-queries-plugin",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nacelle/commerce-queries-plugin",
-			"version": "1.0.0-beta.1",
+			"version": "1.0.0-beta.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@graphql-codegen/cli": "2.16.1",
@@ -14,7 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
-				"@nacelle/storefront-sdk": ">= 2.0.0-beta.0 || >= 2.0.0",
+				"@nacelle/storefront-sdk": ">=2.0.0-beta",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -33,8 +33,7 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": ">= 2.0.0-beta.0 || >= 2.0.0",
-				"graphql": "^16.6.0"
+				"@nacelle/storefront-sdk": ">=2.0.0-beta"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -5339,6 +5338,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -12684,7 +12684,8 @@
 		"graphql": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"dev": true
 		},
 		"graphql-config": {
 			"version": "4.3.6",

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -14,7 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
-				"@nacelle/storefront-sdk": ">=2.0.0-beta",
+				"@nacelle/storefront-sdk": ">=2.0.0-beta.9",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -33,7 +33,7 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": ">=2.0.0-beta"
+				"@nacelle/storefront-sdk": ">=2.0.0-beta.9"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -2561,9 +2561,9 @@
 			}
 		},
 		"node_modules/@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.1.tgz",
-			"integrity": "sha512-fOKMEFT7vKAd7wIEM9aG82jHuuXmrQB7gxNZXIMISoIYzTceRxKIkke3Zpo2krElD5/BVYQgX7ZnCMFdvZgHww==",
+			"version": "2.0.0-beta.9",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.9.tgz",
+			"integrity": "sha512-n0M0WiULLapkwB6pcjfivBrhSntDhAqBDCx+7YrwhFa6Gvva/g6wiTIvIIOo4/lu8MsY/qeYLAAwuzzBBrkcJg==",
 			"dev": true,
 			"dependencies": {
 				"@urql/core": "^3.1.1",
@@ -10592,9 +10592,9 @@
 			}
 		},
 		"@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.1.tgz",
-			"integrity": "sha512-fOKMEFT7vKAd7wIEM9aG82jHuuXmrQB7gxNZXIMISoIYzTceRxKIkke3Zpo2krElD5/BVYQgX7ZnCMFdvZgHww==",
+			"version": "2.0.0-beta.9",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.9.tgz",
+			"integrity": "sha512-n0M0WiULLapkwB6pcjfivBrhSntDhAqBDCx+7YrwhFa6Gvva/g6wiTIvIIOo4/lu8MsY/qeYLAAwuzzBBrkcJg==",
 			"dev": true,
 			"requires": {
 				"@urql/core": "^3.1.1",

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -33,7 +33,7 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": ">=2.0.0-beta.9"
+				"@nacelle/storefront-sdk": ">=2.0.0-beta"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -8184,9 +8184,9 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "0.7.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-			"integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+			"version": "0.7.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
 			"dev": true,
 			"funding": [
 				{
@@ -8233,15 +8233,15 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.15.0.tgz",
-			"integrity": "sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=12.18"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/unixify": {
@@ -14753,9 +14753,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-			"integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+			"version": "0.7.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
 			"dev": true
 		},
 		"ufo": {
@@ -14783,9 +14783,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.15.0.tgz",
-			"integrity": "sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -56,7 +56,7 @@
 		"@graphql-codegen/typescript": "2.8.5",
 		"@graphql-codegen/typescript-operations": "^2.5.10",
 		"@graphql-typed-document-node/core": "^3.1.1",
-		"@nacelle/storefront-sdk": ">=2.0.0-beta",
+		"@nacelle/storefront-sdk": ">=2.0.0-beta.9",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",
 		"@vitest/coverage-c8": "^0.26.0",
@@ -71,7 +71,7 @@
 		"vitest": "^0.26.3"
 	},
 	"peerDependencies": {
-		"@nacelle/storefront-sdk": ">=2.0.0-beta"
+		"@nacelle/storefront-sdk": ">=2.0.0-beta.9"
 	},
 	"volta": {
 		"node": "18.12.1"

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -71,7 +71,7 @@
 		"vitest": "^0.26.3"
 	},
 	"peerDependencies": {
-		"@nacelle/storefront-sdk": ">=2.0.0-beta.9"
+		"@nacelle/storefront-sdk": ">=2.0.0-beta"
 	},
 	"volta": {
 		"node": "18.12.1"

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -71,8 +71,7 @@
 		"vitest": "^0.26.3"
 	},
 	"peerDependencies": {
-		"@nacelle/storefront-sdk": ">=2.0.0-beta",
-		"graphql": "^16.6.0"
+		"@nacelle/storefront-sdk": ">=2.0.0-beta"
 	},
 	"volta": {
 		"node": "18.12.1"

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, it, beforeEach, describe, vi, expectTypeOf } from 'vitest';
 import { CommerceQueries } from './index.js';
-import { StorefrontClient } from '@nacelle/storefront-sdk';
+import {
+	StorefrontClient,
+	fetchExchange,
+	retryExchange
+} from '@nacelle/storefront-sdk';
 import getFetchPayload from '../__mocks__/utils/getFetchPayload.js';
 import SpacePropertiesResult from '../__mocks__/gql/spaceProperties.js';
 import NavigationResult from '../__mocks__/gql/navigation.js';
@@ -53,7 +57,7 @@ const client = new ClientWithCommerceQueries({
 		input: RequestInfo | URL,
 		init?: RequestInit | undefined
 	) => Promise<Response>,
-	advancedOptions: { enableApq: false }
+	exchanges: [retryExchange, fetchExchange]
 });
 
 it('does not error when composed with the `StorefrontClient` class', () => {

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -8470,9 +8470,9 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "0.7.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-			"integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+			"version": "0.7.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
 			"dev": true,
 			"funding": [
 				{
@@ -8519,15 +8519,15 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=12.18"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/unixify": {
@@ -15426,9 +15426,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-			"integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+			"version": "0.7.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
 			"dev": true
 		},
 		"ufo": {
@@ -15456,9 +15456,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@urql/core": "^4.0.6",
-				"@urql/exchange-persisted-fetch": "^2.0.0",
+				"@urql/exchange-persisted": "^3.0.0",
 				"@urql/exchange-retry": "^1.1.0"
 			},
 			"devDependencies": {
@@ -3294,16 +3294,13 @@
 				"wonka": "^6.3.0"
 			}
 		},
-		"node_modules/@urql/exchange-persisted-fetch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.0.0.tgz",
-			"integrity": "sha512-Cb6VJ3kt/ucpvuzUXHvkNhfFWZudqwZ63w9xs/Sr5Ck/vkjnXNa8YkwmPJRXBPkRRyS7++n4yGMsPtl8Aa1OlA==",
+		"node_modules/@urql/exchange-persisted": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.0.tgz",
+			"integrity": "sha512-v0iZsw4Wn+oHTClwZ4512wcuwVh4K3eVMVCBXWUkNf3myRUlcgslPa4i9cq7OHIFYLcXU3fkTWFpcCBJYIKIOg==",
 			"dependencies": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"node_modules/@urql/exchange-retry": {
@@ -5575,6 +5572,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"devOptional": true,
 			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -11517,13 +11515,13 @@
 				"wonka": "^6.3.0"
 			}
 		},
-		"@urql/exchange-persisted-fetch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.0.0.tgz",
-			"integrity": "sha512-Cb6VJ3kt/ucpvuzUXHvkNhfFWZudqwZ63w9xs/Sr5Ck/vkjnXNa8YkwmPJRXBPkRRyS7++n4yGMsPtl8Aa1OlA==",
+		"@urql/exchange-persisted": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.0.tgz",
+			"integrity": "sha512-v0iZsw4Wn+oHTClwZ4512wcuwVh4K3eVMVCBXWUkNf3myRUlcgslPa4i9cq7OHIFYLcXU3fkTWFpcCBJYIKIOg==",
 			"requires": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"@urql/exchange-retry": {
@@ -13255,6 +13253,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"devOptional": true,
 			"peer": true
 		},
 		"graphql-config": {

--- a/packages/storefront-sdk/package-lock.json
+++ b/packages/storefront-sdk/package-lock.json
@@ -9,10 +9,9 @@
 			"version": "2.0.0-beta.8",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@urql/core": "^3.1.1",
+				"@urql/core": "^4.0.6",
 				"@urql/exchange-persisted-fetch": "^2.0.0",
-				"@urql/exchange-retry": "^1.0.0",
-				"graphql": "^16.6.0"
+				"@urql/exchange-retry": "^1.1.0"
 			},
 			"devDependencies": {
 				"@graphql-codegen/cli": "2.16.1",
@@ -36,6 +35,19 @@
 			"engines": {
 				"node": ">=16.11",
 				"npm": ">=7"
+			}
+		},
+		"node_modules/@0no-co/graphql.web": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.0.tgz",
+			"integrity": "sha512-JBq2pWyDchE1vVjj/+c4dzZ8stbpew4RrzpZ3vYdn1WJFGHfYg6YIX1fDdMKtSXJJM9FUlsoDOxemr9WMM2p+A==",
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"graphql": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -3274,14 +3286,12 @@
 			}
 		},
 		"node_modules/@urql/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.6.tgz",
+			"integrity": "sha512-RxlX5nxWZsvS1lPCvOdgdYbIVVfih/DrjPzGZ0ThP1GuVycaxw5t0O7XEXXYHICeXNKj95HJBxW0o/37zg+z6Q==",
 			"dependencies": {
-				"wonka": "^6.1.2"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@0no-co/graphql.web": "^1.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"node_modules/@urql/exchange-persisted-fetch": {
@@ -3297,15 +3307,12 @@
 			}
 		},
 		"node_modules/@urql/exchange-retry": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
-			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.0.tgz",
+			"integrity": "sha512-F6OPBikGDHsxmQh9HmKo4x1Yjaa31dvUeYdA3OzyjwD+DYXFlScHKWUjH1LazHIg6lxsH4K+GUg6kH0GaBa21g==",
 			"dependencies": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
@@ -5568,6 +5575,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -8912,9 +8920,9 @@
 			"dev": true
 		},
 		"node_modules/wonka": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
-			"integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.1.tgz",
+			"integrity": "sha512-nJyGPcjuBiaLFn8QAlrHd+QjV9AlPO7snOWAhgx6aX0nQLMV6Wi0nqfrkmsXIH0efngbDOroOz2QyLnZMF16Hw=="
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -9049,6 +9057,12 @@
 		}
 	},
 	"dependencies": {
+		"@0no-co/graphql.web": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.0.tgz",
+			"integrity": "sha512-JBq2pWyDchE1vVjj/+c4dzZ8stbpew4RrzpZ3vYdn1WJFGHfYg6YIX1fDdMKtSXJJM9FUlsoDOxemr9WMM2p+A==",
+			"requires": {}
+		},
 		"@ampproject/remapping": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -11495,11 +11509,12 @@
 			}
 		},
 		"@urql/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.6.tgz",
+			"integrity": "sha512-RxlX5nxWZsvS1lPCvOdgdYbIVVfih/DrjPzGZ0ThP1GuVycaxw5t0O7XEXXYHICeXNKj95HJBxW0o/37zg+z6Q==",
 			"requires": {
-				"wonka": "^6.1.2"
+				"@0no-co/graphql.web": "^1.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"@urql/exchange-persisted-fetch": {
@@ -11512,12 +11527,12 @@
 			}
 		},
 		"@urql/exchange-retry": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
-			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.0.tgz",
+			"integrity": "sha512-F6OPBikGDHsxmQh9HmKo4x1Yjaa31dvUeYdA3OzyjwD+DYXFlScHKWUjH1LazHIg6lxsH4K+GUg6kH0GaBa21g==",
 			"requires": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.0"
 			}
 		},
 		"@vitest/coverage-c8": {
@@ -13239,7 +13254,8 @@
 		"graphql": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"peer": true
 		},
 		"graphql-config": {
 			"version": "4.3.6",
@@ -15720,9 +15736,9 @@
 			"dev": true
 		},
 		"wonka": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
-			"integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.1.tgz",
+			"integrity": "sha512-nJyGPcjuBiaLFn8QAlrHd+QjV9AlPO7snOWAhgx6aX0nQLMV6Wi0nqfrkmsXIH0efngbDOroOz2QyLnZMF16Hw=="
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -71,7 +71,7 @@
 	},
 	"dependencies": {
 		"@urql/core": "^4.0.6",
-		"@urql/exchange-persisted-fetch": "^2.0.0",
+		"@urql/exchange-persisted": "^3.0.0",
 		"@urql/exchange-retry": "^1.1.0"
 	},
 	"volta": {

--- a/packages/storefront-sdk/package.json
+++ b/packages/storefront-sdk/package.json
@@ -70,10 +70,9 @@
 		"vitest": "^0.26.3"
 	},
 	"dependencies": {
-		"@urql/core": "^3.1.1",
+		"@urql/core": "^4.0.6",
 		"@urql/exchange-persisted-fetch": "^2.0.0",
-		"@urql/exchange-retry": "^1.0.0",
-		"graphql": "^16.6.0"
+		"@urql/exchange-retry": "^1.1.0"
 	},
 	"volta": {
 		"node": "18.12.1"

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -1,4 +1,4 @@
-import { dedupExchange, fetchExchange, gql } from '@urql/core';
+import { fetchExchange, gql } from '@urql/core';
 import { GraphQLError } from 'graphql';
 import {
 	afterEach,
@@ -36,7 +36,7 @@ const client = new StorefrontClient({
 		init?: RequestInit | undefined
 	) => Promise<Response>,
 	// disable APQ since most tests don't need it
-	exchanges: [dedupExchange, retryExchange, fetchExchange]
+	exchanges: [retryExchange, fetchExchange]
 });
 
 describe('create client', () => {
@@ -681,8 +681,7 @@ it('makes requests with APQ disabled', async () => {
 			input: RequestInfo | URL,
 			init?: RequestInit | undefined
 		) => Promise<Response>,
-		// disable APQ since most tests don't need it
-		exchanges: [dedupExchange, retryExchange, fetchExchange]
+		exchanges: [retryExchange, fetchExchange]
 	});
 	mockedFetch.mockImplementationOnce(() =>
 		Promise.resolve(getFetchPayload({ data: NavigationResult }))

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,4 +1,4 @@
-import { createClient, dedupExchange, fetchExchange } from '@urql/core';
+import { createClient, fetchExchange } from '@urql/core';
 import { retryExchange as urqlRetryExchange } from '@urql/exchange-retry';
 import { persistedExchange as urqlPersistedExchange } from '@urql/exchange-persisted';
 import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
@@ -66,16 +66,15 @@ export const retryExchange = urqlRetryExchange({
 	}
 });
 
-export const persistedFetchExchange = urqlPersistedExchange({
+export const persistedExchange = urqlPersistedExchange({
 	preferGetForPersistedQueries: true
 });
 
 export const defaultExchanges: Exchange[] = [
 	// NOTE: the order of these exchanges matters!
 	// see the urql Exchanges docs for details.
-	dedupExchange,
 	retryExchange,
-	persistedFetchExchange,
+	persistedExchange,
 	fetchExchange
 ];
 

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -1,6 +1,6 @@
 import { createClient, dedupExchange, fetchExchange } from '@urql/core';
 import { retryExchange as urqlRetryExchange } from '@urql/exchange-retry';
-import { persistedFetchExchange as urqlPersistedFetchExchange } from '@urql/exchange-persisted-fetch';
+import { persistedExchange as urqlPersistedExchange } from '@urql/exchange-persisted';
 import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
 import type {
 	Client as UrqlClient,
@@ -66,7 +66,7 @@ export const retryExchange = urqlRetryExchange({
 	}
 });
 
-export const persistedFetchExchange = urqlPersistedFetchExchange({
+export const persistedFetchExchange = urqlPersistedExchange({
 	preferGetForPersistedQueries: true
 });
 

--- a/packages/storefront-sdk/src/index.test.ts
+++ b/packages/storefront-sdk/src/index.test.ts
@@ -1,10 +1,9 @@
 import { expect, it } from 'vitest';
 import {
 	StorefrontClient,
-	dedupExchange,
 	defaultExchanges,
 	fetchExchange,
-	persistedFetchExchange,
+	persistedExchange,
 	retryExchange
 } from './index.js';
 import { errorMessages } from './utils/index.js';
@@ -30,15 +29,13 @@ it('returns a `StorefrontClient` instance', () => {
 });
 
 it('exports the expected exchanges', () => {
-	expect(typeof dedupExchange).toBe('function');
 	expect(typeof fetchExchange).toBe('function');
-	expect(typeof persistedFetchExchange).toBe('function');
+	expect(typeof persistedExchange).toBe('function');
 	expect(typeof retryExchange).toBe('function');
 	expect(Array.isArray(defaultExchanges)).toBe(true);
 	expect(defaultExchanges).toStrictEqual([
-		dedupExchange,
 		retryExchange,
-		persistedFetchExchange,
+		persistedExchange,
 		fetchExchange
 	]);
 });

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -19,11 +19,11 @@ export interface StorefrontClientParams {
 
 export {
 	defaultExchanges,
-	persistedFetchExchange,
+	persistedExchange,
 	retryExchange,
 	StorefrontClient
 } from './client/index.js';
-export { dedupExchange, fetchExchange } from '@urql/core';
+export { fetchExchange } from '@urql/core';
 export * from './types/plugins.js';
 export type { StorefrontResponse, QueryParams } from './client/index.js';
 export type { StorefrontConfig } from './types/config.js';


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9479](https://nacelle.atlassian.net/browse/ENG-9479) <!-- link to Jira ticket if one exists -->

> Upgrade SDK and Commerce Queries plugin to urql v4

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

This PR upgrades `@nacelle/storefront-sdk` to use [`@urql/core`](https://www.npmjs.com/package/@urql/core) version 4. Guided by the [`@urql/core` changelog](https://github.com/urql-graphql/urql/blob/main/packages/core/CHANGELOG.md#400), this PR removes the dependency on [`graphql`](https://www.npmjs.com/package/graphql) and updates the urql exchanges that we're using in the Storefront SDK.

This PR also updates `@nacelle/commerce-queries-plugin` to depend on Storefront SDK version [`2.0.0-beta.9`](https://www.npmjs.com/package/@nacelle/storefront-sdk/v/2.0.0-beta.9) or higher for local dev, which allows us to use the new `exchanges` param in unit tests. We can also remove `graphql` as an explicit peer dependency (it will continue to be installed if using the Commerce Queries plugin with Storefront SDK version `2.0.0-beta.9` or lesser beta versions).

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-9479/urql-v4` branch
2. Navigate to `packages/storefront-sdk`
3. `rm -rf node_modules && npm i && npm run build` - the package should build without errors
4. `npm run coverage` - all tests should pass with 100% coverage
![storefront sdk ENG-9479:urql-v4 branch all tests passing](https://user-images.githubusercontent.com/5732000/234320693-874d445d-fc91-4f27-992d-9cb14e51c58d.png)
5. Navigate to `packages/storefront-sdk-plugins/commerce-queries`
6. `rm -rf node_modules && npm i && npm run build` - the package should build without errors
7. `npm run coverage` - all tests should pass with 100% coverage
![commerce queries plugin ENG-9479:urql-v4 branch all tests passing](https://user-images.githubusercontent.com/5732000/234320796-9438e5ea-8458-4f62-843e-59de936088e5.png)

In local testing, I used a modified version of https://github.com/getnacelle/storefront-sdk-2.x-testing to validate that the Storefront SDK and Commerce Queries Plugin are working as expected.

Example with the Storefront SDK's `query` method:

![storefront sdk query method ENG-9479:urql-v4 branch](https://user-images.githubusercontent.com/5732000/234325873-9f67c9e4-c49b-44b4-bb7a-4e3e178a7bab.png)

Example with the Commerce Queries plugin's `products` method:

![commerce queries plugin products method ENG-9479:urql-v4 branch](https://user-images.githubusercontent.com/5732000/234321850-77ce5f33-e6a0-49e3-8c0d-98ea4a4018c3.png)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog9.


[ENG-9479]: https://nacelle.atlassian.net/browse/ENG-9479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ