### PR TITLE
fix: upgrade devDep

### DIFF
--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -14,7 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
-				"@nacelle/storefront-sdk": ">=2.0.0-beta.10",
+				"@nacelle/storefront-sdk": "^2.0.0-hotfix.1",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -2575,9 +2575,9 @@
 			}
 		},
 		"node_modules/@nacelle/storefront-sdk": {
-			"version": "2.0.0-hotfix.0",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.0.tgz",
-			"integrity": "sha512-WCmolm4H9ER+riGBGoDRJvSMCluc+MyA3OaK/EnKB1wvLuLqy6jwhoMN+aJaLmzyosmNJT+gTY3/fZ1YDcGb/g==",
+			"version": "2.0.0-hotfix.1",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.1.tgz",
+			"integrity": "sha512-MSCspvXv952bdU8vONk8fwB4q+MDgYORTN5LipJsxmnE8lzaYlzld5zp1XF433nZlKNjNrXK9MhLq3myPvh0ZA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -10606,9 +10606,9 @@
 			}
 		},
 		"@nacelle/storefront-sdk": {
-			"version": "2.0.0-hotfix.0",
-			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.0.tgz",
-			"integrity": "sha512-WCmolm4H9ER+riGBGoDRJvSMCluc+MyA3OaK/EnKB1wvLuLqy6jwhoMN+aJaLmzyosmNJT+gTY3/fZ1YDcGb/g==",
+			"version": "2.0.0-hotfix.1",
+			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.1.tgz",
+			"integrity": "sha512-MSCspvXv952bdU8vONk8fwB4q+MDgYORTN5LipJsxmnE8lzaYlzld5zp1XF433nZlKNjNrXK9MhLq3myPvh0ZA==",
 			"dev": true,
 			"requires": {
 				"@urql/core": "^4.0.6",

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -56,7 +56,7 @@
 		"@graphql-codegen/typescript": "2.8.5",
 		"@graphql-codegen/typescript-operations": "^2.5.10",
 		"@graphql-typed-document-node/core": "^3.1.1",
-		"@nacelle/storefront-sdk": ">=2.0.0-beta.10",
+		"@nacelle/storefront-sdk": ">=2.0.0-hotfix.1",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",
 		"@vitest/coverage-c8": "^0.26.0",


### PR DESCRIPTION
This PR upgrades the Commerce Queries plugin's devDep on `@nacelle/storefront-sdk` to overcome the **Release** issues here: https://github.com/getnacelle/nacelle-js/actions/runs/4822309441/jobs/8589361575 