### PR TITLE
fix: externalize deps

### DIFF
--- a/.changeset/mighty-balloons-cry.md
+++ b/.changeset/mighty-balloons-cry.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Fixes an internal issue with `@nacelle/storefront-sdk`'s build process, which was causing some external package code to be inadvertently bundled in the `@nacelle/storefront-sdk` package code. This issue both increased the package size and caused issues in Nuxt 2 projects.

--- a/packages/storefront-sdk/vite.config.ts
+++ b/packages/storefront-sdk/vite.config.ts
@@ -17,16 +17,14 @@ export const config: UserConfig = {
 		rollupOptions: {
 			external: [
 				'@urql/core',
-				'@urql/exchange-persisted-fetch',
-				'@urql/exchange-retry',
-				'graphql'
+				'@urql/exchange-persisted',
+				'@urql/exchange-retry'
 			],
 			output: {
 				globals: {
 					'@urql/core': 'Urql',
-					'@urql/exchange-persisted-fetch': 'UrqlExchangePersistedFetch',
-					'@urql/exchange-retry': 'UrqlExchangeRetry',
-					graphql: 'Graphql'
+					'@urql/exchange-persisted': 'UrqlExchangePersisted',
+					'@urql/exchange-retry': 'UrqlExchangeRetry'
 				}
 			}
 		}


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9911](https://nacelle.atlassian.net/browse/ENG-9911) <!-- link to Jira ticket if one exists -->

> Storefront SDK is bundling the persisted fetch exchange

This bug is a consequence of negligence in #370. The name of the Persisted Fetch Exchange package changed with urql 4, but I forgot to update that package's name in `packages/storefront-sdk/vite.config.ts`.

## What is this pull request doing?

This PR updates `packages/storefront-sdk/vite.config.ts` to correctly exclude the Persisted Fetch Exchange from the bundle. It also removes `graphql` from the Vite config, because `graphql` is no longer a dependency (as of #370).

## How to Test

1. Check out the `ENG-9911/externalize-deps` branch
2. Navigate to `packages/storefront-sdk`
3. `npm run build` - there should be no build errors
4. `npm run coverage` - all tests should pass with 100% coverage
5. Clone the [`nuxt-2-storefront-sdk-testing`](https://github.com/getnacelle/nuxt-2-storefront-sdk-testing) repo
6. Once dependencies are installed in the `nuxt-2-storefront-sdk-testing` project and the `.env` has been populated, remove `nuxt-2-storefront-sdk-testing`'s `node_modules/@nacelle/storefront-sdk/dist` and replace it with the contents of `nacelle-js/packages/storefront-sdk/dist`
7. `npm run dev` and navigate to [`localhost:3000`](http://localhost:3000) - you should see product data:

![demo nuxt 2 data fetching with storefront sdk ENG-9911:externalize-deps branch](https://github.com/getnacelle/nacelle-js/assets/5732000/59cc10a7-a82f-442d-923c-17f52e850109)

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).


[ENG-9911]: https://nacelle.atlassian.net/browse/ENG-9911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ