### PR TITLE
refactor: request headers include `x-nacelle-sdk-version`

### DIFF
--- a/.changeset/kind-frogs-chew.md
+++ b/.changeset/kind-frogs-chew.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Adds an `x-nacelle-sdk-version` header to all requests. This improves tracing and observability in the event of a support request.

--- a/packages/storefront-sdk/src/client/createClient.test.ts
+++ b/packages/storefront-sdk/src/client/createClient.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createClient } from '@urql/core';
 import { StorefrontClient } from './index.js';
+import { version as packageVersion } from '../../package.json';
 
 vi.mock('@urql/core');
 
@@ -23,7 +24,9 @@ describe('`createClient`', () => {
 				url: storefrontEndpoint,
 				fetch: globalThis.fetch,
 				fetchOptions: {
-					headers: {}
+					headers: {
+						'x-nacelle-sdk-version': packageVersion
+					}
 				}
 			})
 		);

--- a/packages/storefront-sdk/src/client/index.test.ts
+++ b/packages/storefront-sdk/src/client/index.test.ts
@@ -13,7 +13,11 @@ import { StorefrontClient, retryExchange, retryStatusCodes } from './index.js';
 import { NavigationDocument } from '../../__mocks__/gql/operations.js';
 import getFetchPayload from '../../__mocks__/utils/getFetchPayload.js';
 import NavigationResult from '../../__mocks__/gql/navigation.js';
-import { errorMessages, X_NACELLE_PREVIEW_TOKEN } from '../utils/index.js';
+import {
+	errorMessages,
+	X_NACELLE_SDK_VERSION,
+	X_NACELLE_PREVIEW_TOKEN
+} from '../utils/index.js';
 import type { StorefrontResponse } from './index.js';
 import type {
 	NavigationGroup,
@@ -573,6 +577,26 @@ it('sets the expected header and query param when initialized with a `previewTok
 		[X_NACELLE_PREVIEW_TOKEN]?: string;
 	};
 	expect(requestHeaders[X_NACELLE_PREVIEW_TOKEN]).toBe(myPreviewToken);
+});
+
+it("sends an 'x-nacelle-sdk-version' header", async () => {
+	mockedFetch.mockImplementationOnce(() =>
+		Promise.resolve(getFetchPayload({ data: NavigationResult }))
+	);
+	const variables = { filter: { groupId: 'abc' } };
+	await client.query({
+		query: NavigationDocument,
+		variables
+	});
+
+	const lastFetch = mockedFetch.mock.lastCall as mockRequestArgs;
+	const requestHeaders = lastFetch[1]?.headers as HeadersInit & {
+		[X_NACELLE_SDK_VERSION]?: string;
+	};
+
+	expect(requestHeaders[X_NACELLE_SDK_VERSION]).toMatch(
+		/\b\d{1,2}.\d{1,2}.\d{1,2}\b/ // three sequences of 1-2 digits separated by periods
+	);
 });
 
 it('`getConfig` retrieves config', () => {

--- a/packages/storefront-sdk/src/utils/constants.ts
+++ b/packages/storefront-sdk/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const X_NACELLE_PREVIEW_TOKEN = 'x-nacelle-preview-token';
+export const X_NACELLE_SDK_VERSION = 'x-nacelle-sdk-version';


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9576](https://nacelle.atlassian.net/browse/ENG-9576) <!-- link to Jira ticket if one exists -->

> Send package version in 'x-nacelle-sdk-version' header

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

1. Adds an `x-nacelle-sdk-version` header to requests. This matches `@nacelle/storefront-sdk@1.x` behavior.
2. Moves the handling of endpoint query params and headers to new static methods. This allows us to simplify the constructor and the `setConfig` method.

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

1. Check out the `ENG-9576/send-package-version-in-x-nacelle-sdk-version-header` branch
2. Navigate to `packages/storefront-sdk`
3. `npm run build` - the package should build without errors
4. `npm run coverage` - all test should pass with 100% coverage

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-9576]: https://nacelle.atlassian.net/browse/ENG-9576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ