### PR TITLE
fix: add sdk to github workflow `changes`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
               - 'packages/shopify-checkout/**'
             shopify-cart:
               - 'packages/shopify-cart/**'
-            storefront-sdk:
-              - 'packages/storefront-sdk/**'
+            storefront-sdk-changelog:
+              - 'packages/storefront-sdk/CHANGELOG.md'
 
       - name: Install Dependencies
         run: npm ci
@@ -110,12 +110,12 @@ jobs:
             -Dsonar.test.inclusions=src/**/*.test.ts
 
       - name: Add Front Matter to SDK Changelogs for Readme
-        if: steps.changes.outputs.storefront-sdk == 'true'
+        if: steps.changes.outputs.storefront-sdk-changelog == 'true'
         run: npm run changelog:frontmatter
         working-directory: packages/storefront-sdk
 
       - name: Sync SDK Changelogs to Readme
-        if: steps.changes.outputs.storefront-sdk == 'true'
+        if: steps.changes.outputs.storefront-sdk-changelog == 'true'
         uses: readmeio/rdme@v8
         with:
           rdme: docs packages/storefront-sdk/changelog-readme.md --key=${{ secrets.README_API_KEY }} --version=2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
               - 'packages/shopify-checkout/**'
             shopify-cart:
               - 'packages/shopify-cart/**'
+            storefront-sdk:
+              - 'packages/storefront-sdk/**'
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-8894](https://nacelle.atlassian.net/browse/ENG-8894) <!-- link to Jira ticket if one exists -->

The `changelog` automation didn't trigger during last release indicating that the `steps.changes.outputs.storefront-sdk` wasn't being set to `true`

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

- Adds the `storefront-sdk` to the `changes` step in the github `release` workflow


[ENG-8894]: https://nacelle.atlassian.net/browse/ENG-8894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ