### PR TITLE
fix: add errors to missing env vars

### DIFF
--- a/packages/shopify-cart/src/client/client-dom.spec.ts
+++ b/packages/shopify-cart/src/client/client-dom.spec.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import createShopifyCartClient from './index';
+import createShopifyCartClient, {
+  shopifyShopIdTokenErrorMessage,
+  shopifyStorefrontAccessTokenErrorMessage
+} from './index';
 import mutations from '../graphql/mutations';
 import { mockJsonResponse } from '../../__tests__/utils';
 import * as utilFunctions from '../utils';
@@ -27,6 +30,7 @@ import type {
   CartSelectedDeliveryOptionsUpdateMutation,
   CartSelectedDeliveryOptionInput
 } from '../types/shopify.type';
+import type { CreateClientParams } from './index';
 
 const defaultLanguage: LanguageCode = 'EN';
 const defaultCountry: CountryCode = 'ZZ';
@@ -897,5 +901,17 @@ describe('createShopifyCartClient', () => {
         }
       })
     });
+  });
+
+  it('throws an error if required params are missing', () => {
+    const { shopifyShopId, shopifyStorefrontAccessToken } = clientSettings;
+    expect(() =>
+      createShopifyCartClient({ shopifyShopId } as CreateClientParams)
+    ).toThrow(shopifyStorefrontAccessTokenErrorMessage);
+    expect(() =>
+      createShopifyCartClient({
+        shopifyStorefrontAccessToken
+      } as CreateClientParams)
+    ).toThrow(shopifyShopIdTokenErrorMessage);
   });
 });

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -223,6 +223,16 @@ export default function createShopifyCartClient({
   country = 'ZZ',
   locale = 'en-US'
 }: CreateClientParams): CartClient {
+  if (!shopifyShopId) {
+    throw new Error('@nacelle/shopify-cart: No `shopifyShopId` provided');
+  }
+
+  if (!shopifyStorefrontAccessToken) {
+    throw new Error(
+      '@nacelle/shopify-cart: No `shopifyStorefrontAccessToken` provided'
+    );
+  }
+
   const sanitizedShopId = sanitizeShopId(shopifyShopId as string);
   const gqlClient = createGqlClient({
     shopifyShopId: sanitizedShopId,

--- a/packages/shopify-cart/src/client/index.ts
+++ b/packages/shopify-cart/src/client/index.ts
@@ -206,6 +206,11 @@ export interface CartClient {
   getConfig: GetConfig;
 }
 
+export const shopifyShopIdTokenErrorMessage =
+  '@nacelle/shopify-cart: No `shopifyShopId` provided';
+export const shopifyStorefrontAccessTokenErrorMessage =
+  '@nacelle/shopify-cart: No `shopifyStorefrontAccessToken` provided';
+
 /**
  * Create a Shopify cart client that can:
  * - `cartBuyerIdentityUpdate`: update buyer on an existing Shopify Cart
@@ -224,13 +229,11 @@ export default function createShopifyCartClient({
   locale = 'en-US'
 }: CreateClientParams): CartClient {
   if (!shopifyShopId) {
-    throw new Error('@nacelle/shopify-cart: No `shopifyShopId` provided');
+    throw new Error(shopifyShopIdTokenErrorMessage);
   }
 
   if (!shopifyStorefrontAccessToken) {
-    throw new Error(
-      '@nacelle/shopify-cart: No `shopifyStorefrontAccessToken` provided'
-    );
+    throw new Error(shopifyStorefrontAccessTokenErrorMessage);
   }
 
   const sanitizedShopId = sanitizeShopId(shopifyShopId as string);


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9772](https://nacelle.atlassian.net/browse/ENG-9772) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

Missing parameters to `shopify-cart` package resulted in unclear errors

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

- Adds a descriptive error when `shopifyShopId` or `shopifyStorefrontAccessToken` are missing

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

In `packages/shopify-cart`:
- `npm i && npm run build`
- copy the resulting `dist` folder

In `reference-stores/nuxt`
- Find `node_modules/@nacelle/shopify-cart` directory, remove the `dist` folder and replace it with the previously copied one
- Don't provide `SHOPIFY_SHOP_ID` or `SHOPIFY_STOREFRONT_ACCESS_TOKEN` `env` vars

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [ ] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [ ] Updated the `README.md` with documentation changes (if applicable).


[ENG-9772]: https://nacelle.atlassian.net/browse/ENG-9772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ