### PR TITLE
chore: configure Storefront SDK dependency version

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nacelle/commerce-queries-plugin",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nacelle/commerce-queries-plugin",
-			"version": "1.0.0-beta.7",
+			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@graphql-codegen/cli": "2.16.1",
@@ -14,6 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
+				"@nacelle/storefront-sdk": ">=2.0.0-beta.10",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -32,7 +33,21 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": ">=2.0.0-beta"
+				"@nacelle/storefront-sdk": ">=2.0.0-beta.10"
+			}
+		},
+		"node_modules/@0no-co/graphql.web": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
+			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
+			"dev": true,
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"graphql": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -2560,15 +2575,15 @@
 			}
 		},
 		"node_modules/@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.9",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.9.tgz",
-			"integrity": "sha512-n0M0WiULLapkwB6pcjfivBrhSntDhAqBDCx+7YrwhFa6Gvva/g6wiTIvIIOo4/lu8MsY/qeYLAAwuzzBBrkcJg==",
-			"peer": true,
+			"version": "2.0.0-hotfix.0",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.0.tgz",
+			"integrity": "sha512-WCmolm4H9ER+riGBGoDRJvSMCluc+MyA3OaK/EnKB1wvLuLqy6jwhoMN+aJaLmzyosmNJT+gTY3/fZ1YDcGb/g==",
+			"dev": true,
+			"hasInstallScript": true,
 			"dependencies": {
-				"@urql/core": "^3.1.1",
-				"@urql/exchange-persisted-fetch": "^2.0.0",
-				"@urql/exchange-retry": "^1.0.0",
-				"graphql": "^16.6.0"
+				"@urql/core": "^4.0.6",
+				"@urql/exchange-persisted": "^3.0.0",
+				"@urql/exchange-retry": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=16.11",
@@ -3076,41 +3091,33 @@
 			}
 		},
 		"node_modules/@urql/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
-			"peer": true,
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.7.tgz",
+			"integrity": "sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==",
+			"dev": true,
 			"dependencies": {
-				"wonka": "^6.1.2"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@0no-co/graphql.web": "^1.0.1",
+				"wonka": "^6.3.2"
 			}
 		},
-		"node_modules/@urql/exchange-persisted-fetch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.1.0.tgz",
-			"integrity": "sha512-rWNpbCskNiRjrvN5q5nnbMXI7UMrgIYv2eHSW+zFAfU8V5jf0KiQ11h1gOXyAfpNaG1mq4m0DRIPqeXg0AzQQw==",
-			"peer": true,
+		"node_modules/@urql/exchange-persisted": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.1.tgz",
+			"integrity": "sha512-KDELDmqNe7Z4nbOgF9oE2w3FwkBBfgaORAGZ/3o5jdOeoszpXNfSPRiwUnFyExXMw4rXqyHfDKg5nzvNB7w4Tw==",
+			"dev": true,
 			"dependencies": {
-				"@urql/core": ">=3.1.1",
-				"wonka": "^6.0.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.2"
 			}
 		},
 		"node_modules/@urql/exchange-retry": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
-			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
-			"peer": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
+			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
+			"dev": true,
 			"dependencies": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.2"
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
@@ -5337,6 +5344,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -8594,10 +8602,10 @@
 			}
 		},
 		"node_modules/wonka": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.2.3.tgz",
-			"integrity": "sha512-EFOYiqDeYLXSzGYt2X3aVe9Hq1XJG+Hz/HjTRRT4dZE9q95khHl5+7pzUSXI19dbMO1/2UMrTf7JT7/7JrSQSQ==",
-			"peer": true
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
+			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
+			"dev": true
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -8741,6 +8749,13 @@
 		}
 	},
 	"dependencies": {
+		"@0no-co/graphql.web": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
+			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
+			"dev": true,
+			"requires": {}
+		},
 		"@ampproject/remapping": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -10591,15 +10606,14 @@
 			}
 		},
 		"@nacelle/storefront-sdk": {
-			"version": "2.0.0-beta.9",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-beta.9.tgz",
-			"integrity": "sha512-n0M0WiULLapkwB6pcjfivBrhSntDhAqBDCx+7YrwhFa6Gvva/g6wiTIvIIOo4/lu8MsY/qeYLAAwuzzBBrkcJg==",
-			"peer": true,
+			"version": "2.0.0-hotfix.0",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.0.tgz",
+			"integrity": "sha512-WCmolm4H9ER+riGBGoDRJvSMCluc+MyA3OaK/EnKB1wvLuLqy6jwhoMN+aJaLmzyosmNJT+gTY3/fZ1YDcGb/g==",
+			"dev": true,
 			"requires": {
-				"@urql/core": "^3.1.1",
-				"@urql/exchange-persisted-fetch": "^2.0.0",
-				"@urql/exchange-retry": "^1.0.0",
-				"graphql": "^16.6.0"
+				"@urql/core": "^4.0.6",
+				"@urql/exchange-persisted": "^3.0.0",
+				"@urql/exchange-retry": "^1.1.0"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -10969,32 +10983,33 @@
 			}
 		},
 		"@urql/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
-			"peer": true,
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.7.tgz",
+			"integrity": "sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==",
+			"dev": true,
 			"requires": {
-				"wonka": "^6.1.2"
+				"@0no-co/graphql.web": "^1.0.1",
+				"wonka": "^6.3.2"
 			}
 		},
-		"@urql/exchange-persisted-fetch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted-fetch/-/exchange-persisted-fetch-2.1.0.tgz",
-			"integrity": "sha512-rWNpbCskNiRjrvN5q5nnbMXI7UMrgIYv2eHSW+zFAfU8V5jf0KiQ11h1gOXyAfpNaG1mq4m0DRIPqeXg0AzQQw==",
-			"peer": true,
+		"@urql/exchange-persisted": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.1.tgz",
+			"integrity": "sha512-KDELDmqNe7Z4nbOgF9oE2w3FwkBBfgaORAGZ/3o5jdOeoszpXNfSPRiwUnFyExXMw4rXqyHfDKg5nzvNB7w4Tw==",
+			"dev": true,
 			"requires": {
-				"@urql/core": ">=3.1.1",
-				"wonka": "^6.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.2"
 			}
 		},
 		"@urql/exchange-retry": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.0.0.tgz",
-			"integrity": "sha512-UGyyGAMXzop9C/fIoe7Ij63DkPSy1uMw2jipB5dnB8R3kl80za7LYzVnA1HvBEt2ZPWfMuwez/VGLOQ7XX4bTA==",
-			"peer": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
+			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
+			"dev": true,
 			"requires": {
-				"@urql/core": ">=3.0.0",
-				"wonka": "^6.0.0"
+				"@urql/core": ">=4.0.0",
+				"wonka": "^6.3.2"
 			}
 		},
 		"@vitest/coverage-c8": {
@@ -12684,6 +12699,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+			"dev": true,
 			"peer": true
 		},
 		"graphql-config": {
@@ -15019,10 +15035,10 @@
 			}
 		},
 		"wonka": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.2.3.tgz",
-			"integrity": "sha512-EFOYiqDeYLXSzGYt2X3aVe9Hq1XJG+Hz/HjTRRT4dZE9q95khHl5+7pzUSXI19dbMO1/2UMrTf7JT7/7JrSQSQ==",
-			"peer": true
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
+			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -56,7 +56,7 @@
 		"@graphql-codegen/typescript": "2.8.5",
 		"@graphql-codegen/typescript-operations": "^2.5.10",
 		"@graphql-typed-document-node/core": "^3.1.1",
-		"@nacelle/storefront-sdk": ">=2.0.0",
+		"@nacelle/storefront-sdk": ">=2.0.0-beta.10",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",
 		"@vitest/coverage-c8": "^0.26.0",
@@ -71,7 +71,7 @@
 		"vitest": "^0.26.3"
 	},
 	"peerDependencies": {
-		"@nacelle/storefront-sdk": ">=2.0.0"
+		"@nacelle/storefront-sdk": ">=2.0.0-beta.10"
 	},
 	"volta": {
 		"node": "18.12.1"


### PR DESCRIPTION
This PR updates `@nacelle/commerce-queries-plugin` to depend on `>=2.0.0-beta.10` of `@nacelle/storefront-sdk`. This encompasses `2.0.0`.