### PR TITLE
feat: typename in commerce-queries plugin

### DIFF
--- a/.changeset/eighty-singers-do.md
+++ b/.changeset/eighty-singers-do.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/commerce-queries-plugin': patch
+---
+
+Added `__typename` to fragments

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/content.ts
@@ -1,4 +1,5 @@
 export const mockContentNode = {
+	__typename: 'Content',
 	createdAt: 1637098847,
 	fields: { customField: 'foobar' },
 	handle: 'nacelle-page',

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/product.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/product.ts
@@ -1,6 +1,9 @@
-import type { Product, AllProductsQuery } from '../../src/graphql/documents.js';
+import type {
+	Product_ProductFragment,
+	AllProductsQuery
+} from '../../src/graphql/documents.js';
 
-export const mockProductNode: Product = {
+export const mockProductNode: Product_ProductFragment = {
 	__typename: 'Product',
 	nacelleEntryId: 'product-1',
 	metafields: [],

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/product.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/product.ts
@@ -1,6 +1,7 @@
 import type { Product, AllProductsQuery } from '../../src/graphql/documents.js';
 
 export const mockProductNode: Product = {
+	__typename: 'Product',
 	nacelleEntryId: 'product-1',
 	metafields: [],
 	sourceEntryId: 'test',

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollectionEntries.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollectionEntries.ts
@@ -10,6 +10,7 @@ export const mockPaginatedProductCollectionEntries: {
 			edges: [
 				{
 					node: {
+						__typename: 'ProductCollection',
 						productConnection: {
 							pageInfo: {
 								hasNextPage: true,
@@ -36,6 +37,7 @@ export const mockUnpaginatedProductCollectionEntries: {
 			edges: [
 				{
 					node: {
+						__typename: 'ProductCollection',
 						productConnection: {
 							pageInfo: {
 								hasNextPage: false,
@@ -77,6 +79,7 @@ export function buildProductCollectionEntriesResponse(
 				edges: [
 					{
 						node: {
+							__typename: 'ProductCollection',
 							productConnection: {
 								pageInfo: {
 									hasNextPage,

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollections.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollections.ts
@@ -1,10 +1,10 @@
 import { mockProductNode } from './product.js';
 import type {
-	ProductCollection,
+	ProductCollection_CollectionFragment,
 	AllProductCollectionsQuery
 } from '../../src/graphql/documents.js';
 
-export const mockProductCollectionNode: ProductCollection = {
+export const mockProductCollectionNode: ProductCollection_CollectionFragment = {
 	__typename: 'ProductCollection',
 	nacelleEntryId: 'product-collection-1',
 	sourceEntryId: 'test',
@@ -14,12 +14,9 @@ export const mockProductCollectionNode: ProductCollection = {
 		edges: [{ cursor: 'product-cursor-1', node: mockProductNode }],
 		pageInfo: {
 			endCursor: 'end-cursor-1',
-			hasNextPage: false,
-			hasPreviousPage: false,
-			startCursor: 'start-cursor-1'
+			hasNextPage: false
 		}
 	},
-	products: [],
 	tags: []
 };
 

--- a/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollections.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/__mocks__/gql/productCollections.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../src/graphql/documents.js';
 
 export const mockProductCollectionNode: ProductCollection = {
+	__typename: 'ProductCollection',
 	nacelleEntryId: 'product-collection-1',
 	sourceEntryId: 'test',
 	sourceId: 'abcd',

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -14,6 +14,7 @@
 				"@graphql-codegen/typescript": "2.8.5",
 				"@graphql-codegen/typescript-operations": "^2.5.10",
 				"@graphql-typed-document-node/core": "^3.1.1",
+				"@nacelle/storefront-sdk": ">=2.0.0-hotfix.1",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -39,7 +40,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
 			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
-			"peer": true,
+			"dev": true,
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
 			},
@@ -2577,8 +2578,8 @@
 			"version": "2.0.0-hotfix.1",
 			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.1.tgz",
 			"integrity": "sha512-MSCspvXv952bdU8vONk8fwB4q+MDgYORTN5LipJsxmnE8lzaYlzld5zp1XF433nZlKNjNrXK9MhLq3myPvh0ZA==",
+			"dev": true,
 			"hasInstallScript": true,
-			"peer": true,
 			"dependencies": {
 				"@urql/core": "^4.0.6",
 				"@urql/exchange-persisted": "^3.0.0",
@@ -3093,7 +3094,7 @@
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.7.tgz",
 			"integrity": "sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@0no-co/graphql.web": "^1.0.1",
 				"wonka": "^6.3.2"
@@ -3103,7 +3104,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.1.tgz",
 			"integrity": "sha512-KDELDmqNe7Z4nbOgF9oE2w3FwkBBfgaORAGZ/3o5jdOeoszpXNfSPRiwUnFyExXMw4rXqyHfDKg5nzvNB7w4Tw==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -3113,7 +3114,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
 			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -5343,7 +5344,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-			"devOptional": true,
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -8604,7 +8605,7 @@
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
 			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
-			"peer": true
+			"dev": true
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -8752,7 +8753,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
 			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {}
 		},
 		"@ampproject/remapping": {
@@ -10608,7 +10609,7 @@
 			"version": "2.0.0-hotfix.1",
 			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.0-hotfix.1.tgz",
 			"integrity": "sha512-MSCspvXv952bdU8vONk8fwB4q+MDgYORTN5LipJsxmnE8lzaYlzld5zp1XF433nZlKNjNrXK9MhLq3myPvh0ZA==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": "^4.0.6",
 				"@urql/exchange-persisted": "^3.0.0",
@@ -10985,7 +10986,7 @@
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.0.7.tgz",
 			"integrity": "sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@0no-co/graphql.web": "^1.0.1",
 				"wonka": "^6.3.2"
@@ -10995,7 +10996,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-3.0.1.tgz",
 			"integrity": "sha512-KDELDmqNe7Z4nbOgF9oE2w3FwkBBfgaORAGZ/3o5jdOeoszpXNfSPRiwUnFyExXMw4rXqyHfDKg5nzvNB7w4Tw==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -11005,7 +11006,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
 			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -12698,7 +12699,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-			"devOptional": true,
+			"dev": true,
 			"peer": true
 		},
 		"graphql-config": {
@@ -15037,7 +15038,7 @@
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
 			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
-			"peer": true
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -9,11 +9,11 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@graphql-codegen/cli": "2.16.1",
-				"@graphql-codegen/typed-document-node": "^2.3.11",
-				"@graphql-codegen/typescript": "2.8.5",
-				"@graphql-codegen/typescript-operations": "^2.5.10",
-				"@graphql-typed-document-node/core": "^3.1.1",
+				"@graphql-codegen/cli": "^5.0.0",
+				"@graphql-codegen/typed-document-node": "^5.0.1",
+				"@graphql-codegen/typescript": "^4.0.1",
+				"@graphql-codegen/typescript-operations": "^4.0.1",
+				"@graphql-typed-document-node/core": "^3.2.0",
 				"@nacelle/storefront-sdk": ">=2.0.0-hotfix.1",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
@@ -51,26 +51,13 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@ampproject/remapping/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -238,47 +225,119 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.22.10",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
+			"integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
 			"dev": true,
 			"dependencies": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.12",
-				"@babel/types": "^7.20.7",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
+				"@babel/helper-module-transforms": "^7.22.9",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.2",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -289,13 +348,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+			"integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.7",
+				"@babel/types": "^7.22.10",
 				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -303,50 +363,48 @@
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-			"integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+			"integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.21.3",
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-validator-option": "^7.22.5",
+				"browserslist": "^4.21.9",
 				"lru-cache": "^5.1.1",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-			"integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.10.tgz",
+			"integrity": "sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-replace-supers": "^7.20.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-				"@babel/helper-split-export-declaration": "^7.18.6"
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-member-expression-to-functions": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -356,205 +414,205 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+			"integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.18.10",
-				"@babel/types": "^7.19.0"
+				"@babel/template": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-			"integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
+			"integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+			"integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
+			"integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.20.2",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+			"integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-			"integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-			"integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
+			"integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-member-expression-to-functions": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-			"integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.2"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-			"integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+			"integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.0"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
+			"integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-			"integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+			"integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.5",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -633,9 +691,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-			"integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+			"integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -692,12 +750,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-flow": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
-			"integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
+			"integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -707,12 +765,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
-			"integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.22.5.tgz",
+			"integrity": "sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.19.0"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -722,12 +780,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-			"integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -749,12 +807,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
-			"integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.22.5.tgz",
+			"integrity": "sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -764,12 +822,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
-			"integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.22.5.tgz",
+			"integrity": "sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -779,12 +837,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
-			"integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
+			"integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -794,19 +852,19 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
-			"integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
+			"integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-replace-supers": "^7.20.7",
-				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-compilation-targets": "^7.22.6",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -817,13 +875,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
-			"integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.22.5.tgz",
+			"integrity": "sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/template": "^7.20.7"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/template": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -833,12 +891,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
-			"integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
+			"integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -848,13 +906,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-flow-strip-types": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.19.0.tgz",
-			"integrity": "sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.22.5.tgz",
+			"integrity": "sha512-tujNbZdxdG0/54g/oua8ISToaXTFBf8EnSb5PgQSciIXWOWKX3S4+JR7ZE9ol8FZwf9kxitzkGQ+QWeov/mCiA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.19.0",
-				"@babel/plugin-syntax-flow": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-flow": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -864,12 +922,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
-			"integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.5.tgz",
+			"integrity": "sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -879,14 +937,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
-			"integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.22.5.tgz",
+			"integrity": "sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-compilation-targets": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -896,12 +954,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
-			"integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.22.5.tgz",
+			"integrity": "sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -911,12 +969,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
-			"integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.22.5.tgz",
+			"integrity": "sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -926,14 +984,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-			"integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz",
+			"integrity": "sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-simple-access": "^7.20.2"
+				"@babel/helper-module-transforms": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-simple-access": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -943,13 +1001,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
-			"integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.22.5.tgz",
+			"integrity": "sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6",
-				"@babel/helper-replace-supers": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -959,12 +1017,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
-			"integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.5.tgz",
+			"integrity": "sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -974,12 +1032,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
-			"integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.22.5.tgz",
+			"integrity": "sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -989,12 +1047,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-display-name": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
-			"integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
+			"integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1004,16 +1062,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.7.tgz",
-			"integrity": "sha512-Tfq7qqD+tRj3EoDhY00nn2uP2hsRxgYGi5mLQ5TimKav0a9Lrpd4deE+fcLXU8zFYRjlKPHZhpCvfEA6qnBxqQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
+			"integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/plugin-syntax-jsx": "^7.18.6",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-jsx": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1023,12 +1081,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
-			"integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.22.5.tgz",
+			"integrity": "sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1038,13 +1096,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
-			"integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.22.5.tgz",
+			"integrity": "sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1054,12 +1112,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
-			"integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.22.5.tgz",
+			"integrity": "sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1069,45 +1127,45 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-			"integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+			"integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
 			"dev": true,
 			"dependencies": {
-				"regenerator-runtime": "^0.13.11"
+				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+			"integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.22.5",
+				"@babel/parser": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
-			"integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1116,13 +1174,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-			"integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+			"integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.5",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1134,28 +1192,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
 		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.16.17",
@@ -1560,44 +1596,44 @@
 			}
 		},
 		"node_modules/@graphql-codegen/cli": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.16.1.tgz",
-			"integrity": "sha512-11z3iSlsNCXcNNkoRKG3wCmT9XpLf7/GZG9bWGXkCoveWVRwnRmo37YakHdNV3hbcJ4iiGbR3Z+MX9gUTEPDVA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.0.tgz",
+			"integrity": "sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/generator": "^7.18.13",
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.18.13",
-				"@graphql-codegen/core": "2.6.8",
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-tools/apollo-engine-loader": "^7.3.6",
-				"@graphql-tools/code-file-loader": "^7.3.13",
-				"@graphql-tools/git-loader": "^7.2.13",
-				"@graphql-tools/github-loader": "^7.3.20",
-				"@graphql-tools/graphql-file-loader": "^7.5.0",
-				"@graphql-tools/json-file-loader": "^7.4.1",
-				"@graphql-tools/load": "7.8.0",
-				"@graphql-tools/prisma-loader": "^7.2.7",
-				"@graphql-tools/url-loader": "^7.13.2",
-				"@graphql-tools/utils": "^8.9.0",
-				"@whatwg-node/fetch": "^0.5.0",
+				"@graphql-codegen/core": "^4.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.1",
+				"@graphql-tools/apollo-engine-loader": "^8.0.0",
+				"@graphql-tools/code-file-loader": "^8.0.0",
+				"@graphql-tools/git-loader": "^8.0.0",
+				"@graphql-tools/github-loader": "^8.0.0",
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/prisma-loader": "^8.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.8.0",
 				"chalk": "^4.1.0",
-				"chokidar": "^3.5.2",
-				"cosmiconfig": "^7.0.0",
-				"cosmiconfig-typescript-loader": "4.1.1",
+				"cosmiconfig": "^8.1.3",
 				"debounce": "^1.2.0",
 				"detect-indent": "^6.0.0",
-				"graphql-config": "4.3.6",
+				"graphql-config": "^5.0.2",
 				"inquirer": "^8.0.0",
 				"is-glob": "^4.0.1",
+				"jiti": "^1.17.1",
 				"json-to-pretty-yaml": "^1.2.2",
 				"listr2": "^4.0.5",
 				"log-symbols": "^4.0.0",
+				"micromatch": "^4.0.5",
 				"shell-quote": "^1.7.3",
 				"string-env-interpolation": "^1.0.1",
 				"ts-log": "^2.2.3",
 				"tslib": "^2.4.0",
-				"yaml": "^1.10.0",
+				"yaml": "^2.3.1",
 				"yargs": "^17.0.0"
 			},
 			"bin": {
@@ -1607,875 +1643,806 @@
 				"graphql-codegen-esm": "esm/bin.js"
 			},
 			"peerDependencies": {
+				"@parcel/watcher": "^2.1.0",
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@parcel/watcher": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@graphql-codegen/core": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.6.8.tgz",
-			"integrity": "sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.0.tgz",
+			"integrity": "sha512-JAGRn49lEtSsZVxeIlFVIRxts2lWObR+OQo7V2LHDJ7ohYYw3ilv7nJ8pf8P4GTg/w6ptcYdSdVVdkI8kUHB/Q==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-tools/schema": "^9.0.0",
-				"@graphql-tools/utils": "^9.1.1",
-				"tslib": "~2.4.0"
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
-		"node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
 		"node_modules/@graphql-codegen/plugin-helpers": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
-			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.1.tgz",
+			"integrity": "sha512-6L5sb9D8wptZhnhLLBcheSPU7Tg//DGWgc5tQBWX46KYTOTQHGqDpv50FxAJJOyFVJrveN9otWk9UT9/yfY4ww==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "^9.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"change-case-all": "1.0.15",
 				"common-tags": "1.8.2",
 				"import-from": "4.0.0",
 				"lodash": "~4.17.0",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-			}
-		},
-		"node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-codegen/schema-ast": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz",
-			"integrity": "sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.0.0.tgz",
+			"integrity": "sha512-WIzkJFa9Gz28FITAPILbt+7A8+yzOyd1NxgwFh7ie+EmO9a5zQK6UQ3U/BviirguXCYnn+AR4dXsoDrSrtRA1g==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-tools/utils": "^9.0.0",
-				"tslib": "~2.4.0"
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
-		"node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
 		"node_modules/@graphql-codegen/typed-document-node": {
-			"version": "2.3.12",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.12.tgz",
-			"integrity": "sha512-0yoJIF7PhbgptSY48KMpTHzS5Abgks7ovxQB8yOQEE0IixCr1tSszkghiyvnNZou+YtqvlkgXLR1DA/v+HOdUg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.1.tgz",
+			"integrity": "sha512-VFkhCuJnkgtbbgzoCAwTdJe2G1H6sd3LfCrDqWUrQe53y2ukfSb5Ov1PhAIkCBStKCMQBUY9YgGz9GKR40qQ8g==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-codegen/visitor-plugin-common": "2.13.7",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
 				"change-case-all": "1.0.15",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
 		"node_modules/@graphql-codegen/typescript": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.5.tgz",
-			"integrity": "sha512-5w3zNlnNKM9tI5ZRbhESmsJ4G16rSiFmNQX6Ot56fmcYUC6bnAt5fqvSqs2C+8fVGIIjeWuwjQA5Xn1VkaLY8A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.1.tgz",
+			"integrity": "sha512-3YziQ21dCVdnHb+Us1uDb3pA6eG5Chjv0uTK+bt9dXeMlwYBU8MbtzvQTo4qvzWVC1AxSOKj0rgfNu1xCXqJyA==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-codegen/schema-ast": "^2.6.0",
-				"@graphql-codegen/visitor-plugin-common": "2.13.5",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/schema-ast": "^4.0.0",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
 		"node_modules/@graphql-codegen/typescript-operations": {
-			"version": "2.5.12",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.12.tgz",
-			"integrity": "sha512-/w8IgRIQwmebixf514FOQp2jXOe7vxZbMiSFoQqJgEgzrr42joPsgu4YGU+owv2QPPmu4736OcX8FSavb7SLiA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.0.1.tgz",
+			"integrity": "sha512-GpUWWdBVUec/Zqo23aFLBMrXYxN2irypHqDcKjN78JclDPdreasAEPcIpMfqf4MClvpmvDLy4ql+djVAwmkjbw==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-codegen/typescript": "^2.8.7",
-				"@graphql-codegen/visitor-plugin-common": "2.13.7",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/typescript": "^4.0.1",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
-				"tslib": "~2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-			}
-		},
-		"node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.7.tgz",
-			"integrity": "sha512-Nm5keWqIgg/VL7fivGmglF548tJRP2ttSmfTMuAdY5GNGTJTVZOzNbIOfnbVEDMMWF4V+quUuSyeUQ6zRxtX1w==",
-			"dev": true,
-			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-codegen/schema-ast": "^2.6.1",
-				"@graphql-codegen/visitor-plugin-common": "2.13.7",
-				"auto-bind": "~4.0.0",
-				"tslib": "~2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-			}
-		},
-		"node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
-			"version": "2.13.5",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.5.tgz",
-			"integrity": "sha512-OV/mGnSvB/WkEqFu/3bPkAPDNRGRB3xONww5+06CObl383yGrasqM04shYYK4cpcCn9PVWFe8u0SLSEeGmMVrg==",
-			"dev": true,
-			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-tools/optimize": "^1.3.0",
-				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
-				"@graphql-tools/utils": "^8.8.0",
-				"auto-bind": "~4.0.0",
-				"change-case-all": "1.0.15",
-				"dependency-graph": "^0.11.0",
-				"graphql-tag": "^2.11.0",
-				"parse-filepath": "^1.0.2",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
 		"node_modules/@graphql-codegen/visitor-plugin-common": {
-			"version": "2.13.7",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.7.tgz",
-			"integrity": "sha512-xE6iLDhr9sFM1qwCGJcCXRu5MyA0moapG2HVejwyAXXLubYKYwWnoiEigLH2b5iauh6xsl6XP8hh9D1T1dn5Cw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-4.0.1.tgz",
+			"integrity": "sha512-Bi/1z0nHg4QMsAqAJhds+ForyLtk7A3HQOlkrZNm3xEkY7lcBzPtiOTLBtvziwopBsXUxqeSwVjOOFPLS5Yw1Q==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-tools/optimize": "^1.3.0",
-				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
-				"@graphql-tools/utils": "^9.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/optimize": "^2.0.0",
+				"@graphql-tools/relay-operation-optimizer": "^7.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"auto-bind": "~4.0.0",
 				"change-case-all": "1.0.15",
 				"dependency-graph": "^0.11.0",
 				"graphql-tag": "^2.11.0",
 				"parse-filepath": "^1.0.2",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			},
 			"peerDependencies": {
 				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
-		"node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
 		"node_modules/@graphql-tools/apollo-engine-loader": {
-			"version": "7.3.21",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.21.tgz",
-			"integrity": "sha512-mCf5CRZ64Cj4pmXpcgSJDkHj93owntvAmyHpY651yAmQKYJ5Kltrw6rreo2VJr1Eu4BWdHqcMS++NLq5GPGewg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz",
+			"integrity": "sha512-axQTbN5+Yxs1rJ6cWQBOfw3AEeC+fvIuZSfJLPLLvFJLj4pUm9fhxey/g6oQZAAQJqKPfw+tLDUQvnfvRK8Kmg==",
 			"dev": true,
 			"dependencies": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/utils": "9.1.3",
-				"@whatwg-node/fetch": "^0.5.0",
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
 				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
-		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/events": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+			"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/fetch": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+			"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@whatwg-node/node-fetch": "^0.4.8",
+				"urlpattern-polyfill": "^9.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			"engines": {
+				"node": ">=16.0.0"
 			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/node-fetch": {
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+			"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/events": "^0.1.0",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/urlpattern-polyfill": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+			"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+			"dev": true
 		},
 		"node_modules/@graphql-tools/batch-execute": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.14.tgz",
-			"integrity": "sha512-m6yXqqmFAH2V5JuSIC/geiGLBQA1Y6RddOJfUtkc9Z7ttkULRCd1W39TpYS6IlrCwYyTj+klO1/kdWiny38f5g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.1.tgz",
+			"integrity": "sha512-cc96n/JNARtnYjru6KQl3u3MLrQLfFBu8VoDRRG2BQmShodw4QJ8fn7MzFABjkBHFQPydNGN1QOKBCjq6ui/3g==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
-				"dataloader": "2.1.0",
+				"@graphql-tools/utils": "^10.0.5",
+				"dataloader": "^2.2.2",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/code-file-loader": {
-			"version": "7.3.15",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.15.tgz",
-			"integrity": "sha512-cF8VNc/NANTyVSIK8BkD/KSXRF64DvvomuJ0evia7tJu4uGTXgDjimTMWsTjKRGOOBSTEbL6TA8e4DdIYq6Udw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.0.2.tgz",
+			"integrity": "sha512-AKNpkElUL2cWocYpC4DzNEpo6qJw8Lp+L3bKQ/mIfmbsQxgLz5uve6zHBMhDaFPdlwfIox41N3iUSvi77t9e8A==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/graphql-tag-pluck": "8.0.2",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/delegate": {
-			"version": "9.0.21",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.21.tgz",
-			"integrity": "sha512-SM8tFeq6ogFGhIxDE82WTS44/3IQ/wz9QksAKT7xWkcICQnyR9U6Qyt+W7VGnHiybqNsVK3kHNNS/i4KGSF85g==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.2.tgz",
+			"integrity": "sha512-ZU7VnR2xFgHrGnsuw6+nRJkcvSucn7w5ooxb/lTKlVfrNJfTwJevNcNKMnbtPUSajG3+CaFym/nU6v44GXCmNw==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/batch-execute": "8.5.14",
-				"@graphql-tools/executor": "0.0.11",
-				"@graphql-tools/schema": "9.0.12",
-				"@graphql-tools/utils": "9.1.3",
-				"dataloader": "2.1.0",
-				"tslib": "~2.4.0",
-				"value-or-promise": "1.0.11"
+				"@graphql-tools/batch-execute": "^9.0.1",
+				"@graphql-tools/executor": "^1.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.5",
+				"dataloader": "^2.2.2",
+				"tslib": "^2.5.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/executor": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.11.tgz",
-			"integrity": "sha512-GjtXW0ZMGZGKad6A1HXFPArkfxE0AIpznusZuQdy4laQx+8Ut3Zx8SAFJNnDfZJ2V5kU29B5Xv3Fr0/DiMBHOQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
+			"integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
-				"@graphql-typed-document-node/core": "3.1.1",
-				"@repeaterjs/repeater": "3.0.4",
+				"@graphql-tools/utils": "^10.0.0",
+				"@graphql-typed-document-node/core": "3.2.0",
+				"@repeaterjs/repeater": "^3.0.4",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/executor-graphql-ws": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.5.tgz",
-			"integrity": "sha512-1bJfZdSBPCJWz1pJ5g/YHMtGt6YkNRDdmqNQZ8v+VlQTNVfuBpY2vzj15uvf5uDrZLg2MSQThrKlL8av4yFpsA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.0.tgz",
+			"integrity": "sha512-yM67SzwE8rYRpm4z4AuGtABlOp9mXXVy6sxXnTJRoYIdZrmDbKVfIY+CpZUJCqS0FX3xf2+GoHlsj7Qswaxgcg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
-				"@repeaterjs/repeater": "3.0.4",
+				"@graphql-tools/utils": "^10.0.2",
 				"@types/ws": "^8.0.0",
-				"graphql-ws": "5.11.2",
-				"isomorphic-ws": "5.0.0",
+				"graphql-ws": "^5.14.0",
+				"isomorphic-ws": "^5.0.0",
 				"tslib": "^2.4.0",
-				"ws": "8.11.0"
+				"ws": "^8.13.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/executor-graphql-ws/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/executor-http": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.0.8.tgz",
-			"integrity": "sha512-Y0WzbBW2dDm68EqjRO7eaCC38H6mNFUCcy8ivwnv0hon/N4GjQJhrR0cApJh/xqn/YqCY0Sn2ScmdGVuSdaCcA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.2.tgz",
+			"integrity": "sha512-JKTB4E3kdQM2/1NEcyrVPyQ8057ZVthCV5dFJiKktqY9IdmF00M8gupFcW3jlbM/Udn78ickeUBsUzA3EouqpA==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
-				"@repeaterjs/repeater": "3.0.4",
-				"@whatwg-node/fetch": "0.5.4",
-				"dset": "3.1.2",
+				"@graphql-tools/utils": "^10.0.2",
+				"@repeaterjs/repeater": "^3.0.4",
+				"@whatwg-node/fetch": "^0.9.0",
 				"extract-files": "^11.0.0",
-				"meros": "1.2.1",
+				"meros": "^1.2.1",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
-		"node_modules/@graphql-tools/executor-http/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+		"node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/events": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+			"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/fetch": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+			"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@whatwg-node/node-fetch": "^0.4.8",
+				"urlpattern-polyfill": "^9.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			"engines": {
+				"node": ">=16.0.0"
 			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/node-fetch": {
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+			"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/events": "^0.1.0",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/urlpattern-polyfill": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+			"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+			"dev": true
 		},
 		"node_modules/@graphql-tools/executor-legacy-ws": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.5.tgz",
-			"integrity": "sha512-j2ZQVTI4rKIT41STzLPK206naYDhHxmGHot0siJKBKX1vMqvxtWBqvL66v7xYEOaX79wJrFc8l6oeURQP2LE6g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
+			"integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"@types/ws": "^8.0.0",
 				"isomorphic-ws": "5.0.0",
 				"tslib": "^2.4.0",
-				"ws": "8.11.0"
+				"ws": "8.13.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/executor-legacy-ws/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/git-loader": {
-			"version": "7.2.15",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.15.tgz",
-			"integrity": "sha512-1d5HmeuxhSNjQ2+k2rfKgcKcnZEC6H5FM2pY5lSXHMv8VdBELZd7pYDs5/JxoZarDVYfYOJ5xTeVzxf+Du3VNg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.2.tgz",
+			"integrity": "sha512-AuCB0nlPvsHh8u42zRZdlD/ZMaWP9A44yAkQUVCZir1E/LG63fsZ9svTWJ+CbusW3Hd0ZP9qpxEhlHxnd4Tlsg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/graphql-tag-pluck": "8.0.2",
+				"@graphql-tools/utils": "^10.0.0",
 				"is-glob": "4.0.3",
 				"micromatch": "^4.0.4",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/git-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/github-loader": {
-			"version": "7.3.22",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.3.22.tgz",
-			"integrity": "sha512-JE5F/ObbwknO7+gDfeuKAZtLS831WV8/SsLzQLMGY0hdgTbsAg2/xziAGprNToK4GMSD7ygCer9ZryvxBKMwbQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.0.tgz",
+			"integrity": "sha512-VuroArWKcG4yaOWzV0r19ElVIV6iH6UKDQn1MXemND0xu5TzrFme0kf3U9o0YwNo0kUYEk9CyFM0BYg4he17FA==",
 			"dev": true,
 			"dependencies": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
-				"@whatwg-node/fetch": "^0.5.0",
-				"tslib": "^2.4.0"
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/executor-http": "^1.0.0",
+				"@graphql-tools/graphql-tag-pluck": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
+				"tslib": "^2.4.0",
+				"value-or-promise": "^1.0.12"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
-		"node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+		"node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/events": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+			"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/fetch": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+			"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@whatwg-node/node-fetch": "^0.4.8",
+				"urlpattern-polyfill": "^9.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			"engines": {
+				"node": ">=16.0.0"
 			}
+		},
+		"node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/node-fetch": {
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+			"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/events": "^0.1.0",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/github-loader/node_modules/urlpattern-polyfill": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+			"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+			"dev": true
 		},
 		"node_modules/@graphql-tools/graphql-file-loader": {
-			"version": "7.5.13",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.13.tgz",
-			"integrity": "sha512-VWFVnw3aB6sykGfpb/Dn3sxQswqvp2FsVwDy8ubH1pgLuxlDuurhHjRHvMG2+p7IaHC7q8T3Vk/rLtZftrwOBQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.0.tgz",
+			"integrity": "sha512-wRXj9Z1IFL3+zJG1HWEY0S4TXal7+s1vVhbZva96MSp0kbb/3JBF7j0cnJ44Eq0ClccMgGCDFqPFXty4JlpaPg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/import": "6.7.14",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/import": "7.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/graphql-tag-pluck": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.4.2.tgz",
-			"integrity": "sha512-SXM1wR5TExrxocQTxZK5r74jTbg8GxSYLY3mOPCREGz6Fu7PNxMxfguUzGUAB43Mf44Dn8oVztzd2eitv2Qgww==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.0.2.tgz",
+			"integrity": "sha512-U6fE4yEHxuk/nqmPixHpw1WhqdS6aYuaV60m1bEmUmGJNbpAhaMBy01JncpvpF15yZR5LZ0UjkHg+A3Lhoc8YQ==",
 			"dev": true,
 			"dependencies": {
+				"@babel/core": "^7.22.9",
 				"@babel/parser": "^7.16.8",
-				"@babel/plugin-syntax-import-assertions": "7.20.0",
+				"@babel/plugin-syntax-import-assertions": "^7.20.0",
 				"@babel/traverse": "^7.16.8",
 				"@babel/types": "^7.16.8",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/import": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.14.tgz",
-			"integrity": "sha512-lRX/MHM0Km497kg4VXMvtV1DeG/AfPJFO2ovaL0kDujWEdyCsWxsB4whY7nPeiNaPA/nT3mQ8MU7yFzVjogF/Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.0.tgz",
+			"integrity": "sha512-NVZiTO8o1GZs6OXzNfjB+5CtQtqsZZpQOq+Uu0w57kdUkT4RlQKlwhT8T81arEsbV55KpzkpFsOZP7J1wdmhBw==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"resolve-from": "5.0.0",
 				"tslib": "^2.4.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/json-file-loader": {
-			"version": "7.4.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.14.tgz",
-			"integrity": "sha512-AD9v3rN08wvVqgbrUSiHa8Ztrlk3EgwctcxuNE5qm47zPNL4gLaJ7Tw/KlGOR7Cm+pjlQylJHMUKNfaRLPZ0og==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
+			"integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/load": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.8.0.tgz",
-			"integrity": "sha512-l4FGgqMW0VOqo+NMYizwV8Zh+KtvVqOf93uaLo9wJ3sS3y/egPCgxPMDJJ/ufQZG3oZ/0oWeKt68qop3jY0yZg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.0.tgz",
+			"integrity": "sha512-Cy874bQJH0FP2Az7ELPM49iDzOljQmK1PPH6IuxsWzLSTxwTqd8dXA09dcVZrI7/LsN26heTY2R8q2aiiv0GxQ==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"p-limit": "3.1.0",
 				"tslib": "^2.4.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/load/node_modules/@graphql-tools/merge": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.6.tgz",
-			"integrity": "sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==",
-			"dev": true,
-			"dependencies": {
-				"@graphql-tools/utils": "8.12.0",
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/load/node_modules/@graphql-tools/schema": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.4.tgz",
-			"integrity": "sha512-B/b8ukjs18fq+/s7p97P8L1VMrwapYc3N2KvdG/uNThSazRRn8GsBK0Nr+FH+mVKiUfb4Dno79e3SumZVoHuOQ==",
-			"dev": true,
-			"dependencies": {
-				"@graphql-tools/merge": "8.3.6",
-				"@graphql-tools/utils": "8.12.0",
-				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.12.0.tgz",
-			"integrity": "sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/merge": {
-			"version": "8.3.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.14.tgz",
-			"integrity": "sha512-zV0MU1DnxJLIB0wpL4N3u21agEiYFsjm6DI130jqHpwF0pR9HkF+Ni65BNfts4zQelP0GjkHltG+opaozAJ1NA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+			"integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/optimize": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.3.1.tgz",
-			"integrity": "sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+			"integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/prisma-loader": {
-			"version": "7.2.50",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.50.tgz",
-			"integrity": "sha512-tSZFtx5GP5LBHmChwVCkvFw9oCwc0QVP2xR/Pyp61c3Fb2gyqzFq/8lnbcmxR+Oi9/Cwt3JsSc4Jkg8jBi5HLw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.1.tgz",
+			"integrity": "sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/url-loader": "7.16.29",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"@types/js-yaml": "^4.0.0",
 				"@types/json-stable-stringify": "^1.0.32",
-				"@types/jsonwebtoken": "^8.5.0",
+				"@whatwg-node/fetch": "^0.9.0",
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
 				"dotenv": "^16.0.0",
-				"graphql-request": "^5.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"isomorphic-fetch": "^3.0.0",
+				"graphql-request": "^6.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"jose": "^4.11.4",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
 				"yaml-ast-parser": "^0.0.43"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/events": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+			"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/fetch": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+			"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/node-fetch": "^0.4.8",
+				"urlpattern-polyfill": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/node-fetch": {
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+			"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/events": "^0.1.0",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/urlpattern-polyfill": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+			"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+			"dev": true
+		},
 		"node_modules/@graphql-tools/relay-operation-optimizer": {
-			"version": "6.5.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.14.tgz",
-			"integrity": "sha512-RAy1fMfXig9X3gIkYnfEmv0mh20vZuAgWDq+zf1MrrsCAP364B+DKrBjLwn3D+4e0PMTlqwmqR0JB5t1VtZn2w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.0.tgz",
+			"integrity": "sha512-UNlJi5y3JylhVWU4MBpL0Hun4Q7IoJwv9xYtmAz+CgRa066szzY7dcuPfxrA7cIGgG/Q6TVsKsYaiF4OHPs1Fw==",
 			"dev": true,
 			"dependencies": {
 				"@ardatan/relay-compiler": "12.0.0",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/schema": {
-			"version": "9.0.12",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.12.tgz",
-			"integrity": "sha512-DmezcEltQai0V1y96nwm0Kg11FDS/INEFekD4nnVgzBqawvznWqK6D6bujn+cw6kivoIr3Uq//QmU/hBlBzUlQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+			"integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/merge": "8.3.14",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/merge": "^9.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/url-loader": {
-			"version": "7.16.29",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.29.tgz",
-			"integrity": "sha512-e7c0rLH4BIaYxOgglHhWbupTn3JZFXYIHXpY+T1CcTF3nQQCaKy8o59+R2AjtEgx3Az1WNahGn4xgkKUxUwCBw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
+			"integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
 			"dev": true,
 			"dependencies": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/delegate": "9.0.21",
-				"@graphql-tools/executor-graphql-ws": "0.0.5",
-				"@graphql-tools/executor-http": "0.0.8",
-				"@graphql-tools/executor-legacy-ws": "0.0.5",
-				"@graphql-tools/utils": "9.1.3",
-				"@graphql-tools/wrap": "9.2.23",
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/delegate": "^10.0.0",
+				"@graphql-tools/executor-graphql-ws": "^1.0.0",
+				"@graphql-tools/executor-http": "^1.0.0",
+				"@graphql-tools/executor-legacy-ws": "^1.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@graphql-tools/wrap": "^10.0.0",
 				"@types/ws": "^8.0.0",
-				"@whatwg-node/fetch": "^0.5.0",
-				"isomorphic-ws": "5.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
+				"isomorphic-ws": "^5.0.0",
 				"tslib": "^2.4.0",
 				"value-or-promise": "^1.0.11",
-				"ws": "8.11.0"
+				"ws": "^8.12.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
-		"node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+		"node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/events": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+			"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+			"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@whatwg-node/node-fetch": "^0.4.8",
+				"urlpattern-polyfill": "^9.0.0"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			"engines": {
+				"node": ">=16.0.0"
 			}
+		},
+		"node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/node-fetch": {
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+			"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/events": "^0.1.0",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/url-loader/node_modules/urlpattern-polyfill": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+			"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+			"dev": true
 		},
 		"node_modules/@graphql-tools/utils": {
-			"version": "8.13.1",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
-			"integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+			"version": "10.0.5",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.5.tgz",
+			"integrity": "sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==",
 			"dev": true,
 			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"dset": "^3.1.2",
 				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/wrap": {
-			"version": "9.2.23",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.23.tgz",
-			"integrity": "sha512-R+ar8lHdSnRQtfvkwQMOkBRlYLcBPdmFzZPiAj+tL9Nii4VNr4Oub37jcHiPBvRZSdKa9FHcKq5kKSQcbg1xuQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
+			"integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/delegate": "9.0.21",
-				"@graphql-tools/schema": "9.0.12",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/delegate": "^10.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
 			},
-			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-			}
-		},
-		"node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-			"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
+			"engines": {
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-typed-document-node/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
 			"dev": true,
 			"peerDependencies": {
-				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2509,12 +2476,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/schema": {
@@ -2626,9 +2587,9 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-schema": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
-			"integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+			"integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
 			"dev": true,
 			"dependencies": {
 				"asn1js": "^3.0.5",
@@ -2649,16 +2610,16 @@
 			}
 		},
 		"node_modules/@peculiar/webcrypto": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
-			"integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+			"integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
 			"dev": true,
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.3.0",
+				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
 				"pvtsutils": "^1.3.2",
-				"tslib": "^2.4.1",
-				"webcrypto-core": "^1.7.4"
+				"tslib": "^2.5.0",
+				"webcrypto-core": "^1.7.7"
 			},
 			"engines": {
 				"node": ">=10.12.0"
@@ -2688,39 +2649,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
 			"integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-			"dev": true
-		},
-		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
 			"dev": true
 		},
 		"node_modules/@types/chai": {
@@ -2768,25 +2696,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/jsonwebtoken": {
-			"version": "8.5.9",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-			"integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/node": {
 			"version": "18.11.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
 			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-			"dev": true
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -2796,9 +2709,9 @@
 			"dev": true
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-			"integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+			"integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
@@ -3133,32 +3046,36 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/@whatwg-node/events": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+			"integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
+			"dev": true
+		},
 		"node_modules/@whatwg-node/fetch": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.5.4.tgz",
-			"integrity": "sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==",
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+			"integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
 			"dev": true,
 			"dependencies": {
 				"@peculiar/webcrypto": "^1.4.0",
-				"abort-controller": "^3.0.0",
+				"@whatwg-node/node-fetch": "^0.3.6",
 				"busboy": "^1.6.0",
-				"form-data-encoder": "^1.7.1",
-				"formdata-node": "^4.3.1",
-				"node-fetch": "^2.6.7",
-				"undici": "^5.12.0",
-				"web-streams-polyfill": "^3.2.0"
+				"urlpattern-polyfill": "^8.0.0",
+				"web-streams-polyfill": "^3.2.1"
 			}
 		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+		"node_modules/@whatwg-node/node-fetch": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+			"integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
 			"dev": true,
 			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
+				"@whatwg-node/events": "^0.0.3",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
 			}
 		},
 		"node_modules/acorn": {
@@ -3192,15 +3109,15 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
 			"dev": true,
 			"dependencies": {
-				"debug": "4"
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -3270,25 +3187,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -3379,12 +3277,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true
 		},
 		"node_modules/auto-bind": {
 			"version": "4.0.0",
@@ -3480,15 +3372,6 @@
 				}
 			]
 		},
-		"node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -3523,9 +3406,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.21.10",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3535,13 +3418,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001517",
+				"electron-to-chromium": "^1.4.477",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.11"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3582,12 +3469,6 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
 			}
-		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -3704,9 +3585,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+			"version": "1.0.30001521",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+			"integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3716,6 +3597,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -3815,33 +3700,6 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
-			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
-			},
-			"engines": {
-				"node": ">= 8.10.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/clean-stack": {
@@ -3949,18 +3807,6 @@
 			"integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
 			"dev": true
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -3994,59 +3840,30 @@
 			"dev": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
 				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
+				"path-type": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig-toml-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
-			"integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
-			"dev": true,
-			"dependencies": {
-				"@iarna/toml": "^2.2.5"
-			}
-		},
-		"node_modules/cosmiconfig-typescript-loader": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
-			"integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
+				"node": ">=14"
 			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"cosmiconfig": ">=7",
-				"ts-node": ">=10",
-				"typescript": ">=3"
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
 			}
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
 		},
 		"node_modules/cross-fetch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+			"integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
 			"dev": true,
 			"dependencies": {
-				"node-fetch": "2.6.7"
+				"node-fetch": "^2.6.12"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -4064,9 +3881,9 @@
 			}
 		},
 		"node_modules/dataloader": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-			"integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+			"integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
 			"dev": true
 		},
 		"node_modules/debounce": {
@@ -4156,15 +3973,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/dependency-graph": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
@@ -4181,15 +3989,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -4227,12 +4026,15 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/motdotla/dotenv?sponsor=1"
 			}
 		},
 		"node_modules/dset": {
@@ -4244,19 +4046,10 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.4.494",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
+			"integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -4854,15 +4647,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -4888,6 +4672,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jaydenseric"
 			}
+		},
+		"node_modules/fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+			"dev": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4923,6 +4713,30 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-querystring": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+			"dev": true,
+			"dependencies": {
+				"fast-decode-uri-component": "^1.0.1"
+			}
+		},
+		"node_modules/fast-url-parser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+			"integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^1.3.2"
+			}
+		},
+		"node_modules/fast-url-parser/node_modules/punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+			"dev": true
+		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4942,9 +4756,9 @@
 			}
 		},
 		"node_modules/fbjs": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
-			"integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+			"integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
 			"dev": true,
 			"dependencies": {
 				"cross-fetch": "^3.1.5",
@@ -4953,7 +4767,7 @@
 				"object-assign": "^4.1.0",
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.30"
+				"ua-parser-js": "^1.0.35"
 			}
 		},
 		"node_modules/fbjs-css-vars": {
@@ -5065,48 +4879,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-			"dev": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/form-data-encoder": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-			"dev": true
-		},
-		"node_modules/formdata-node": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-			"dev": true,
-			"dependencies": {
-				"node-domexception": "1.0.0",
-				"web-streams-polyfill": "4.0.0-beta.3"
-			},
-			"engines": {
-				"node": ">= 12.20"
-			}
-		},
-		"node_modules/formdata-node/node_modules/web-streams-polyfill": {
-			"version": "4.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-			"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -5351,52 +5123,40 @@
 			}
 		},
 		"node_modules/graphql-config": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.3.6.tgz",
-			"integrity": "sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
+			"integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/graphql-file-loader": "^7.3.7",
-				"@graphql-tools/json-file-loader": "^7.3.7",
-				"@graphql-tools/load": "^7.5.5",
-				"@graphql-tools/merge": "^8.2.6",
-				"@graphql-tools/url-loader": "^7.9.7",
-				"@graphql-tools/utils": "^8.6.5",
-				"cosmiconfig": "7.0.1",
-				"cosmiconfig-toml-loader": "1.0.0",
-				"cosmiconfig-typescript-loader": "^4.0.0",
-				"minimatch": "4.2.1",
-				"string-env-interpolation": "1.0.1",
-				"ts-node": "^10.8.1",
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/merge": "^9.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"cosmiconfig": "^8.1.0",
+				"jiti": "^1.18.2",
+				"minimatch": "^4.2.3",
+				"string-env-interpolation": "^1.0.1",
 				"tslib": "^2.4.0"
 			},
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">= 16.0.0"
 			},
 			"peerDependencies": {
+				"cosmiconfig-toml-loader": "^1.0.0",
 				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-			}
-		},
-		"node_modules/graphql-config/node_modules/cosmiconfig": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
 			},
-			"engines": {
-				"node": ">=10"
+			"peerDependenciesMeta": {
+				"cosmiconfig-toml-loader": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/graphql-config/node_modules/minimatch": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-			"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
+			"integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -5406,30 +5166,16 @@
 			}
 		},
 		"node_modules/graphql-request": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
-			"integrity": "sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+			"integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-typed-document-node/core": "^3.1.1",
-				"cross-fetch": "^3.1.5",
-				"extract-files": "^9.0.0",
-				"form-data": "^3.0.0"
+				"@graphql-typed-document-node/core": "^3.2.0",
+				"cross-fetch": "^3.1.5"
 			},
 			"peerDependencies": {
 				"graphql": "14 - 16"
-			}
-		},
-		"node_modules/graphql-request/node_modules/extract-files": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
-			"integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
-			"dev": true,
-			"engines": {
-				"node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jaydenseric"
 			}
 		},
 		"node_modules/graphql-tag": {
@@ -5448,9 +5194,9 @@
 			}
 		},
 		"node_modules/graphql-ws": {
-			"version": "5.11.2",
-			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
-			"integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+			"integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -5557,30 +5303,29 @@
 			"dev": true
 		},
 		"node_modules/http-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+			"integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
 			"dev": true,
 			"dependencies": {
-				"@tootallnate/once": "2",
-				"agent-base": "6",
-				"debug": "4"
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+			"integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
 			"dev": true,
 			"dependencies": {
-				"agent-base": "6",
+				"agent-base": "^7.0.2",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -5796,18 +5541,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"dependencies": {
-				"binary-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-boolean-object": {
@@ -6134,16 +5867,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
-		"node_modules/isomorphic-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-			"integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-			"dev": true,
-			"dependencies": {
-				"node-fetch": "^2.6.1",
-				"whatwg-fetch": "^3.4.1"
-			}
-		},
 		"node_modules/isomorphic-ws": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
@@ -6187,6 +5910,24 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.1.tgz",
+			"integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
+			"dev": true,
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
+		"node_modules/jose": {
+			"version": "4.14.4",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+			"integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-sdsl": {
@@ -6297,76 +6038,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-			"integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash": "^4.17.21",
-				"ms": "^2.1.1",
-				"semver": "^7.3.8"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/levn": {
@@ -6582,12 +6253,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
 		"node_modules/map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -6607,9 +6272,9 @@
 			}
 		},
 		"node_modules/meros": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/meros/-/meros-1.2.1.tgz",
-			"integrity": "sha512-R2f/jxYqCAGI19KhAvaxSOxALBMkaXWH2a7rOyqQw+ZmizX5bKkEYWLzdhC+U82ZVVPVp6MCXe3EkVligh+12g==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+			"integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
 			"dev": true,
 			"engines": {
 				"node": ">=13"
@@ -6634,27 +6299,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -6751,29 +6395,10 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
 		"node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
 			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -6797,16 +6422,19 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
 			"dev": true,
+			"dependencies": {
+				"remove-trailing-separator": "^1.0.1"
+			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7277,13 +6905,19 @@
 			}
 		},
 		"node_modules/pvtsutils": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-			"integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.4.tgz",
+			"integrity": "sha512-Y2lmrVPui6d2U0n8lWRSTQ2Ri/0VDcA/BHAPS8/+5ElWp5drG4oPryLaqnehJT71Q2GgmGeB4mau+lSR1gCCmA==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"tslib": "^2.6.1"
 			}
+		},
+		"node_modules/pvtsutils/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"dev": true
 		},
 		"node_modules/pvutils": {
 			"version": "1.1.3",
@@ -7328,22 +6962,10 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
-			"engines": {
-				"node": ">=8.10.0"
-			}
-		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
 			"dev": true
 		},
 		"node_modules/regexp.prototype.flags": {
@@ -7596,9 +7218,9 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8036,49 +7658,6 @@
 			"integrity": "sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==",
 			"dev": true
 		},
-		"node_modules/ts-node": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-			"dev": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -8104,9 +7683,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
 			"dev": true
 		},
 		"node_modules/tsutils": {
@@ -8191,9 +7770,9 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "0.7.35",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
+			"version": "1.0.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+			"integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
 			"dev": true,
 			"funding": [
 				{
@@ -8239,18 +7818,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/undici": {
-			"version": "5.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
-			"dev": true,
-			"dependencies": {
-				"busboy": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
 		"node_modules/unixify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -8263,22 +7830,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/unixify/node_modules/normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-			"dev": true,
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
 			"dev": true,
 			"funding": [
 				{
@@ -8288,6 +7843,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
@@ -8295,7 +7854,7 @@
 				"picocolors": "^1.0.0"
 			},
 			"bin": {
-				"browserslist-lint": "cli.js"
+				"update-browserslist-db": "cli.js"
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
@@ -8328,16 +7887,16 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+			"integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+			"dev": true
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
@@ -8355,9 +7914,9 @@
 			}
 		},
 		"node_modules/value-or-promise": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-			"integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -8510,12 +8069,12 @@
 			}
 		},
 		"node_modules/webcrypto-core": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-			"integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+			"integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
 			"dev": true,
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.1.6",
+				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
 				"asn1js": "^3.0.1",
 				"pvtsutils": "^1.3.2",
@@ -8526,12 +8085,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true
-		},
-		"node_modules/whatwg-fetch": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
 			"dev": true
 		},
 		"node_modules/whatwg-url": {
@@ -8576,9 +8129,9 @@
 			}
 		},
 		"node_modules/which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
 			"dev": true
 		},
 		"node_modules/which-typed-array": {
@@ -8640,16 +8193,16 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -8676,12 +8229,12 @@
 			"dev": true
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/yaml-ast-parser": {
@@ -8726,15 +8279,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8757,25 +8301,13 @@
 			"requires": {}
 		},
 		"@ampproject/remapping": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"dependencies": {
-				"@jridgewell/gen-mapping": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-					"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/set-array": "^1.0.0",
-						"@jridgewell/sourcemap-codec": "^1.4.10"
-					}
-				}
 			}
 		},
 		"@ardatan/relay-compiler": {
@@ -8909,244 +8441,299 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.22.10",
+				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
+			"integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
 			"dev": true,
 			"requires": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.12",
-				"@babel/types": "^7.20.7",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
+				"@babel/helper-module-transforms": "^7.22.9",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.2",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+			"integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.7",
+				"@babel/types": "^7.22.10",
 				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-			"integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+			"integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.21.3",
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-validator-option": "^7.22.5",
+				"browserslist": "^4.21.9",
 				"lru-cache": "^5.1.1",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-			"integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.10.tgz",
+			"integrity": "sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-replace-supers": "^7.20.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-				"@babel/helper-split-export-declaration": "^7.18.6"
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-member-expression-to-functions": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"semver": "^6.3.1"
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+			"integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
 			"dev": true
 		},
 		"@babel/helper-function-name": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.18.10",
-				"@babel/types": "^7.19.0"
+				"@babel/template": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-			"integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
+			"integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+			"integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
+			"integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.20.2",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.5"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+			"integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-			"integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
 			"dev": true
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-			"integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
+			"integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-member-expression-to-functions": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-			"integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.2"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-			"integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+			"integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.0"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
+			"integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-			"integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+			"integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/template": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.5",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
@@ -9209,9 +8796,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-			"integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+			"integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-class-properties": {
@@ -9247,30 +8834,30 @@
 			}
 		},
 		"@babel/plugin-syntax-flow": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
-			"integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
+			"integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-syntax-import-assertions": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
-			"integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.22.5.tgz",
+			"integrity": "sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.19.0"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-			"integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -9283,251 +8870,251 @@
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
-			"integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.22.5.tgz",
+			"integrity": "sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
-			"integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.22.5.tgz",
+			"integrity": "sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
-			"integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
+			"integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
-			"integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
+			"integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-replace-supers": "^7.20.7",
-				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-compilation-targets": "^7.22.6",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-optimise-call-expression": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
-			"integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.22.5.tgz",
+			"integrity": "sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/template": "^7.20.7"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/template": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
-			"integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
+			"integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.19.0.tgz",
-			"integrity": "sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.22.5.tgz",
+			"integrity": "sha512-tujNbZdxdG0/54g/oua8ISToaXTFBf8EnSb5PgQSciIXWOWKX3S4+JR7ZE9ol8FZwf9kxitzkGQ+QWeov/mCiA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.19.0",
-				"@babel/plugin-syntax-flow": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-flow": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
-			"integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.5.tgz",
+			"integrity": "sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
-			"integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.22.5.tgz",
+			"integrity": "sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-compilation-targets": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
-			"integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.22.5.tgz",
+			"integrity": "sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
-			"integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.22.5.tgz",
+			"integrity": "sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-			"integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz",
+			"integrity": "sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-simple-access": "^7.20.2"
+				"@babel/helper-module-transforms": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-simple-access": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
-			"integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.22.5.tgz",
+			"integrity": "sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6",
-				"@babel/helper-replace-supers": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
-			"integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.5.tgz",
+			"integrity": "sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
-			"integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.22.5.tgz",
+			"integrity": "sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
-			"integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
+			"integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.7.tgz",
-			"integrity": "sha512-Tfq7qqD+tRj3EoDhY00nn2uP2hsRxgYGi5mLQ5TimKav0a9Lrpd4deE+fcLXU8zFYRjlKPHZhpCvfEA6qnBxqQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
+			"integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/plugin-syntax-jsx": "^7.18.6",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-jsx": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
-			"integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.22.5.tgz",
+			"integrity": "sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
-			"integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.22.5.tgz",
+			"integrity": "sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
-			"integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.22.5.tgz",
+			"integrity": "sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.9"
+				"@babel/helper-plugin-utils": "^7.22.5"
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-			"integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+			"integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.11"
+				"regenerator-runtime": "^0.14.0"
 			}
 		},
 		"@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+			"integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.22.5",
+				"@babel/parser": "^7.22.5",
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
-			"integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-environment-visitor": "^7.22.5",
+				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-			"integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+			"integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.5",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -9536,27 +9123,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"dependencies": {
-				"@jridgewell/trace-mapping": {
-					"version": "0.3.9",
-					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/resolve-uri": "^3.0.3",
-						"@jridgewell/sourcemap-codec": "^1.4.10"
-					}
-				}
-			}
 		},
 		"@esbuild/android-arm": {
 			"version": "0.16.17",
@@ -9747,787 +9313,641 @@
 			}
 		},
 		"@graphql-codegen/cli": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.16.1.tgz",
-			"integrity": "sha512-11z3iSlsNCXcNNkoRKG3wCmT9XpLf7/GZG9bWGXkCoveWVRwnRmo37YakHdNV3hbcJ4iiGbR3Z+MX9gUTEPDVA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.0.tgz",
+			"integrity": "sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==",
 			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.18.13",
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.18.13",
-				"@graphql-codegen/core": "2.6.8",
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-tools/apollo-engine-loader": "^7.3.6",
-				"@graphql-tools/code-file-loader": "^7.3.13",
-				"@graphql-tools/git-loader": "^7.2.13",
-				"@graphql-tools/github-loader": "^7.3.20",
-				"@graphql-tools/graphql-file-loader": "^7.5.0",
-				"@graphql-tools/json-file-loader": "^7.4.1",
-				"@graphql-tools/load": "7.8.0",
-				"@graphql-tools/prisma-loader": "^7.2.7",
-				"@graphql-tools/url-loader": "^7.13.2",
-				"@graphql-tools/utils": "^8.9.0",
-				"@whatwg-node/fetch": "^0.5.0",
+				"@graphql-codegen/core": "^4.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.1",
+				"@graphql-tools/apollo-engine-loader": "^8.0.0",
+				"@graphql-tools/code-file-loader": "^8.0.0",
+				"@graphql-tools/git-loader": "^8.0.0",
+				"@graphql-tools/github-loader": "^8.0.0",
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/prisma-loader": "^8.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.8.0",
 				"chalk": "^4.1.0",
-				"chokidar": "^3.5.2",
-				"cosmiconfig": "^7.0.0",
-				"cosmiconfig-typescript-loader": "4.1.1",
+				"cosmiconfig": "^8.1.3",
 				"debounce": "^1.2.0",
 				"detect-indent": "^6.0.0",
-				"graphql-config": "4.3.6",
+				"graphql-config": "^5.0.2",
 				"inquirer": "^8.0.0",
 				"is-glob": "^4.0.1",
+				"jiti": "^1.17.1",
 				"json-to-pretty-yaml": "^1.2.2",
 				"listr2": "^4.0.5",
 				"log-symbols": "^4.0.0",
+				"micromatch": "^4.0.5",
 				"shell-quote": "^1.7.3",
 				"string-env-interpolation": "^1.0.1",
 				"ts-log": "^2.2.3",
 				"tslib": "^2.4.0",
-				"yaml": "^1.10.0",
+				"yaml": "^2.3.1",
 				"yargs": "^17.0.0"
 			}
 		},
 		"@graphql-codegen/core": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.6.8.tgz",
-			"integrity": "sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.0.tgz",
+			"integrity": "sha512-JAGRn49lEtSsZVxeIlFVIRxts2lWObR+OQo7V2LHDJ7ohYYw3ilv7nJ8pf8P4GTg/w6ptcYdSdVVdkI8kUHB/Q==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-tools/schema": "^9.0.0",
-				"@graphql-tools/utils": "^9.1.1",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/plugin-helpers": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
-			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.1.tgz",
+			"integrity": "sha512-6L5sb9D8wptZhnhLLBcheSPU7Tg//DGWgc5tQBWX46KYTOTQHGqDpv50FxAJJOyFVJrveN9otWk9UT9/yfY4ww==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "^9.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"change-case-all": "1.0.15",
 				"common-tags": "1.8.2",
 				"import-from": "4.0.0",
 				"lodash": "~4.17.0",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/schema-ast": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz",
-			"integrity": "sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.0.0.tgz",
+			"integrity": "sha512-WIzkJFa9Gz28FITAPILbt+7A8+yzOyd1NxgwFh7ie+EmO9a5zQK6UQ3U/BviirguXCYnn+AR4dXsoDrSrtRA1g==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-tools/utils": "^9.0.0",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/typed-document-node": {
-			"version": "2.3.12",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.12.tgz",
-			"integrity": "sha512-0yoJIF7PhbgptSY48KMpTHzS5Abgks7ovxQB8yOQEE0IixCr1tSszkghiyvnNZou+YtqvlkgXLR1DA/v+HOdUg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.1.tgz",
+			"integrity": "sha512-VFkhCuJnkgtbbgzoCAwTdJe2G1H6sd3LfCrDqWUrQe53y2ukfSb5Ov1PhAIkCBStKCMQBUY9YgGz9GKR40qQ8g==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-codegen/visitor-plugin-common": "2.13.7",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
 				"change-case-all": "1.0.15",
-				"tslib": "~2.4.0"
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/typescript": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.5.tgz",
-			"integrity": "sha512-5w3zNlnNKM9tI5ZRbhESmsJ4G16rSiFmNQX6Ot56fmcYUC6bnAt5fqvSqs2C+8fVGIIjeWuwjQA5Xn1VkaLY8A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.1.tgz",
+			"integrity": "sha512-3YziQ21dCVdnHb+Us1uDb3pA6eG5Chjv0uTK+bt9dXeMlwYBU8MbtzvQTo4qvzWVC1AxSOKj0rgfNu1xCXqJyA==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.1",
-				"@graphql-codegen/schema-ast": "^2.6.0",
-				"@graphql-codegen/visitor-plugin-common": "2.13.5",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/schema-ast": "^4.0.0",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-codegen/visitor-plugin-common": {
-					"version": "2.13.5",
-					"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.5.tgz",
-					"integrity": "sha512-OV/mGnSvB/WkEqFu/3bPkAPDNRGRB3xONww5+06CObl383yGrasqM04shYYK4cpcCn9PVWFe8u0SLSEeGmMVrg==",
-					"dev": true,
-					"requires": {
-						"@graphql-codegen/plugin-helpers": "^3.1.1",
-						"@graphql-tools/optimize": "^1.3.0",
-						"@graphql-tools/relay-operation-optimizer": "^6.5.0",
-						"@graphql-tools/utils": "^8.8.0",
-						"auto-bind": "~4.0.0",
-						"change-case-all": "1.0.15",
-						"dependency-graph": "^0.11.0",
-						"graphql-tag": "^2.11.0",
-						"parse-filepath": "^1.0.2",
-						"tslib": "~2.4.0"
-					}
-				}
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/typescript-operations": {
-			"version": "2.5.12",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.12.tgz",
-			"integrity": "sha512-/w8IgRIQwmebixf514FOQp2jXOe7vxZbMiSFoQqJgEgzrr42joPsgu4YGU+owv2QPPmu4736OcX8FSavb7SLiA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.0.1.tgz",
+			"integrity": "sha512-GpUWWdBVUec/Zqo23aFLBMrXYxN2irypHqDcKjN78JclDPdreasAEPcIpMfqf4MClvpmvDLy4ql+djVAwmkjbw==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-codegen/typescript": "^2.8.7",
-				"@graphql-codegen/visitor-plugin-common": "2.13.7",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-codegen/typescript": "^4.0.1",
+				"@graphql-codegen/visitor-plugin-common": "4.0.1",
 				"auto-bind": "~4.0.0",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-codegen/typescript": {
-					"version": "2.8.7",
-					"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.7.tgz",
-					"integrity": "sha512-Nm5keWqIgg/VL7fivGmglF548tJRP2ttSmfTMuAdY5GNGTJTVZOzNbIOfnbVEDMMWF4V+quUuSyeUQ6zRxtX1w==",
-					"dev": true,
-					"requires": {
-						"@graphql-codegen/plugin-helpers": "^3.1.2",
-						"@graphql-codegen/schema-ast": "^2.6.1",
-						"@graphql-codegen/visitor-plugin-common": "2.13.7",
-						"auto-bind": "~4.0.0",
-						"tslib": "~2.4.0"
-					}
-				}
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-codegen/visitor-plugin-common": {
-			"version": "2.13.7",
-			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.7.tgz",
-			"integrity": "sha512-xE6iLDhr9sFM1qwCGJcCXRu5MyA0moapG2HVejwyAXXLubYKYwWnoiEigLH2b5iauh6xsl6XP8hh9D1T1dn5Cw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-4.0.1.tgz",
+			"integrity": "sha512-Bi/1z0nHg4QMsAqAJhds+ForyLtk7A3HQOlkrZNm3xEkY7lcBzPtiOTLBtvziwopBsXUxqeSwVjOOFPLS5Yw1Q==",
 			"dev": true,
 			"requires": {
-				"@graphql-codegen/plugin-helpers": "^3.1.2",
-				"@graphql-tools/optimize": "^1.3.0",
-				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
-				"@graphql-tools/utils": "^9.0.0",
+				"@graphql-codegen/plugin-helpers": "^5.0.0",
+				"@graphql-tools/optimize": "^2.0.0",
+				"@graphql-tools/relay-operation-optimizer": "^7.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"auto-bind": "~4.0.0",
 				"change-case-all": "1.0.15",
 				"dependency-graph": "^0.11.0",
 				"graphql-tag": "^2.11.0",
 				"parse-filepath": "^1.0.2",
-				"tslib": "~2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"tslib": "~2.5.0"
 			}
 		},
 		"@graphql-tools/apollo-engine-loader": {
-			"version": "7.3.21",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.21.tgz",
-			"integrity": "sha512-mCf5CRZ64Cj4pmXpcgSJDkHj93owntvAmyHpY651yAmQKYJ5Kltrw6rreo2VJr1Eu4BWdHqcMS++NLq5GPGewg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz",
+			"integrity": "sha512-axQTbN5+Yxs1rJ6cWQBOfw3AEeC+fvIuZSfJLPLLvFJLj4pUm9fhxey/g6oQZAAQJqKPfw+tLDUQvnfvRK8Kmg==",
 			"dev": true,
 			"requires": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/utils": "9.1.3",
-				"@whatwg-node/fetch": "^0.5.0",
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
 				"tslib": "^2.4.0"
 			},
 			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+				"@whatwg-node/events": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+					"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+					"dev": true
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+					"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^2.4.0"
+						"@whatwg-node/node-fetch": "^0.4.8",
+						"urlpattern-polyfill": "^9.0.0"
 					}
+				},
+				"@whatwg-node/node-fetch": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+					"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+					"dev": true,
+					"requires": {
+						"@whatwg-node/events": "^0.1.0",
+						"busboy": "^1.6.0",
+						"fast-querystring": "^1.1.1",
+						"fast-url-parser": "^1.1.3",
+						"tslib": "^2.3.1"
+					}
+				},
+				"urlpattern-polyfill": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+					"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+					"dev": true
 				}
 			}
 		},
 		"@graphql-tools/batch-execute": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.14.tgz",
-			"integrity": "sha512-m6yXqqmFAH2V5JuSIC/geiGLBQA1Y6RddOJfUtkc9Z7ttkULRCd1W39TpYS6IlrCwYyTj+klO1/kdWiny38f5g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.1.tgz",
+			"integrity": "sha512-cc96n/JNARtnYjru6KQl3u3MLrQLfFBu8VoDRRG2BQmShodw4QJ8fn7MzFABjkBHFQPydNGN1QOKBCjq6ui/3g==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
-				"dataloader": "2.1.0",
+				"@graphql-tools/utils": "^10.0.5",
+				"dataloader": "^2.2.2",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"value-or-promise": "^1.0.12"
 			}
 		},
 		"@graphql-tools/code-file-loader": {
-			"version": "7.3.15",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.15.tgz",
-			"integrity": "sha512-cF8VNc/NANTyVSIK8BkD/KSXRF64DvvomuJ0evia7tJu4uGTXgDjimTMWsTjKRGOOBSTEbL6TA8e4DdIYq6Udw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.0.2.tgz",
+			"integrity": "sha512-AKNpkElUL2cWocYpC4DzNEpo6qJw8Lp+L3bKQ/mIfmbsQxgLz5uve6zHBMhDaFPdlwfIox41N3iUSvi77t9e8A==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/graphql-tag-pluck": "8.0.2",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/delegate": {
-			"version": "9.0.21",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.21.tgz",
-			"integrity": "sha512-SM8tFeq6ogFGhIxDE82WTS44/3IQ/wz9QksAKT7xWkcICQnyR9U6Qyt+W7VGnHiybqNsVK3kHNNS/i4KGSF85g==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.2.tgz",
+			"integrity": "sha512-ZU7VnR2xFgHrGnsuw6+nRJkcvSucn7w5ooxb/lTKlVfrNJfTwJevNcNKMnbtPUSajG3+CaFym/nU6v44GXCmNw==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/batch-execute": "8.5.14",
-				"@graphql-tools/executor": "0.0.11",
-				"@graphql-tools/schema": "9.0.12",
-				"@graphql-tools/utils": "9.1.3",
-				"dataloader": "2.1.0",
-				"tslib": "~2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"@graphql-tools/batch-execute": "^9.0.1",
+				"@graphql-tools/executor": "^1.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.5",
+				"dataloader": "^2.2.2",
+				"tslib": "^2.5.0"
 			}
 		},
 		"@graphql-tools/executor": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.11.tgz",
-			"integrity": "sha512-GjtXW0ZMGZGKad6A1HXFPArkfxE0AIpznusZuQdy4laQx+8Ut3Zx8SAFJNnDfZJ2V5kU29B5Xv3Fr0/DiMBHOQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
+			"integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
-				"@graphql-typed-document-node/core": "3.1.1",
-				"@repeaterjs/repeater": "3.0.4",
+				"@graphql-tools/utils": "^10.0.0",
+				"@graphql-typed-document-node/core": "3.2.0",
+				"@repeaterjs/repeater": "^3.0.4",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"value-or-promise": "^1.0.12"
 			}
 		},
 		"@graphql-tools/executor-graphql-ws": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.5.tgz",
-			"integrity": "sha512-1bJfZdSBPCJWz1pJ5g/YHMtGt6YkNRDdmqNQZ8v+VlQTNVfuBpY2vzj15uvf5uDrZLg2MSQThrKlL8av4yFpsA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.0.tgz",
+			"integrity": "sha512-yM67SzwE8rYRpm4z4AuGtABlOp9mXXVy6sxXnTJRoYIdZrmDbKVfIY+CpZUJCqS0FX3xf2+GoHlsj7Qswaxgcg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
-				"@repeaterjs/repeater": "3.0.4",
+				"@graphql-tools/utils": "^10.0.2",
 				"@types/ws": "^8.0.0",
-				"graphql-ws": "5.11.2",
-				"isomorphic-ws": "5.0.0",
+				"graphql-ws": "^5.14.0",
+				"isomorphic-ws": "^5.0.0",
 				"tslib": "^2.4.0",
-				"ws": "8.11.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"ws": "^8.13.0"
 			}
 		},
 		"@graphql-tools/executor-http": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.0.8.tgz",
-			"integrity": "sha512-Y0WzbBW2dDm68EqjRO7eaCC38H6mNFUCcy8ivwnv0hon/N4GjQJhrR0cApJh/xqn/YqCY0Sn2ScmdGVuSdaCcA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.2.tgz",
+			"integrity": "sha512-JKTB4E3kdQM2/1NEcyrVPyQ8057ZVthCV5dFJiKktqY9IdmF00M8gupFcW3jlbM/Udn78ickeUBsUzA3EouqpA==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
-				"@repeaterjs/repeater": "3.0.4",
-				"@whatwg-node/fetch": "0.5.4",
-				"dset": "3.1.2",
+				"@graphql-tools/utils": "^10.0.2",
+				"@repeaterjs/repeater": "^3.0.4",
+				"@whatwg-node/fetch": "^0.9.0",
 				"extract-files": "^11.0.0",
-				"meros": "1.2.1",
+				"meros": "^1.2.1",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "^1.0.12"
 			},
 			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+				"@whatwg-node/events": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+					"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+					"dev": true
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+					"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^2.4.0"
+						"@whatwg-node/node-fetch": "^0.4.8",
+						"urlpattern-polyfill": "^9.0.0"
 					}
+				},
+				"@whatwg-node/node-fetch": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+					"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+					"dev": true,
+					"requires": {
+						"@whatwg-node/events": "^0.1.0",
+						"busboy": "^1.6.0",
+						"fast-querystring": "^1.1.1",
+						"fast-url-parser": "^1.1.3",
+						"tslib": "^2.3.1"
+					}
+				},
+				"urlpattern-polyfill": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+					"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+					"dev": true
 				}
 			}
 		},
 		"@graphql-tools/executor-legacy-ws": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.5.tgz",
-			"integrity": "sha512-j2ZQVTI4rKIT41STzLPK206naYDhHxmGHot0siJKBKX1vMqvxtWBqvL66v7xYEOaX79wJrFc8l6oeURQP2LE6g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
+			"integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"@types/ws": "^8.0.0",
 				"isomorphic-ws": "5.0.0",
 				"tslib": "^2.4.0",
-				"ws": "8.11.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"ws": "8.13.0"
 			}
 		},
 		"@graphql-tools/git-loader": {
-			"version": "7.2.15",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.15.tgz",
-			"integrity": "sha512-1d5HmeuxhSNjQ2+k2rfKgcKcnZEC6H5FM2pY5lSXHMv8VdBELZd7pYDs5/JxoZarDVYfYOJ5xTeVzxf+Du3VNg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.2.tgz",
+			"integrity": "sha512-AuCB0nlPvsHh8u42zRZdlD/ZMaWP9A44yAkQUVCZir1E/LG63fsZ9svTWJ+CbusW3Hd0ZP9qpxEhlHxnd4Tlsg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/graphql-tag-pluck": "8.0.2",
+				"@graphql-tools/utils": "^10.0.0",
 				"is-glob": "4.0.3",
 				"micromatch": "^4.0.4",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/github-loader": {
-			"version": "7.3.22",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.3.22.tgz",
-			"integrity": "sha512-JE5F/ObbwknO7+gDfeuKAZtLS831WV8/SsLzQLMGY0hdgTbsAg2/xziAGprNToK4GMSD7ygCer9ZryvxBKMwbQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.0.tgz",
+			"integrity": "sha512-VuroArWKcG4yaOWzV0r19ElVIV6iH6UKDQn1MXemND0xu5TzrFme0kf3U9o0YwNo0kUYEk9CyFM0BYg4he17FA==",
 			"dev": true,
 			"requires": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/graphql-tag-pluck": "7.4.2",
-				"@graphql-tools/utils": "9.1.3",
-				"@whatwg-node/fetch": "^0.5.0",
-				"tslib": "^2.4.0"
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/executor-http": "^1.0.0",
+				"@graphql-tools/graphql-tag-pluck": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
+				"tslib": "^2.4.0",
+				"value-or-promise": "^1.0.12"
 			},
 			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+				"@whatwg-node/events": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+					"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+					"dev": true
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+					"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^2.4.0"
+						"@whatwg-node/node-fetch": "^0.4.8",
+						"urlpattern-polyfill": "^9.0.0"
 					}
+				},
+				"@whatwg-node/node-fetch": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+					"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+					"dev": true,
+					"requires": {
+						"@whatwg-node/events": "^0.1.0",
+						"busboy": "^1.6.0",
+						"fast-querystring": "^1.1.1",
+						"fast-url-parser": "^1.1.3",
+						"tslib": "^2.3.1"
+					}
+				},
+				"urlpattern-polyfill": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+					"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+					"dev": true
 				}
 			}
 		},
 		"@graphql-tools/graphql-file-loader": {
-			"version": "7.5.13",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.13.tgz",
-			"integrity": "sha512-VWFVnw3aB6sykGfpb/Dn3sxQswqvp2FsVwDy8ubH1pgLuxlDuurhHjRHvMG2+p7IaHC7q8T3Vk/rLtZftrwOBQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.0.tgz",
+			"integrity": "sha512-wRXj9Z1IFL3+zJG1HWEY0S4TXal7+s1vVhbZva96MSp0kbb/3JBF7j0cnJ44Eq0ClccMgGCDFqPFXty4JlpaPg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/import": "6.7.14",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/import": "7.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/graphql-tag-pluck": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.4.2.tgz",
-			"integrity": "sha512-SXM1wR5TExrxocQTxZK5r74jTbg8GxSYLY3mOPCREGz6Fu7PNxMxfguUzGUAB43Mf44Dn8oVztzd2eitv2Qgww==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.0.2.tgz",
+			"integrity": "sha512-U6fE4yEHxuk/nqmPixHpw1WhqdS6aYuaV60m1bEmUmGJNbpAhaMBy01JncpvpF15yZR5LZ0UjkHg+A3Lhoc8YQ==",
 			"dev": true,
 			"requires": {
+				"@babel/core": "^7.22.9",
 				"@babel/parser": "^7.16.8",
-				"@babel/plugin-syntax-import-assertions": "7.20.0",
+				"@babel/plugin-syntax-import-assertions": "^7.20.0",
 				"@babel/traverse": "^7.16.8",
 				"@babel/types": "^7.16.8",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/import": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.14.tgz",
-			"integrity": "sha512-lRX/MHM0Km497kg4VXMvtV1DeG/AfPJFO2ovaL0kDujWEdyCsWxsB4whY7nPeiNaPA/nT3mQ8MU7yFzVjogF/Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.0.tgz",
+			"integrity": "sha512-NVZiTO8o1GZs6OXzNfjB+5CtQtqsZZpQOq+Uu0w57kdUkT4RlQKlwhT8T81arEsbV55KpzkpFsOZP7J1wdmhBw==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"resolve-from": "5.0.0",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/json-file-loader": {
-			"version": "7.4.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.14.tgz",
-			"integrity": "sha512-AD9v3rN08wvVqgbrUSiHa8Ztrlk3EgwctcxuNE5qm47zPNL4gLaJ7Tw/KlGOR7Cm+pjlQylJHMUKNfaRLPZ0og==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
+			"integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"globby": "^11.0.3",
 				"tslib": "^2.4.0",
 				"unixify": "^1.0.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/load": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.8.0.tgz",
-			"integrity": "sha512-l4FGgqMW0VOqo+NMYizwV8Zh+KtvVqOf93uaLo9wJ3sS3y/egPCgxPMDJJ/ufQZG3oZ/0oWeKt68qop3jY0yZg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.0.tgz",
+			"integrity": "sha512-Cy874bQJH0FP2Az7ELPM49iDzOljQmK1PPH6IuxsWzLSTxwTqd8dXA09dcVZrI7/LsN26heTY2R8q2aiiv0GxQ==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"p-limit": "3.1.0",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/merge": {
-					"version": "8.3.6",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.6.tgz",
-					"integrity": "sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==",
-					"dev": true,
-					"requires": {
-						"@graphql-tools/utils": "8.12.0",
-						"tslib": "^2.4.0"
-					}
-				},
-				"@graphql-tools/schema": {
-					"version": "9.0.4",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.4.tgz",
-					"integrity": "sha512-B/b8ukjs18fq+/s7p97P8L1VMrwapYc3N2KvdG/uNThSazRRn8GsBK0Nr+FH+mVKiUfb4Dno79e3SumZVoHuOQ==",
-					"dev": true,
-					"requires": {
-						"@graphql-tools/merge": "8.3.6",
-						"@graphql-tools/utils": "8.12.0",
-						"tslib": "^2.4.0",
-						"value-or-promise": "1.0.11"
-					}
-				},
-				"@graphql-tools/utils": {
-					"version": "8.12.0",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.12.0.tgz",
-					"integrity": "sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/merge": {
-			"version": "8.3.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.14.tgz",
-			"integrity": "sha512-zV0MU1DnxJLIB0wpL4N3u21agEiYFsjm6DI130jqHpwF0pR9HkF+Ni65BNfts4zQelP0GjkHltG+opaozAJ1NA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+			"integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/optimize": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.3.1.tgz",
-			"integrity": "sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+			"integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.4.0"
 			}
 		},
 		"@graphql-tools/prisma-loader": {
-			"version": "7.2.50",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.50.tgz",
-			"integrity": "sha512-tSZFtx5GP5LBHmChwVCkvFw9oCwc0QVP2xR/Pyp61c3Fb2gyqzFq/8lnbcmxR+Oi9/Cwt3JsSc4Jkg8jBi5HLw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.1.tgz",
+			"integrity": "sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/url-loader": "7.16.29",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"@types/js-yaml": "^4.0.0",
 				"@types/json-stable-stringify": "^1.0.32",
-				"@types/jsonwebtoken": "^8.5.0",
+				"@whatwg-node/fetch": "^0.9.0",
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
 				"dotenv": "^16.0.0",
-				"graphql-request": "^5.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"isomorphic-fetch": "^3.0.0",
+				"graphql-request": "^6.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"jose": "^4.11.4",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
 				"yaml-ast-parser": "^0.0.43"
 			},
 			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+				"@whatwg-node/events": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+					"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+					"dev": true
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+					"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^2.4.0"
+						"@whatwg-node/node-fetch": "^0.4.8",
+						"urlpattern-polyfill": "^9.0.0"
 					}
+				},
+				"@whatwg-node/node-fetch": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+					"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+					"dev": true,
+					"requires": {
+						"@whatwg-node/events": "^0.1.0",
+						"busboy": "^1.6.0",
+						"fast-querystring": "^1.1.1",
+						"fast-url-parser": "^1.1.3",
+						"tslib": "^2.3.1"
+					}
+				},
+				"urlpattern-polyfill": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+					"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+					"dev": true
 				}
 			}
 		},
 		"@graphql-tools/relay-operation-optimizer": {
-			"version": "6.5.14",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.14.tgz",
-			"integrity": "sha512-RAy1fMfXig9X3gIkYnfEmv0mh20vZuAgWDq+zf1MrrsCAP364B+DKrBjLwn3D+4e0PMTlqwmqR0JB5t1VtZn2w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.0.tgz",
+			"integrity": "sha512-UNlJi5y3JylhVWU4MBpL0Hun4Q7IoJwv9xYtmAz+CgRa066szzY7dcuPfxrA7cIGgG/Q6TVsKsYaiF4OHPs1Fw==",
 			"dev": true,
 			"requires": {
 				"@ardatan/relay-compiler": "12.0.0",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
 			}
 		},
 		"@graphql-tools/schema": {
-			"version": "9.0.12",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.12.tgz",
-			"integrity": "sha512-DmezcEltQai0V1y96nwm0Kg11FDS/INEFekD4nnVgzBqawvznWqK6D6bujn+cw6kivoIr3Uq//QmU/hBlBzUlQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+			"integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/merge": "8.3.14",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/merge": "^9.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"value-or-promise": "^1.0.12"
 			}
 		},
 		"@graphql-tools/url-loader": {
-			"version": "7.16.29",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.29.tgz",
-			"integrity": "sha512-e7c0rLH4BIaYxOgglHhWbupTn3JZFXYIHXpY+T1CcTF3nQQCaKy8o59+R2AjtEgx3Az1WNahGn4xgkKUxUwCBw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
+			"integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
 			"dev": true,
 			"requires": {
-				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/delegate": "9.0.21",
-				"@graphql-tools/executor-graphql-ws": "0.0.5",
-				"@graphql-tools/executor-http": "0.0.8",
-				"@graphql-tools/executor-legacy-ws": "0.0.5",
-				"@graphql-tools/utils": "9.1.3",
-				"@graphql-tools/wrap": "9.2.23",
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/delegate": "^10.0.0",
+				"@graphql-tools/executor-graphql-ws": "^1.0.0",
+				"@graphql-tools/executor-http": "^1.0.0",
+				"@graphql-tools/executor-legacy-ws": "^1.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@graphql-tools/wrap": "^10.0.0",
 				"@types/ws": "^8.0.0",
-				"@whatwg-node/fetch": "^0.5.0",
-				"isomorphic-ws": "5.0.0",
+				"@whatwg-node/fetch": "^0.9.0",
+				"isomorphic-ws": "^5.0.0",
 				"tslib": "^2.4.0",
 				"value-or-promise": "^1.0.11",
-				"ws": "8.11.0"
+				"ws": "^8.12.0"
 			},
 			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
+				"@whatwg-node/events": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+					"integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+					"dev": true
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.9.9",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+					"integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^2.4.0"
+						"@whatwg-node/node-fetch": "^0.4.8",
+						"urlpattern-polyfill": "^9.0.0"
 					}
+				},
+				"@whatwg-node/node-fetch": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz",
+					"integrity": "sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==",
+					"dev": true,
+					"requires": {
+						"@whatwg-node/events": "^0.1.0",
+						"busboy": "^1.6.0",
+						"fast-querystring": "^1.1.1",
+						"fast-url-parser": "^1.1.3",
+						"tslib": "^2.3.1"
+					}
+				},
+				"urlpattern-polyfill": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+					"integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+					"dev": true
 				}
 			}
 		},
 		"@graphql-tools/utils": {
-			"version": "8.13.1",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
-			"integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+			"version": "10.0.5",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.5.tgz",
+			"integrity": "sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==",
 			"dev": true,
 			"requires": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"dset": "^3.1.2",
 				"tslib": "^2.4.0"
 			}
 		},
 		"@graphql-tools/wrap": {
-			"version": "9.2.23",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.23.tgz",
-			"integrity": "sha512-R+ar8lHdSnRQtfvkwQMOkBRlYLcBPdmFzZPiAj+tL9Nii4VNr4Oub37jcHiPBvRZSdKa9FHcKq5kKSQcbg1xuQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
+			"integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/delegate": "9.0.21",
-				"@graphql-tools/schema": "9.0.12",
-				"@graphql-tools/utils": "9.1.3",
+				"@graphql-tools/delegate": "^10.0.0",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
-			},
-			"dependencies": {
-				"@graphql-tools/utils": {
-					"version": "9.1.3",
-					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.3.tgz",
-					"integrity": "sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.4.0"
-					}
-				}
+				"value-or-promise": "^1.0.12"
 			}
 		},
 		"@graphql-typed-document-node/core": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-			"integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
 			"dev": true,
 			"requires": {}
 		},
@@ -10552,12 +9972,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
 			"dev": true
 		},
 		"@istanbuljs/schema": {
@@ -10643,9 +10057,9 @@
 			}
 		},
 		"@peculiar/asn1-schema": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
-			"integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+			"integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
 			"dev": true,
 			"requires": {
 				"asn1js": "^3.0.5",
@@ -10663,16 +10077,16 @@
 			}
 		},
 		"@peculiar/webcrypto": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
-			"integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+			"integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
 			"dev": true,
 			"requires": {
-				"@peculiar/asn1-schema": "^2.3.0",
+				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
 				"pvtsutils": "^1.3.2",
-				"tslib": "^2.4.1",
-				"webcrypto-core": "^1.7.4"
+				"tslib": "^2.5.0",
+				"webcrypto-core": "^1.7.7"
 			}
 		},
 		"@pkgr/utils": {
@@ -10693,36 +10107,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
 			"integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-			"dev": true
-		},
-		"@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-			"dev": true
-		},
-		"@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
 			"dev": true
 		},
 		"@types/chai": {
@@ -10770,25 +10154,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"@types/jsonwebtoken": {
-			"version": "8.5.9",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-			"integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/node": {
 			"version": "18.11.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
 			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-			"dev": true
-		},
-		"@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
 		"@types/semver": {
@@ -10798,9 +10167,9 @@
 			"dev": true
 		},
 		"@types/ws": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-			"integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+			"integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -11022,29 +10391,36 @@
 				"vitest": "0.26.3"
 			}
 		},
+		"@whatwg-node/events": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+			"integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
+			"dev": true
+		},
 		"@whatwg-node/fetch": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.5.4.tgz",
-			"integrity": "sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==",
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+			"integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
 			"dev": true,
 			"requires": {
 				"@peculiar/webcrypto": "^1.4.0",
-				"abort-controller": "^3.0.0",
+				"@whatwg-node/node-fetch": "^0.3.6",
 				"busboy": "^1.6.0",
-				"form-data-encoder": "^1.7.1",
-				"formdata-node": "^4.3.1",
-				"node-fetch": "^2.6.7",
-				"undici": "^5.12.0",
-				"web-streams-polyfill": "^3.2.0"
+				"urlpattern-polyfill": "^8.0.0",
+				"web-streams-polyfill": "^3.2.1"
 			}
 		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+		"@whatwg-node/node-fetch": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+			"integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
 			"dev": true,
 			"requires": {
-				"event-target-shim": "^5.0.0"
+				"@whatwg-node/events": "^0.0.3",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"fast-url-parser": "^1.1.3",
+				"tslib": "^2.3.1"
 			}
 		},
 		"acorn": {
@@ -11067,12 +10443,12 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
 			"dev": true,
 			"requires": {
-				"debug": "4"
+				"debug": "^4.3.4"
 			}
 		},
 		"aggregate-error": {
@@ -11120,22 +10496,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -11203,12 +10563,6 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 			"dev": true
 		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true
-		},
 		"auto-bind": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
@@ -11274,12 +10628,6 @@
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"dev": true
 		},
-		"binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-			"dev": true
-		},
 		"bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -11311,15 +10659,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.21.10",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001517",
+				"electron-to-chromium": "^1.4.477",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.11"
 			}
 		},
 		"bser": {
@@ -11340,12 +10688,6 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
 			}
-		},
-		"buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.2",
@@ -11443,9 +10785,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+			"version": "1.0.30001521",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+			"integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
 			"dev": true
 		},
 		"capital-case": {
@@ -11534,22 +10876,6 @@
 			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
 			"dev": true
 		},
-		"chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-			"dev": true,
-			"requires": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"fsevents": "~2.3.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
-			}
-		},
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -11625,15 +10951,6 @@
 			"integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
 			"dev": true
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -11664,47 +10981,24 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
 			"dev": true,
 			"requires": {
-				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
 				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
+				"path-type": "^4.0.0"
 			}
-		},
-		"cosmiconfig-toml-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
-			"integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
-			"dev": true,
-			"requires": {
-				"@iarna/toml": "^2.2.5"
-			}
-		},
-		"cosmiconfig-typescript-loader": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
-			"integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
-			"dev": true,
-			"requires": {}
-		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
 		},
 		"cross-fetch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+			"integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
 			"dev": true,
 			"requires": {
-				"node-fetch": "2.6.7"
+				"node-fetch": "^2.6.12"
 			}
 		},
 		"cross-spawn": {
@@ -11719,9 +11013,9 @@
 			}
 		},
 		"dataloader": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-			"integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+			"integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
 			"dev": true
 		},
 		"debounce": {
@@ -11785,12 +11079,6 @@
 				"object-keys": "^1.1.1"
 			}
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true
-		},
 		"dependency-graph": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
@@ -11801,12 +11089,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
 			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-			"dev": true
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -11838,9 +11120,9 @@
 			}
 		},
 		"dotenv": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
 			"dev": true
 		},
 		"dset": {
@@ -11849,19 +11131,10 @@
 			"integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
 			"dev": true
 		},
-		"ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.4.494",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
+			"integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -12320,12 +11593,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true
-		},
 		"external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -12341,6 +11608,12 @@
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
 			"integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+			"dev": true
+		},
+		"fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
 			"dev": true
 		},
 		"fast-deep-equal": {
@@ -12374,6 +11647,32 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"fast-querystring": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+			"dev": true,
+			"requires": {
+				"fast-decode-uri-component": "^1.0.1"
+			}
+		},
+		"fast-url-parser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+			"integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^1.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+					"dev": true
+				}
+			}
+		},
 		"fastq": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -12393,9 +11692,9 @@
 			}
 		},
 		"fbjs": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
-			"integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+			"integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
 			"dev": true,
 			"requires": {
 				"cross-fetch": "^3.1.5",
@@ -12404,7 +11703,7 @@
 				"object-assign": "^4.1.0",
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.30"
+				"ua-parser-js": "^1.0.35"
 			}
 		},
 		"fbjs-css-vars": {
@@ -12491,41 +11790,6 @@
 			"requires": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^3.0.2"
-			}
-		},
-		"form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"form-data-encoder": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-			"dev": true
-		},
-		"formdata-node": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-			"dev": true,
-			"requires": {
-				"node-domexception": "1.0.0",
-				"web-streams-polyfill": "4.0.0-beta.3"
-			},
-			"dependencies": {
-				"web-streams-polyfill": {
-					"version": "4.0.0-beta.3",
-					"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-					"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-					"dev": true
-				}
 			}
 		},
 		"fs.realpath": {
@@ -12703,43 +11967,28 @@
 			"peer": true
 		},
 		"graphql-config": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.3.6.tgz",
-			"integrity": "sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
+			"integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/graphql-file-loader": "^7.3.7",
-				"@graphql-tools/json-file-loader": "^7.3.7",
-				"@graphql-tools/load": "^7.5.5",
-				"@graphql-tools/merge": "^8.2.6",
-				"@graphql-tools/url-loader": "^7.9.7",
-				"@graphql-tools/utils": "^8.6.5",
-				"cosmiconfig": "7.0.1",
-				"cosmiconfig-toml-loader": "1.0.0",
-				"cosmiconfig-typescript-loader": "^4.0.0",
-				"minimatch": "4.2.1",
-				"string-env-interpolation": "1.0.1",
-				"ts-node": "^10.8.1",
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/merge": "^9.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"cosmiconfig": "^8.1.0",
+				"jiti": "^1.18.2",
+				"minimatch": "^4.2.3",
+				"string-env-interpolation": "^1.0.1",
 				"tslib": "^2.4.0"
 			},
 			"dependencies": {
-				"cosmiconfig": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-					"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-					"dev": true,
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.2.1",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.10.0"
-					}
-				},
 				"minimatch": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-					"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
+					"integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -12748,23 +11997,13 @@
 			}
 		},
 		"graphql-request": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
-			"integrity": "sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+			"integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
 			"dev": true,
 			"requires": {
-				"@graphql-typed-document-node/core": "^3.1.1",
-				"cross-fetch": "^3.1.5",
-				"extract-files": "^9.0.0",
-				"form-data": "^3.0.0"
-			},
-			"dependencies": {
-				"extract-files": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
-					"integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
-					"dev": true
-				}
+				"@graphql-typed-document-node/core": "^3.2.0",
+				"cross-fetch": "^3.1.5"
 			}
 		},
 		"graphql-tag": {
@@ -12777,9 +12016,9 @@
 			}
 		},
 		"graphql-ws": {
-			"version": "5.11.2",
-			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
-			"integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+			"integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
 			"dev": true,
 			"requires": {}
 		},
@@ -12851,23 +12090,22 @@
 			"dev": true
 		},
 		"http-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+			"integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
 			"dev": true,
 			"requires": {
-				"@tootallnate/once": "2",
-				"agent-base": "6",
-				"debug": "4"
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+			"integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
 			"dev": true,
 			"requires": {
-				"agent-base": "6",
+				"agent-base": "^7.0.2",
 				"debug": "4"
 			}
 		},
@@ -13027,15 +12265,6 @@
 			"dev": true,
 			"requires": {
 				"has-bigints": "^1.0.1"
-			}
-		},
-		"is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-boolean-object": {
@@ -13254,16 +12483,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
-		"isomorphic-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-			"integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-			"dev": true,
-			"requires": {
-				"node-fetch": "^2.6.1",
-				"whatwg-fetch": "^3.4.1"
-			}
-		},
 		"isomorphic-ws": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
@@ -13297,6 +12516,18 @@
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			}
+		},
+		"jiti": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.1.tgz",
+			"integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
+			"dev": true
+		},
+		"jose": {
+			"version": "4.14.4",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+			"integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+			"dev": true
 		},
 		"js-sdsl": {
 			"version": "4.2.0",
@@ -13379,65 +12610,6 @@
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
 			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
 			"dev": true
-		},
-		"jsonwebtoken": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-			"integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-			"dev": true,
-			"requires": {
-				"jws": "^3.2.2",
-				"lodash": "^4.17.21",
-				"ms": "^2.1.1",
-				"semver": "^7.3.8"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
-			}
-		},
-		"jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"requires": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"requires": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
-			}
 		},
 		"levn": {
 			"version": "0.4.1",
@@ -13598,12 +12770,6 @@
 				"semver": "^6.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -13617,9 +12783,9 @@
 			"dev": true
 		},
 		"meros": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/meros/-/meros-1.2.1.tgz",
-			"integrity": "sha512-R2f/jxYqCAGI19KhAvaxSOxALBMkaXWH2a7rOyqQw+ZmizX5bKkEYWLzdhC+U82ZVVPVp6MCXe3EkVligh+12g==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+			"integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
 			"dev": true,
 			"requires": {}
 		},
@@ -13631,21 +12797,6 @@
 			"requires": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
@@ -13729,16 +12880,10 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true
-		},
 		"node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
@@ -13751,16 +12896,19 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
 		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
 		},
 		"nullthrows": {
 			"version": "1.1.1",
@@ -14097,12 +13245,20 @@
 			"dev": true
 		},
 		"pvtsutils": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-			"integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.4.tgz",
+			"integrity": "sha512-Y2lmrVPui6d2U0n8lWRSTQ2Ri/0VDcA/BHAPS8/+5ElWp5drG4oPryLaqnehJT71Q2GgmGeB4mau+lSR1gCCmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "^2.4.0"
+				"tslib": "^2.6.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"dev": true
+				}
 			}
 		},
 		"pvutils": {
@@ -14128,19 +13284,10 @@
 				"util-deprecate": "^1.0.1"
 			}
 		},
-		"readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
-			"requires": {
-				"picomatch": "^2.2.1"
-			}
-		},
 		"regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
 			"dev": true
 		},
 		"regexp.prototype.flags": {
@@ -14312,9 +13459,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
 		},
 		"sentence-case": {
@@ -14662,27 +13809,6 @@
 			"integrity": "sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==",
 			"dev": true
 		},
-		"ts-node": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-			"dev": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -14707,9 +13833,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
 			"dev": true
 		},
 		"tsutils": {
@@ -14768,9 +13894,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.35",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-			"integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
+			"version": "1.0.35",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+			"integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
 			"dev": true
 		},
 		"ufo": {
@@ -14797,15 +13923,6 @@
 			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
 			"dev": true
 		},
-		"undici": {
-			"version": "5.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
-			"dev": true,
-			"requires": {
-				"busboy": "^1.6.0"
-			}
-		},
 		"unixify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -14813,23 +13930,12 @@
 			"dev": true,
 			"requires": {
 				"normalize-path": "^2.1.1"
-			},
-			"dependencies": {
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				}
 			}
 		},
 		"update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.1.1",
@@ -14863,16 +13969,16 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"urlpattern-polyfill": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+			"integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+			"dev": true
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
 		"v8-to-istanbul": {
@@ -14887,9 +13993,9 @@
 			}
 		},
 		"value-or-promise": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-			"integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
 			"dev": true
 		},
 		"vite": {
@@ -14958,12 +14064,12 @@
 			"dev": true
 		},
 		"webcrypto-core": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-			"integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+			"integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
 			"dev": true,
 			"requires": {
-				"@peculiar/asn1-schema": "^2.1.6",
+				"@peculiar/asn1-schema": "^2.3.6",
 				"@peculiar/json-schema": "^1.1.12",
 				"asn1js": "^3.0.1",
 				"pvtsutils": "^1.3.2",
@@ -14974,12 +14080,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true
-		},
-		"whatwg-fetch": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
 			"dev": true
 		},
 		"whatwg-url": {
@@ -15015,9 +14115,9 @@
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
 			"dev": true
 		},
 		"which-typed-array": {
@@ -15064,9 +14164,9 @@
 			"dev": true
 		},
 		"ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -15083,9 +14183,9 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
 			"dev": true
 		},
 		"yaml-ast-parser": {
@@ -15121,12 +14221,6 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true
 		},
 		"yocto-queue": {

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -51,11 +51,11 @@
 		"test": "__tests__"
 	},
 	"devDependencies": {
-		"@graphql-codegen/cli": "2.16.1",
-		"@graphql-codegen/typed-document-node": "^2.3.11",
-		"@graphql-codegen/typescript": "2.8.5",
-		"@graphql-codegen/typescript-operations": "^2.5.10",
-		"@graphql-typed-document-node/core": "^3.1.1",
+		"@graphql-codegen/cli": "^5.0.0",
+		"@graphql-codegen/typed-document-node": "^5.0.1",
+		"@graphql-codegen/typescript": "^4.0.1",
+		"@graphql-codegen/typescript-operations": "^4.0.1",
+		"@graphql-typed-document-node/core": "^3.2.0",
 		"@nacelle/storefront-sdk": ">=2.0.0-hotfix.1",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/documents.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/documents.ts
@@ -156,6 +156,8 @@ export type ContentCollectionFilterInput = {
 	locale?: InputMaybe<Scalars['String']>;
 	/** Filter content collection entries by Nacelle entry id. */
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	/** Filter content collection entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -192,6 +194,8 @@ export type ContentFilterInput = {
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ContentSearchOptions>;
+	/** Filter content entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
 	type?: InputMaybe<Scalars['String']>;
 };
@@ -239,6 +243,18 @@ export type Metafield = {
 	value: Scalars['String'];
 };
 
+/** Represents a single price */
+export type Money = {
+	__typename?: 'Money';
+	/** [source] An amount for the money */
+	amount: Scalars['Int'];
+	/** [source] A currencyCode identifier for the amount */
+	currencyCode: Scalars['String'];
+	/** [source] (optional) The precision to which the currency amount should be displayed */
+	precisionDigits?: Maybe<Scalars['Int']>;
+};
+
+/** The mutation root. */
 export type Mutation = {
 	__typename?: 'Mutation';
 	root?: Maybe<Scalars['String']>;
@@ -369,6 +385,23 @@ export type PriceRule = {
 	title: Scalars['String'];
 };
 
+/** Fields available for standalone pricing */
+export type Pricing = {
+	__typename?: 'Pricing';
+	/** [source] List of metafields associated with the pricing */
+	metafields?: Maybe<Scalars['JSON']>;
+	/** [source] The default price */
+	price?: Maybe<Money>;
+	/** [source] The shipping price */
+	shipping?: Maybe<Money>;
+	/** [source] The discounted price */
+	strikeThroughPrice?: Maybe<Money>;
+	/** [source] The tax amount */
+	taxValue?: Maybe<Money>;
+	/** [sys] Reference to parent variant by Nacelle ID */
+	variantEntryId: Scalars['ID'];
+};
+
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
 export type Product = Node & {
 	__typename?: 'Product';
@@ -398,6 +431,11 @@ export type Product = Node & {
 	variants: Array<Variant>;
 	/** [source] Vendor name for product. */
 	vendor?: Maybe<Scalars['String']>;
+};
+
+/** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
+export type ProductVariantsArgs = {
+	filter?: InputMaybe<ProductFilterInput>;
 };
 
 /** Represents a collection of products. */
@@ -474,12 +512,14 @@ export type ProductCollectionFilterInput = {
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductCollectionSearchOptions>;
+	/** Filter product collection entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
 	type?: InputMaybe<Scalars['String']>;
 };
 
 /** Searchable fields for product collection */
-export type ProductCollectionSearchFields = 'HANDLE' | 'TITLE';
+export type ProductCollectionSearchFields = 'HANDLE' | 'TAGS' | 'TITLE';
 
 /** Search options for Product Collection */
 export type ProductCollectionSearchOptions = {
@@ -567,8 +607,12 @@ export type ProductFilterInput = {
 	locale?: InputMaybe<Scalars['String']>;
 	/** Filter product entries by Nacelle entry id. */
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	/** Filter product variant standalone pricing by country code */
+	pricingCountryCode?: InputMaybe<Scalars['String']>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductSearchOptions>;
+	/** Filter product entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 };
 
 /** List of Product ids grouped for a specific purpose. */
@@ -603,9 +647,13 @@ export type ProductSearchOptions = {
 
 export type Query = {
 	__typename?: 'Query';
+	_service: _Service;
 	/** Query a list of content entries with Relay-style pagination */
 	allContent: ContentConnection;
-	/** Query a list of content collection entries with Relay-style pagination */
+	/**
+	 * Query a list of content collection entries with Relay-style pagination
+	 * @deprecated `allContent` should be used for paginated content queries.
+	 */
 	allContentCollections: ContentCollectionConnection;
 	/** Query a list of ProductCollection entries with Relay-style pagination */
 	allProductCollections: ProductCollectionConnection;
@@ -618,7 +666,7 @@ export type Query = {
 	content: Array<Content>;
 	/**
 	 * Query a collection of contents
-	 * @deprecated `allContentCollections` should be used for paginated content collection queries.
+	 * @deprecated `allContent` should be used for paginated content queries.
 	 */
 	contentCollections: Array<ContentCollection>;
 	/** Get navigation groups for a space */
@@ -744,6 +792,8 @@ export type Variant = Node & {
 	priceCurrency?: Maybe<Scalars['String']>;
 	/** [source] List of pricing rules associated with the variant */
 	priceRules: Array<PriceRule>;
+	/** [source] standalone pricing */
+	pricing?: Maybe<Array<Maybe<Pricing>>>;
 	/** [sys] Reference to parent product by Nacelle ID. */
 	productEntryId?: Maybe<Scalars['ID']>;
 	/** [sys] Reference to parent product by handle. */
@@ -809,8 +859,14 @@ export type VariantContent = Node & {
 	variantEntryId?: Maybe<Scalars['ID']>;
 };
 
+export type _Service = {
+	__typename?: '_Service';
+	/** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied */
+	sdl?: Maybe<Scalars['String']>;
+};
+
 export type CollectionContent_CollectionContentFragment = {
-	__typename?: 'CollectionContent';
+	__typename: 'CollectionContent';
 	collectionEntryId: string;
 	createdAt?: number | null;
 	description?: string | null;
@@ -844,7 +900,7 @@ export type CollectionContent_CollectionContentFragment = {
 };
 
 export type Content_ContentFragment = {
-	__typename?: 'Content';
+	__typename: 'Content';
 	createdAt?: number | null;
 	fields?: any | null;
 	handle?: string | null;
@@ -895,7 +951,7 @@ export type NavigationItem_NavigationItemFragment = {
 };
 
 export type Product_ProductFragment = {
-	__typename?: 'Product';
+	__typename: 'Product';
 	availableForSale?: boolean | null;
 	createdAt?: number | null;
 	indexedAt?: number | null;
@@ -914,7 +970,7 @@ export type Product_ProductFragment = {
 		value: string;
 	}>;
 	variants: Array<{
-		__typename?: 'Variant';
+		__typename: 'Variant';
 		availableForSale?: boolean | null;
 		compareAtPrice?: any | null;
 		createdAt?: number | null;
@@ -932,7 +988,7 @@ export type Product_ProductFragment = {
 		weight?: number | null;
 		weightUnit?: string | null;
 		content?: {
-			__typename?: 'VariantContent';
+			__typename: 'VariantContent';
 			createdAt?: number | null;
 			description?: string | null;
 			fields?: any | null;
@@ -1018,7 +1074,7 @@ export type Product_ProductFragment = {
 		}>;
 	}>;
 	content?: {
-		__typename?: 'ProductContent';
+		__typename: 'ProductContent';
 		createdAt?: number | null;
 		description?: string | null;
 		fields?: any | null;
@@ -1067,7 +1123,7 @@ export type Product_ProductFragment = {
 };
 
 export type ProductContent_ProductContentFragment = {
-	__typename?: 'ProductContent';
+	__typename: 'ProductContent';
 	createdAt?: number | null;
 	description?: string | null;
 	fields?: any | null;
@@ -1171,7 +1227,7 @@ export type Seo_SeoFragment = {
 };
 
 export type Variant_VariantFragment = {
-	__typename?: 'Variant';
+	__typename: 'Variant';
 	availableForSale?: boolean | null;
 	compareAtPrice?: any | null;
 	createdAt?: number | null;
@@ -1189,7 +1245,7 @@ export type Variant_VariantFragment = {
 	weight?: number | null;
 	weightUnit?: string | null;
 	content?: {
-		__typename?: 'VariantContent';
+		__typename: 'VariantContent';
 		createdAt?: number | null;
 		description?: string | null;
 		fields?: any | null;
@@ -1276,7 +1332,7 @@ export type Variant_VariantFragment = {
 };
 
 export type VariantContent_VariantContentFragment = {
-	__typename?: 'VariantContent';
+	__typename: 'VariantContent';
 	createdAt?: number | null;
 	description?: string | null;
 	fields?: any | null;
@@ -1342,7 +1398,7 @@ export type AllContentQuery = {
 			__typename?: 'ContentEdge';
 			cursor: string;
 			node: {
-				__typename?: 'Content';
+				__typename: 'Content';
 				createdAt?: number | null;
 				fields?: any | null;
 				handle?: string | null;
@@ -1475,7 +1531,7 @@ export type ProductCollectionEntriesQuery = {
 					edges: Array<{
 						__typename?: 'ProductEdge';
 						node: {
-							__typename?: 'Product';
+							__typename: 'Product';
 							availableForSale?: boolean | null;
 							createdAt?: number | null;
 							indexedAt?: number | null;
@@ -1494,7 +1550,7 @@ export type ProductCollectionEntriesQuery = {
 								value: string;
 							}>;
 							variants: Array<{
-								__typename?: 'Variant';
+								__typename: 'Variant';
 								availableForSale?: boolean | null;
 								compareAtPrice?: any | null;
 								createdAt?: number | null;
@@ -1512,7 +1568,7 @@ export type ProductCollectionEntriesQuery = {
 								weight?: number | null;
 								weightUnit?: string | null;
 								content?: {
-									__typename?: 'VariantContent';
+									__typename: 'VariantContent';
 									createdAt?: number | null;
 									description?: string | null;
 									fields?: any | null;
@@ -1598,7 +1654,7 @@ export type ProductCollectionEntriesQuery = {
 								}>;
 							}>;
 							content?: {
-								__typename?: 'ProductContent';
+								__typename: 'ProductContent';
 								createdAt?: number | null;
 								description?: string | null;
 								fields?: any | null;
@@ -1683,7 +1739,7 @@ export type AllProductCollectionsQuery = {
 				tags: Array<string>;
 				updatedAt?: number | null;
 				content?: {
-					__typename?: 'CollectionContent';
+					__typename: 'CollectionContent';
 					collectionEntryId: string;
 					createdAt?: number | null;
 					description?: string | null;
@@ -1737,7 +1793,7 @@ export type AllProductCollectionsQuery = {
 					edges: Array<{
 						__typename?: 'ProductEdge';
 						node: {
-							__typename?: 'Product';
+							__typename: 'Product';
 							availableForSale?: boolean | null;
 							createdAt?: number | null;
 							indexedAt?: number | null;
@@ -1756,7 +1812,7 @@ export type AllProductCollectionsQuery = {
 								value: string;
 							}>;
 							variants: Array<{
-								__typename?: 'Variant';
+								__typename: 'Variant';
 								availableForSale?: boolean | null;
 								compareAtPrice?: any | null;
 								createdAt?: number | null;
@@ -1774,7 +1830,7 @@ export type AllProductCollectionsQuery = {
 								weight?: number | null;
 								weightUnit?: string | null;
 								content?: {
-									__typename?: 'VariantContent';
+									__typename: 'VariantContent';
 									createdAt?: number | null;
 									description?: string | null;
 									fields?: any | null;
@@ -1860,7 +1916,7 @@ export type AllProductCollectionsQuery = {
 								}>;
 							}>;
 							content?: {
-								__typename?: 'ProductContent';
+								__typename: 'ProductContent';
 								createdAt?: number | null;
 								description?: string | null;
 								fields?: any | null;
@@ -1935,7 +1991,7 @@ export type AllProductsQuery = {
 			__typename?: 'ProductEdge';
 			cursor: string;
 			node: {
-				__typename?: 'Product';
+				__typename: 'Product';
 				availableForSale?: boolean | null;
 				createdAt?: number | null;
 				indexedAt?: number | null;
@@ -1954,7 +2010,7 @@ export type AllProductsQuery = {
 					value: string;
 				}>;
 				variants: Array<{
-					__typename?: 'Variant';
+					__typename: 'Variant';
 					availableForSale?: boolean | null;
 					compareAtPrice?: any | null;
 					createdAt?: number | null;
@@ -1972,7 +2028,7 @@ export type AllProductsQuery = {
 					weight?: number | null;
 					weightUnit?: string | null;
 					content?: {
-						__typename?: 'VariantContent';
+						__typename: 'VariantContent';
 						createdAt?: number | null;
 						description?: string | null;
 						fields?: any | null;
@@ -2058,7 +2114,7 @@ export type AllProductsQuery = {
 					}>;
 				}>;
 				content?: {
-					__typename?: 'ProductContent';
+					__typename: 'ProductContent';
 					createdAt?: number | null;
 					description?: string | null;
 					fields?: any | null;
@@ -2212,6 +2268,7 @@ export const CollectionContent_CollectionContentFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'collectionEntryId' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
@@ -2285,6 +2342,7 @@ export const Content_ContentFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
@@ -2358,6 +2416,7 @@ export const VariantContent_VariantContentFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
 					{
@@ -2535,6 +2594,7 @@ export const Variant_VariantFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
 					{
@@ -2631,6 +2691,7 @@ export const ProductContent_ProductContentFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
 					{
@@ -2727,6 +2788,7 @@ export const Product_ProductFragmentDoc = {
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/documents.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/documents.ts
@@ -10,82 +10,91 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
 	[SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+	T extends { [key: string]: unknown },
+	K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+	| T
+	| {
+			[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+	  };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-	ID: string;
-	String: string;
-	Boolean: boolean;
-	Int: number;
-	Float: number;
-	Decimal: any;
-	JSON: any;
+	ID: { input: string; output: string };
+	String: { input: string; output: string };
+	Boolean: { input: boolean; output: boolean };
+	Int: { input: number; output: number };
+	Float: { input: number; output: number };
+	Decimal: { input: any; output: any };
+	JSON: { input: any; output: any };
 };
 
 export type CollectionContent = Node & {
 	__typename?: 'CollectionContent';
 	/** [sys] Reference to collection by Nacelle ID. */
-	collectionEntryId: Scalars['ID'];
+	collectionEntryId: Scalars['ID']['output'];
 	/** [source] The Unix timestamp in seconds when the collection content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a collection. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a collection. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Reference to collection by handle. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of product collection to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of metafields associated with the product collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] Specifies if the collection content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] SEO fields for a collection */
 	seo?: Maybe<Seo>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The title for a collection. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the collection content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents master pieces of content like a page, article, employee, press-release, etc. */
 export type Content = Node & {
 	__typename?: 'Content';
 	/** [source] The Unix timestamp in seconds when the content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] Stringified JSON representing custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [source] A human-friendly unique string for the content. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of the content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] Specifies if the content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the content. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The title for the content. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The categorization for the content, often used for search and filter. */
-	type?: Maybe<Scalars['String']>;
+	type?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
@@ -96,38 +105,38 @@ export type ContentCollection = Node & {
 	/** [source] List of content entries with Relay-style pagination */
 	contentConnection: ContentConnection;
 	/** [source] The Unix timestamp in seconds when the content collection was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/**
 	 * [source] List of content entries for a given content collection.
 	 * @deprecated `contentConnection` should be used for paginated content queries.
 	 */
 	entries: Array<Content>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the content collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the collection. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the content collection was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
 export type ContentCollectionContentConnectionArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
 export type ContentCollectionEntriesArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Result of a ContentCollection Query with pagination info */
@@ -140,24 +149,24 @@ export type ContentCollectionConnection = NodeConnection & {
 /** Implementation of an Edge type for ContentCollection entries */
 export type ContentCollectionEdge = NodeEdge & {
 	__typename?: 'ContentCollectionEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: ContentCollection;
 };
 
 /** Filter results for product collection */
 export type ContentCollectionFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n collections of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter content collection entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter content collection entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content collection entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -165,47 +174,47 @@ export type ContentConnection = NodeConnection & {
 	__typename?: 'ContentConnection';
 	edges: Array<ContentEdge>;
 	/** [source] Returns filtered number of entries for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of entries in a collection for collection queries, null for content queries */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Content entries */
 export type ContentEdge = NodeEdge & {
 	__typename?: 'ContentEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Content;
 };
 
 /** Filter results for content */
 export type ContentFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Determines how many levels of nested content entries should be returned */
-	entryDepth?: InputMaybe<Scalars['Int']>;
+	entryDepth?: InputMaybe<Scalars['Int']['input']>;
 	/** Returns the first n content entries of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter content entries by entry handle. Requires type filter or defaults to type of 'page'. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter content entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ContentSearchOptions>;
 	/** Filter content entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
-	type?: InputMaybe<Scalars['String']>;
+	type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** List of Content ids grouped for a specific purpose. */
 export type ContentList = {
 	__typename?: 'ContentList';
-	ids: Array<Scalars['ID']>;
-	listHandle?: Maybe<Scalars['String']>;
-	title?: Maybe<Scalars['String']>;
+	ids: Array<Scalars['ID']['output']>;
+	listHandle?: Maybe<Scalars['String']['output']>;
+	title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Searchable fields for content */
@@ -220,68 +229,68 @@ export type ContentSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** A piece of media that can represent an Image, 3dModel, or Video. */
 export type Media = {
 	__typename?: 'Media';
-	altText?: Maybe<Scalars['String']>;
-	id?: Maybe<Scalars['ID']>;
-	mimeType?: Maybe<Scalars['String']>;
-	src: Scalars['String'];
-	thumbnailSrc?: Maybe<Scalars['String']>;
-	type: Scalars['String'];
+	altText?: Maybe<Scalars['String']['output']>;
+	id?: Maybe<Scalars['ID']['output']>;
+	mimeType?: Maybe<Scalars['String']['output']>;
+	src: Scalars['String']['output'];
+	thumbnailSrc?: Maybe<Scalars['String']['output']>;
+	type: Scalars['String']['output'];
 };
 
 /** Metafields represent custom metadata attached to a resource. Metafields can be sorted into namespaces and are comprised of keys, values */
 export type Metafield = {
 	__typename?: 'Metafield';
-	id?: Maybe<Scalars['ID']>;
-	key: Scalars['String'];
-	namespace?: Maybe<Scalars['String']>;
-	value: Scalars['String'];
+	id?: Maybe<Scalars['ID']['output']>;
+	key: Scalars['String']['output'];
+	namespace?: Maybe<Scalars['String']['output']>;
+	value: Scalars['String']['output'];
 };
 
 /** Represents a single price */
 export type Money = {
 	__typename?: 'Money';
 	/** [source] An amount for the money */
-	amount: Scalars['Int'];
+	amount: Scalars['Int']['output'];
 	/** [source] A currencyCode identifier for the amount */
-	currencyCode: Scalars['String'];
+	currencyCode: Scalars['String']['output'];
 	/** [source] (optional) The precision to which the currency amount should be displayed */
-	precisionDigits?: Maybe<Scalars['Int']>;
+	precisionDigits?: Maybe<Scalars['Int']['output']>;
 };
 
 /** The mutation root. */
 export type Mutation = {
 	__typename?: 'Mutation';
-	root?: Maybe<Scalars['String']>;
+	root?: Maybe<Scalars['String']['output']>;
 };
 
 /** The filter to apply, when selecting navigation items. */
 export type NavigationFilterInput = {
 	/** The navigation group to filter by */
-	groupId?: InputMaybe<Scalars['String']>;
+	groupId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type NavigationGroup = {
 	__typename?: 'NavigationGroup';
 	/** Created-at timestamp */
-	createdAt?: Maybe<Scalars['String']>;
+	createdAt?: Maybe<Scalars['String']['output']>;
 	/** The unique identifier of the navigation group */
-	groupId: Scalars['String'];
+	groupId: Scalars['String']['output'];
 	/** Items within a navigation group */
 	items?: Maybe<Array<NavigationGroupItem>>;
 	/** Navigation properties */
 	properties?: Maybe<Array<NavigationPropertyItem>>;
 	/** Displayable title of a navigation group */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** Updated-at timestamp */
-	updatedAt?: Maybe<Scalars['String']>;
+	updatedAt?: Maybe<Scalars['String']['output']>;
 	/** Updated-by user ID */
-	updatedBy?: Maybe<Scalars['String']>;
+	updatedBy?: Maybe<Scalars['String']['output']>;
 };
 
 export type NavigationGroupItem = {
@@ -293,23 +302,23 @@ export type NavigationGroupItem = {
 	/** Navigation properties */
 	properties?: Maybe<Array<NavigationPropertyItem>>;
 	/** Displayable title of a navigation item */
-	title: Scalars['String'];
+	title: Scalars['String']['output'];
 	/** Item type */
 	type?: Maybe<NavigationPropertyType>;
 	/** Route to a navigation item */
-	url: Scalars['String'];
+	url: Scalars['String']['output'];
 };
 
 export type NavigationMediaItem = {
 	__typename?: 'NavigationMediaItem';
 	/** URL that links to the media item */
-	url?: Maybe<Scalars['String']>;
+	url?: Maybe<Scalars['String']['output']>;
 };
 
 export type NavigationPropertyItem = {
 	__typename?: 'NavigationPropertyItem';
-	key: Scalars['String'];
-	value: Scalars['String'];
+	key: Scalars['String']['output'];
+	value: Scalars['String']['output'];
 };
 
 export type NavigationPropertyType =
@@ -323,7 +332,7 @@ export type NavigationPropertyType =
 /** An entry with a Globally Unique ID */
 export type Node = {
 	/** The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 };
 
 /** An object containing an array of Node data and pagination information */
@@ -334,17 +343,17 @@ export type NodeConnection = {
 
 /** An object containing a node with Nacelle data and a cursor for pagination and filtering */
 export type NodeEdge = {
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Node;
 };
 
 /** Pagination object indicating if there are more pages of data and where the next page starts. */
 export type PageInfo = {
 	__typename?: 'PageInfo';
-	endCursor: Scalars['String'];
-	hasNextPage: Scalars['Boolean'];
-	hasPreviousPage: Scalars['Boolean'];
-	startCursor: Scalars['String'];
+	endCursor: Scalars['String']['output'];
+	hasNextPage: Scalars['Boolean']['output'];
+	hasPreviousPage: Scalars['Boolean']['output'];
+	startCursor: Scalars['String']['output'];
 };
 
 /** A price break definition. */
@@ -353,43 +362,43 @@ export type PriceBreak = {
 	/** [source] List of metafields associated with the price break. */
 	metafields: Array<Metafield>;
 	/** [source] The price associated with this price break. */
-	price?: Maybe<Scalars['Decimal']>;
+	price?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Maximum quantity of variant needed to apply price break. */
-	quantityMax?: Maybe<Scalars['Int']>;
+	quantityMax?: Maybe<Scalars['Int']['output']>;
 	/** [source] Minimum quantity of variant needed to apply price break. */
-	quantityMin?: Maybe<Scalars['Int']>;
+	quantityMin?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A price rule definition. */
 export type PriceRule = {
 	__typename?: 'PriceRule';
 	/** [source] Array of customer segment ids. Unused. */
-	availableTo: Array<Scalars['String']>;
+	availableTo: Array<Scalars['String']['output']>;
 	/** [source] The compare at price of the price rule. This can be used to mark a variant as on sale. */
-	comparedAtPrice?: Maybe<Scalars['Decimal']>;
+	comparedAtPrice?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Country code associated with this price rule. Distinct from currency code. */
-	country?: Maybe<Scalars['String']>;
+	country?: Maybe<Scalars['String']['output']>;
 	/** [source] Identifying handle of price rule if applicable. */
-	handle: Scalars['String'];
+	handle: Scalars['String']['output'];
 	/** [source] The id of the source price rule if applicable. */
-	id?: Maybe<Scalars['ID']>;
+	id?: Maybe<Scalars['ID']['output']>;
 	/** [source] List of metafields associated with the price rule. */
 	metafields: Array<Metafield>;
 	/** [source] The price associated with this price rule. */
-	price: Scalars['Decimal'];
+	price: Scalars['Decimal']['output'];
 	/** [source] Used for changing a variant's price based on quantity selected. */
 	priceBreaks: Array<PriceBreak>;
 	/** [source] The currency code for this price rule. */
-	priceCurrency: Scalars['String'];
+	priceCurrency: Scalars['String']['output'];
 	/** [source] The title of the price rule. */
-	title: Scalars['String'];
+	title: Scalars['String']['output'];
 };
 
 /** Fields available for standalone pricing */
 export type Pricing = {
 	__typename?: 'Pricing';
 	/** [source] List of metafields associated with the pricing */
-	metafields?: Maybe<Scalars['JSON']>;
+	metafields?: Maybe<Scalars['JSON']['output']>;
 	/** [source] The default price */
 	price?: Maybe<Money>;
 	/** [source] The shipping price */
@@ -399,38 +408,38 @@ export type Pricing = {
 	/** [source] The tax amount */
 	taxValue?: Maybe<Money>;
 	/** [sys] Reference to parent variant by Nacelle ID */
-	variantEntryId: Scalars['ID'];
+	variantEntryId: Scalars['ID']['output'];
 };
 
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
 export type Product = Node & {
 	__typename?: 'Product';
 	/** [source] Specifies if at least one product variant is available for sale. */
-	availableForSale?: Maybe<Scalars['Boolean']>;
+	availableForSale?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] Localized content for the product. */
 	content?: Maybe<ProductContent>;
 	/** [source] The Unix timestamp in seconds when the product was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the product. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The categorization for a product, often used for search and filter. */
-	productType?: Maybe<Scalars['String']>;
+	productType?: Maybe<Scalars['String']['output']>;
 	/** [source] The ID for the product from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the product. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of variants for the product. */
 	variants: Array<Variant>;
 	/** [source] Vendor name for product. */
-	vendor?: Maybe<Scalars['String']>;
+	vendor?: Maybe<Scalars['String']['output']>;
 };
 
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
@@ -444,13 +453,13 @@ export type ProductCollection = Node & {
 	/** [source] Localized content associated with the product collection. */
 	content?: Maybe<CollectionContent>;
 	/** [source] The Unix timestamp in seconds when the product collection was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the product collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] List of products entries with Relay-style pagination */
 	productConnection: ProductConnection;
 	/**
@@ -459,25 +468,25 @@ export type ProductCollection = Node & {
 	 */
 	products: Array<Product>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the collection. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product collection was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of products. */
 export type ProductCollectionProductConnectionArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Represents a collection of products. */
 export type ProductCollectionProductsArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -485,37 +494,37 @@ export type ProductCollectionConnection = NodeConnection & {
 	__typename?: 'ProductCollectionConnection';
 	edges: Array<ProductCollectionEdge>;
 	/** [source] Returns filtered number of collections for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of collections for backend search, defaults to null */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Content entries */
 export type ProductCollectionEdge = NodeEdge & {
 	__typename?: 'ProductCollectionEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: ProductCollection;
 };
 
 /** Filter results for product collection */
 export type ProductCollectionFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n collections of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter product collection entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter product collection entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductCollectionSearchOptions>;
 	/** Filter product collection entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
-	type?: InputMaybe<Scalars['String']>;
+	type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Searchable fields for product collection */
@@ -530,7 +539,7 @@ export type ProductCollectionSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Order by which to sort */
@@ -541,93 +550,93 @@ export type ProductConnection = NodeConnection & {
 	__typename?: 'ProductConnection';
 	edges: Array<ProductEdge>;
 	/** [source] Returns filtered number of products for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of products in a collection for collection queries, null for product queries */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A piece of product content represents the localized version of data points, with more flexibility. */
 export type ProductContent = Node & {
 	__typename?: 'ProductContent';
 	/** [source] The Unix timestamp in seconds when the product content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a product. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a product. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Reference to product by handle. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of product content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of media for a product */
 	media: Array<Media>;
 	/** [source] List of metafields associated with the product content. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] List of product options. */
 	options: Array<ProductOption>;
 	/** [sys] Reference to product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [source] Specifies if the product content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] SEO fields for a product */
 	seo?: Maybe<Seo>;
 	/** [source] The ID for the product content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The title for a product. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Product entries */
 export type ProductEdge = NodeEdge & {
 	__typename?: 'ProductEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Product;
 };
 
 /** Filter results for product */
 export type ProductFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n products of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter product entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter product entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter product variant standalone pricing by country code */
-	pricingCountryCode?: InputMaybe<Scalars['String']>;
+	pricingCountryCode?: InputMaybe<Scalars['String']['input']>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductSearchOptions>;
 	/** Filter product entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** List of Product ids grouped for a specific purpose. */
 export type ProductList = {
 	__typename?: 'ProductList';
-	ids: Array<Scalars['ID']>;
-	listHandle?: Maybe<Scalars['String']>;
-	title?: Maybe<Scalars['String']>;
+	ids: Array<Scalars['ID']['output']>;
+	listHandle?: Maybe<Scalars['String']['output']>;
+	title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Product property names like Size, Color, and Material that the customers can select. Variants are selected based on permutations of these options. */
 export type ProductOption = {
 	__typename?: 'ProductOption';
-	name: Scalars['String'];
-	values: Array<Scalars['String']>;
+	name: Scalars['String']['output'];
+	values: Array<Scalars['String']['output']>;
 };
 
 /** Searchable fields for product */
@@ -642,7 +651,7 @@ export type ProductSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Query = {
@@ -681,7 +690,7 @@ export type Query = {
 	 * @deprecated `allProducts` should be used for paginated product queries.
 	 */
 	products: Array<Product>;
-	root?: Maybe<Scalars['String']>;
+	root?: Maybe<Scalars['String']['output']>;
 	/** Space properties data for a space */
 	spaceProperties: SpaceProperties;
 };
@@ -725,22 +734,22 @@ export type QueryProductsArgs = {
 /** A simple response indicating that an indexing event was received. Processing will occur in the background. */
 export type QueryResponse = {
 	__typename?: 'QueryResponse';
-	message: Scalars['String'];
+	message: Scalars['String']['output'];
 };
 
 /** A field used to provide SEO data for web crawlers */
 export type Seo = {
 	__typename?: 'SEO';
-	description: Scalars['String'];
-	title: Scalars['String'];
+	description: Scalars['String']['output'];
+	title: Scalars['String']['output'];
 };
 
 /** Properties used by customers to select a product variant. Products can have multiple options, like different sizes or colors. */
 export type SelectedOption = {
 	__typename?: 'SelectedOption';
-	label?: Maybe<Scalars['String']>;
-	name: Scalars['String'];
-	value: Scalars['String'];
+	label?: Maybe<Scalars['String']['output']>;
+	name: Scalars['String']['output'];
+	value: Scalars['String']['output'];
 };
 
 export type SpaceProperties = {
@@ -748,17 +757,17 @@ export type SpaceProperties = {
 	/** List of space properties grouped by namespace */
 	properties?: Maybe<Array<Maybe<SpacePropertyNamespace>>>;
 	/** Updated-at timestamp */
-	updatedAt?: Maybe<Scalars['String']>;
+	updatedAt?: Maybe<Scalars['String']['output']>;
 	/** Updated-by user ID */
-	updatedBy?: Maybe<Scalars['String']>;
+	updatedBy?: Maybe<Scalars['String']['output']>;
 };
 
 export type SpacePropertyItem = {
 	__typename?: 'SpacePropertyItem';
 	/** Property name */
-	key: Scalars['String'];
+	key: Scalars['String']['output'];
 	/** Property value */
-	value: Scalars['String'];
+	value: Scalars['String']['output'];
 };
 
 export type SpacePropertyNamespace = {
@@ -766,103 +775,342 @@ export type SpacePropertyNamespace = {
 	/** List of space properties items */
 	items?: Maybe<Array<Maybe<SpacePropertyItem>>>;
 	/** Namespace name */
-	namespace?: Maybe<Scalars['String']>;
+	namespace?: Maybe<Scalars['String']['output']>;
 };
 
 /** A product variant represents a different version of a product, such as differing sizes or differing colors. */
 export type Variant = Node & {
 	__typename?: 'Variant';
 	/** [source] Specifies if the variant is available for sale. */
-	availableForSale?: Maybe<Scalars['Boolean']>;
+	availableForSale?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] The compare at price of the variant. This can be used to mark a variant as on sale. */
-	compareAtPrice?: Maybe<Scalars['Decimal']>;
+	compareAtPrice?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Localized content for the variant. */
 	content?: Maybe<VariantContent>;
 	/** [source] The Unix timestamp in seconds when the variant was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the variant. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The price of the variant. */
-	price?: Maybe<Scalars['Decimal']>;
+	price?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] The currency of the variant price. */
-	priceCurrency?: Maybe<Scalars['String']>;
+	priceCurrency?: Maybe<Scalars['String']['output']>;
 	/** [source] List of pricing rules associated with the variant */
 	priceRules: Array<PriceRule>;
 	/** [source] standalone pricing */
 	pricing?: Maybe<Array<Maybe<Pricing>>>;
 	/** [sys] Reference to parent product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [sys] Reference to parent product by handle. */
-	productHandle?: Maybe<Scalars['String']>;
+	productHandle?: Maybe<Scalars['String']['output']>;
 	/** [source] The total sellable quantity of the variant for online sales channels. */
-	quantityAvailable?: Maybe<Scalars['Int']>;
+	quantityAvailable?: Maybe<Scalars['Int']['output']>;
 	/** [source] The SKU (stock keeping unit) associated with the variant. */
-	sku?: Maybe<Scalars['String']>;
+	sku?: Maybe<Scalars['String']['output']>;
 	/** [source] The ID for the product variant from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The Unix timestamp in seconds when the variant was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The variant sort position. */
-	variantPosition?: Maybe<Scalars['Int']>;
+	variantPosition?: Maybe<Scalars['Int']['output']>;
 	/** [source] The weight of the variant in the unit specified with weightUnit. */
-	weight?: Maybe<Scalars['Float']>;
+	weight?: Maybe<Scalars['Float']['output']>;
 	/** [source] The unit of measurement for weight. */
-	weightUnit?: Maybe<Scalars['String']>;
+	weightUnit?: Maybe<Scalars['String']['output']>;
 };
 
 /** A piece of variant content represents the localized version of data points, with more flexibility. */
 export type VariantContent = Node & {
 	__typename?: 'VariantContent';
 	/** [source] The Unix timestamp in seconds when the variant content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a variant. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a variant. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of variant content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of media for a variant */
 	media: Array<Media>;
 	/** [source] List of metafields associated with the variant content. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [sys] Reference to parent product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [sys] Reference to parent product by handle. */
-	productHandle?: Maybe<Scalars['String']>;
+	productHandle?: Maybe<Scalars['String']['output']>;
 	/** [source] Specifies if the variant content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] List of product options applied to the variant. */
 	selectedOptions: Array<SelectedOption>;
 	/** [source] The ID for the variant content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] Source url of variant swatch. */
-	swatchSrc?: Maybe<Scalars['String']>;
+	swatchSrc?: Maybe<Scalars['String']['output']>;
 	/** [source] The title for a variant. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the variant content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Reference to parent variant by Nacelle ID. */
-	variantEntryId?: Maybe<Scalars['ID']>;
+	variantEntryId?: Maybe<Scalars['ID']['output']>;
 };
 
 export type _Service = {
 	__typename?: '_Service';
 	/** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied */
-	sdl?: Maybe<Scalars['String']>;
+	sdl?: Maybe<Scalars['String']['output']>;
+};
+
+export type ProductCollection_CollectionFragment = {
+	__typename: 'ProductCollection';
+	createdAt?: number | null;
+	indexedAt?: number | null;
+	nacelleEntryId: string;
+	sourceEntryId: string;
+	sourceId: string;
+	tags: Array<string>;
+	updatedAt?: number | null;
+	content?: {
+		__typename: 'CollectionContent';
+		collectionEntryId: string;
+		createdAt?: number | null;
+		description?: string | null;
+		fields?: any | null;
+		handle?: string | null;
+		indexedAt?: number | null;
+		locale?: string | null;
+		nacelleEntryId: string;
+		published?: boolean | null;
+		sourceEntryId: string;
+		sourceId: string;
+		title?: string | null;
+		updatedAt?: number | null;
+		featuredMedia?: {
+			__typename?: 'Media';
+			altText?: string | null;
+			id?: string | null;
+			mimeType?: string | null;
+			src: string;
+			thumbnailSrc?: string | null;
+			type: string;
+		} | null;
+		metafields: Array<{
+			__typename?: 'Metafield';
+			id?: string | null;
+			key: string;
+			namespace?: string | null;
+			value: string;
+		}>;
+		seo?: { __typename?: 'SEO'; title: string; description: string } | null;
+	} | null;
+	metafields: Array<{
+		__typename?: 'Metafield';
+		id?: string | null;
+		key: string;
+		namespace?: string | null;
+		value: string;
+	}>;
+	productConnection: {
+		__typename?: 'ProductConnection';
+		totalCount?: number | null;
+		pageInfo: {
+			__typename?: 'PageInfo';
+			hasNextPage: boolean;
+			endCursor: string;
+		};
+		edges: Array<{
+			__typename?: 'ProductEdge';
+			cursor: string;
+			node: {
+				__typename: 'Product';
+				availableForSale?: boolean | null;
+				createdAt?: number | null;
+				indexedAt?: number | null;
+				nacelleEntryId: string;
+				productType?: string | null;
+				sourceEntryId: string;
+				sourceId: string;
+				tags: Array<string>;
+				updatedAt?: number | null;
+				vendor?: string | null;
+				metafields: Array<{
+					__typename?: 'Metafield';
+					id?: string | null;
+					key: string;
+					namespace?: string | null;
+					value: string;
+				}>;
+				variants: Array<{
+					__typename: 'Variant';
+					availableForSale?: boolean | null;
+					compareAtPrice?: any | null;
+					createdAt?: number | null;
+					indexedAt?: number | null;
+					nacelleEntryId: string;
+					price?: any | null;
+					priceCurrency?: string | null;
+					productEntryId?: string | null;
+					productHandle?: string | null;
+					quantityAvailable?: number | null;
+					sku?: string | null;
+					sourceEntryId: string;
+					sourceId: string;
+					updatedAt?: number | null;
+					weight?: number | null;
+					weightUnit?: string | null;
+					content?: {
+						__typename: 'VariantContent';
+						createdAt?: number | null;
+						description?: string | null;
+						fields?: any | null;
+						indexedAt?: number | null;
+						locale?: string | null;
+						nacelleEntryId: string;
+						productEntryId?: string | null;
+						productHandle?: string | null;
+						published?: boolean | null;
+						sourceEntryId: string;
+						sourceId: string;
+						swatchSrc?: string | null;
+						title?: string | null;
+						updatedAt?: number | null;
+						variantEntryId?: string | null;
+						featuredMedia?: {
+							__typename?: 'Media';
+							altText?: string | null;
+							id?: string | null;
+							mimeType?: string | null;
+							src: string;
+							thumbnailSrc?: string | null;
+							type: string;
+						} | null;
+						media: Array<{
+							__typename?: 'Media';
+							altText?: string | null;
+							id?: string | null;
+							mimeType?: string | null;
+							src: string;
+							thumbnailSrc?: string | null;
+							type: string;
+						}>;
+						metafields: Array<{
+							__typename?: 'Metafield';
+							id?: string | null;
+							key: string;
+							namespace?: string | null;
+							value: string;
+						}>;
+						selectedOptions: Array<{
+							__typename?: 'SelectedOption';
+							label?: string | null;
+							name: string;
+							value: string;
+						}>;
+					} | null;
+					metafields: Array<{
+						__typename?: 'Metafield';
+						id?: string | null;
+						key: string;
+						namespace?: string | null;
+						value: string;
+					}>;
+					priceRules: Array<{
+						__typename?: 'PriceRule';
+						comparedAtPrice?: any | null;
+						country?: string | null;
+						id?: string | null;
+						price: any;
+						priceCurrency: string;
+						title: string;
+						metafields: Array<{
+							__typename?: 'Metafield';
+							id?: string | null;
+							key: string;
+							namespace?: string | null;
+							value: string;
+						}>;
+						priceBreaks: Array<{
+							__typename?: 'PriceBreak';
+							price?: any | null;
+							quantityMax?: number | null;
+							quantityMin?: number | null;
+							metafields: Array<{
+								__typename?: 'Metafield';
+								id?: string | null;
+								key: string;
+								namespace?: string | null;
+								value: string;
+							}>;
+						}>;
+					}>;
+				}>;
+				content?: {
+					__typename: 'ProductContent';
+					createdAt?: number | null;
+					description?: string | null;
+					fields?: any | null;
+					handle?: string | null;
+					indexedAt?: number | null;
+					locale?: string | null;
+					nacelleEntryId: string;
+					productEntryId?: string | null;
+					published?: boolean | null;
+					sourceEntryId: string;
+					sourceId: string;
+					title?: string | null;
+					updatedAt?: number | null;
+					featuredMedia?: {
+						__typename?: 'Media';
+						altText?: string | null;
+						id?: string | null;
+						mimeType?: string | null;
+						src: string;
+						thumbnailSrc?: string | null;
+						type: string;
+					} | null;
+					media: Array<{
+						__typename?: 'Media';
+						altText?: string | null;
+						id?: string | null;
+						mimeType?: string | null;
+						src: string;
+						thumbnailSrc?: string | null;
+						type: string;
+					}>;
+					metafields: Array<{
+						__typename?: 'Metafield';
+						id?: string | null;
+						key: string;
+						namespace?: string | null;
+						value: string;
+					}>;
+					options: Array<{
+						__typename?: 'ProductOption';
+						name: string;
+						values: Array<string>;
+					}>;
+					seo?: {
+						__typename?: 'SEO';
+						title: string;
+						description: string;
+					} | null;
+				} | null;
+			};
+		}>;
+	};
 };
 
 export type CollectionContent_CollectionContentFragment = {
@@ -1509,8 +1757,8 @@ export type NavigationQuery = {
 
 export type ProductCollectionEntriesQueryVariables = Exact<{
 	filter?: InputMaybe<ProductCollectionFilterInput>;
-	entriesFirst?: InputMaybe<Scalars['Int']>;
-	entriesAfter?: InputMaybe<Scalars['String']>;
+	entriesFirst?: InputMaybe<Scalars['Int']['input']>;
+	entriesAfter?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type ProductCollectionEntriesQuery = {
@@ -1520,7 +1768,7 @@ export type ProductCollectionEntriesQuery = {
 		edges: Array<{
 			__typename?: 'ProductCollectionEdge';
 			node: {
-				__typename?: 'ProductCollection';
+				__typename: 'ProductCollection';
 				productConnection: {
 					__typename?: 'ProductConnection';
 					pageInfo: {
@@ -1714,7 +1962,7 @@ export type ProductCollectionEntriesQuery = {
 
 export type AllProductCollectionsQueryVariables = Exact<{
 	filter?: InputMaybe<ProductCollectionFilterInput>;
-	maxReturnedEntriesPerCollection?: InputMaybe<Scalars['Int']>;
+	maxReturnedEntriesPerCollection?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type AllProductCollectionsQuery = {
@@ -1730,7 +1978,7 @@ export type AllProductCollectionsQuery = {
 			__typename?: 'ProductCollectionEdge';
 			cursor: string;
 			node: {
-				__typename?: 'ProductCollection';
+				__typename: 'ProductCollection';
 				createdAt?: number | null;
 				indexedAt?: number | null;
 				nacelleEntryId: string;
@@ -1792,6 +2040,7 @@ export type AllProductCollectionsQuery = {
 					};
 					edges: Array<{
 						__typename?: 'ProductEdge';
+						cursor: string;
 						node: {
 							__typename: 'Product';
 							availableForSale?: boolean | null;
@@ -2323,86 +2572,63 @@ export const CollectionContent_CollectionContentFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
 				]
 			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
 		}
 	]
 } as unknown as DocumentNode<
 	CollectionContent_CollectionContentFragment,
 	unknown
 >;
-export const Content_ContentFragmentDoc = {
-	kind: 'Document',
-	definitions: [
-		{
-			kind: 'FragmentDefinition',
-			name: { kind: 'Name', value: 'Content_content' },
-			typeCondition: {
-				kind: 'NamedType',
-				name: { kind: 'Name', value: 'Content' }
-			},
-			selectionSet: {
-				kind: 'SelectionSet',
-				selections: [
-					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
-				]
-			}
-		}
-	]
-} as unknown as DocumentNode<Content_ContentFragment, unknown>;
-export const NavigationItem_NavigationItemFragmentDoc = {
-	kind: 'Document',
-	definitions: [
-		{
-			kind: 'FragmentDefinition',
-			name: { kind: 'Name', value: 'NavigationItem_navigationItem' },
-			typeCondition: {
-				kind: 'NamedType',
-				name: { kind: 'Name', value: 'NavigationGroupItem' }
-			},
-			selectionSet: {
-				kind: 'SelectionSet',
-				selections: [
-					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
-					{
-						kind: 'Field',
-						name: { kind: 'Name', value: 'media' },
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'url' } }
-							]
-						}
-					},
-					{
-						kind: 'Field',
-						name: { kind: 'Name', value: 'properties' },
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
-							]
-						}
-					}
-				]
-			}
-		}
-	]
-} as unknown as DocumentNode<NavigationItem_NavigationItemFragment, unknown>;
 export const VariantContent_VariantContentFragmentDoc = {
 	kind: 'Document',
 	definitions: [
@@ -2485,6 +2711,42 @@ export const VariantContent_VariantContentFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
 				]
 			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
 		}
 	]
 } as unknown as DocumentNode<VariantContent_VariantContentFragment, unknown>;
@@ -2517,6 +2779,23 @@ export const ProductPriceBreak_ProductPriceBreakFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
 				]
 			}
 		}
@@ -2573,6 +2852,52 @@ export const ProductPriceRules_ProductPriceRulesFragmentDoc = {
 					},
 					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
 				]
 			}
 		}
@@ -2653,6 +2978,199 @@ export const Variant_VariantFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
 				]
 			}
 		}
@@ -2772,6 +3290,72 @@ export const ProductContent_ProductContentFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
 				]
 			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
 		}
 	]
 } as unknown as DocumentNode<ProductContent_ProductContentFragment, unknown>;
@@ -2840,9 +3424,1107 @@ export const Product_ProductFragmentDoc = {
 					}
 				]
 			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Variant_variant' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Variant' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'VariantContent_variantContent' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceRules' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceRules_productPriceRules'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityAvailable' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sku' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductContent_productContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'options' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductOption_productOption' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
 		}
 	]
 } as unknown as DocumentNode<Product_ProductFragment, unknown>;
+export const ProductCollection_CollectionFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductCollection_collection' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductCollection' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'CollectionContent_collectionContent'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'productConnection' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'first' },
+								value: {
+									kind: 'Variable',
+									name: {
+										kind: 'Name',
+										value: 'maxReturnedEntriesPerCollection'
+									}
+								}
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'totalCount' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'pageInfo' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'hasNextPage' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'endCursor' }
+											}
+										]
+									}
+								},
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'edges' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'cursor' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'node' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{
+															kind: 'FragmentSpread',
+															name: { kind: 'Name', value: 'Product_product' }
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Variant_variant' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Variant' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'VariantContent_variantContent' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceRules' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceRules_productPriceRules'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityAvailable' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sku' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductContent_productContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'options' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductOption_productOption' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollectionContent_collectionContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'CollectionContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'collectionEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Product_product' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Product' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'vendor' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'variants' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Variant_variant' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductContent_productContent' }
+								}
+							]
+						}
+					}
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<ProductCollection_CollectionFragment, unknown>;
+export const Content_ContentFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Content_content' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Content' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<Content_ContentFragment, unknown>;
+export const NavigationItem_NavigationItemFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NavigationItem_navigationItem' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'NavigationGroupItem' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'url' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'properties' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					}
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<NavigationItem_NavigationItemFragment, unknown>;
 export const AllContentDocument = {
 	kind: 'Document',
 	definitions: [
@@ -2916,6 +4598,10 @@ export const AllContentDocument = {
 													kind: 'SelectionSet',
 													selections: [
 														{
+															kind: 'Field',
+															name: { kind: 'Name', value: '__typename' }
+														},
+														{
 															kind: 'FragmentSpread',
 															name: { kind: 'Name', value: 'Content_content' }
 														}
@@ -2931,7 +4617,33 @@ export const AllContentDocument = {
 				]
 			}
 		},
-		...Content_ContentFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Content_content' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Content' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<AllContentQuery, AllContentQueryVariables>;
 export const NavigationDocument = {
@@ -3068,7 +4780,43 @@ export const NavigationDocument = {
 				]
 			}
 		},
-		...NavigationItem_NavigationItemFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NavigationItem_navigationItem' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'NavigationGroupItem' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'url' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'properties' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<NavigationQuery, NavigationQueryVariables>;
 export const ProductCollectionEntriesDocument = {
@@ -3138,6 +4886,10 @@ export const ProductCollectionEntriesDocument = {
 												selectionSet: {
 													kind: 'SelectionSet',
 													selections: [
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: '__typename' }
+														},
 														{
 															kind: 'Field',
 															name: {
@@ -3234,16 +4986,456 @@ export const ProductCollectionEntriesDocument = {
 				]
 			}
 		},
-		...Product_ProductFragmentDoc.definitions,
-		...Metafield_MetafieldFragmentDoc.definitions,
-		...Variant_VariantFragmentDoc.definitions,
-		...VariantContent_VariantContentFragmentDoc.definitions,
-		...Media_MediaFragmentDoc.definitions,
-		...ProductPriceRules_ProductPriceRulesFragmentDoc.definitions,
-		...ProductPriceBreak_ProductPriceBreakFragmentDoc.definitions,
-		...ProductContent_ProductContentFragmentDoc.definitions,
-		...ProductOption_ProductOptionFragmentDoc.definitions,
-		...Seo_SeoFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Variant_variant' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Variant' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'VariantContent_variantContent' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceRules' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceRules_productPriceRules'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityAvailable' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sku' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductContent_productContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'options' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductOption_productOption' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Product_product' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Product' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'vendor' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'variants' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Variant_variant' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductContent_productContent' }
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	ProductCollectionEntriesQuery,
@@ -3330,142 +5522,11 @@ export const AllProductCollectionsDocument = {
 													kind: 'SelectionSet',
 													selections: [
 														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'content' },
-															selectionSet: {
-																kind: 'SelectionSet',
-																selections: [
-																	{
-																		kind: 'FragmentSpread',
-																		name: {
-																			kind: 'Name',
-																			value:
-																				'CollectionContent_collectionContent'
-																		}
-																	}
-																]
-															}
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'createdAt' }
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'indexedAt' }
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'metafields' },
-															selectionSet: {
-																kind: 'SelectionSet',
-																selections: [
-																	{
-																		kind: 'FragmentSpread',
-																		name: {
-																			kind: 'Name',
-																			value: 'Metafield_metafield'
-																		}
-																	}
-																]
-															}
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'nacelleEntryId' }
-														},
-														{
-															kind: 'Field',
+															kind: 'FragmentSpread',
 															name: {
 																kind: 'Name',
-																value: 'productConnection'
-															},
-															arguments: [
-																{
-																	kind: 'Argument',
-																	name: { kind: 'Name', value: 'first' },
-																	value: {
-																		kind: 'Variable',
-																		name: {
-																			kind: 'Name',
-																			value: 'maxReturnedEntriesPerCollection'
-																		}
-																	}
-																}
-															],
-															selectionSet: {
-																kind: 'SelectionSet',
-																selections: [
-																	{
-																		kind: 'Field',
-																		name: { kind: 'Name', value: 'totalCount' }
-																	},
-																	{
-																		kind: 'Field',
-																		name: { kind: 'Name', value: 'pageInfo' },
-																		selectionSet: {
-																			kind: 'SelectionSet',
-																			selections: [
-																				{
-																					kind: 'Field',
-																					name: {
-																						kind: 'Name',
-																						value: 'hasNextPage'
-																					}
-																				},
-																				{
-																					kind: 'Field',
-																					name: {
-																						kind: 'Name',
-																						value: 'endCursor'
-																					}
-																				}
-																			]
-																		}
-																	},
-																	{
-																		kind: 'Field',
-																		name: { kind: 'Name', value: 'edges' },
-																		selectionSet: {
-																			kind: 'SelectionSet',
-																			selections: [
-																				{
-																					kind: 'Field',
-																					name: { kind: 'Name', value: 'node' },
-																					selectionSet: {
-																						kind: 'SelectionSet',
-																						selections: [
-																							{
-																								kind: 'FragmentSpread',
-																								name: {
-																									kind: 'Name',
-																									value: 'Product_product'
-																								}
-																							}
-																						]
-																					}
-																				}
-																			]
-																		}
-																	}
-																]
+																value: 'ProductCollection_collection'
 															}
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'sourceEntryId' }
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'sourceId' }
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'tags' }
-														},
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'updatedAt' }
 														}
 													]
 												}
@@ -3479,17 +5540,638 @@ export const AllProductCollectionsDocument = {
 				]
 			}
 		},
-		...CollectionContent_CollectionContentFragmentDoc.definitions,
-		...Media_MediaFragmentDoc.definitions,
-		...Metafield_MetafieldFragmentDoc.definitions,
-		...Seo_SeoFragmentDoc.definitions,
-		...Product_ProductFragmentDoc.definitions,
-		...Variant_VariantFragmentDoc.definitions,
-		...VariantContent_VariantContentFragmentDoc.definitions,
-		...ProductPriceRules_ProductPriceRulesFragmentDoc.definitions,
-		...ProductPriceBreak_ProductPriceBreakFragmentDoc.definitions,
-		...ProductContent_ProductContentFragmentDoc.definitions,
-		...ProductOption_ProductOptionFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollectionContent_collectionContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'CollectionContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'collectionEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Variant_variant' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Variant' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'VariantContent_variantContent' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceRules' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceRules_productPriceRules'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityAvailable' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sku' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductContent_productContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'options' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductOption_productOption' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Product_product' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Product' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'vendor' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'variants' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Variant_variant' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductContent_productContent' }
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductCollection_collection' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductCollection' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'CollectionContent_collectionContent'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'productConnection' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'first' },
+								value: {
+									kind: 'Variable',
+									name: {
+										kind: 'Name',
+										value: 'maxReturnedEntriesPerCollection'
+									}
+								}
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'totalCount' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'pageInfo' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'hasNextPage' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'endCursor' }
+											}
+										]
+									}
+								},
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'edges' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'cursor' }
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'node' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{
+															kind: 'FragmentSpread',
+															name: { kind: 'Name', value: 'Product_product' }
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	AllProductCollectionsQuery,
@@ -3583,16 +6265,456 @@ export const AllProductsDocument = {
 				]
 			}
 		},
-		...Product_ProductFragmentDoc.definitions,
-		...Metafield_MetafieldFragmentDoc.definitions,
-		...Variant_VariantFragmentDoc.definitions,
-		...VariantContent_VariantContentFragmentDoc.definitions,
-		...Media_MediaFragmentDoc.definitions,
-		...ProductPriceRules_ProductPriceRulesFragmentDoc.definitions,
-		...ProductPriceBreak_ProductPriceBreakFragmentDoc.definitions,
-		...ProductContent_ProductContentFragmentDoc.definitions,
-		...ProductOption_ProductOptionFragmentDoc.definitions,
-		...Seo_SeoFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Metafield_metafield' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Metafield' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'key' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'namespace' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Media_media' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Media' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'altText' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'mimeType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'src' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'thumbnailSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'VariantContent_variantContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'VariantContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'selectedOptions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'value' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'swatchSrc' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'variantEntryId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceBreak_productPriceBreak' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceBreak' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMax' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityMin' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductPriceRules_productPriceRules' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'PriceRule' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'comparedAtPrice' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'country' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceBreaks' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceBreak_productPriceBreak'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Variant_variant' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Variant' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'compareAtPrice' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'VariantContent_variantContent' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'price' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'priceCurrency' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'priceRules' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: {
+										kind: 'Name',
+										value: 'ProductPriceRules_productPriceRules'
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productHandle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'quantityAvailable' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sku' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weight' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'weightUnit' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductOption_productOption' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductOption' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'values' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'SEO_seo' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'SEO' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ProductContent_productContent' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'ProductContent' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'featuredMedia' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'fields' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'handle' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'locale' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'media' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Media_media' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'options' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductOption_productOption' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'productEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'published' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'seo' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'SEO_seo' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'title' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Product_product' },
+			typeCondition: {
+				kind: 'NamedType',
+				name: { kind: 'Name', value: 'Product' }
+			},
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'availableForSale' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'indexedAt' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'metafields' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Metafield_metafield' }
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'nacelleEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'productType' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceEntryId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'sourceId' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'tags' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'vendor' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'variants' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'Variant_variant' }
+								}
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'content' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'FragmentSpread',
+									name: { kind: 'Name', value: 'ProductContent_productContent' }
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<AllProductsQuery, AllProductsQueryVariables>;
 export const SpacePropertiesDocument = {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/collection.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/collection.ts
@@ -1,0 +1,31 @@
+export default /* GraphQL */ `
+	fragment ProductCollection_collection on ProductCollection {
+		__typename
+		content {
+			...CollectionContent_collectionContent
+		}
+		createdAt
+		indexedAt
+		metafields {
+			...Metafield_metafield
+		}
+		nacelleEntryId
+		productConnection(first: $maxReturnedEntriesPerCollection) {
+			totalCount
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+			edges {
+				cursor
+				node {
+					...Product_product
+				}
+			}
+		}
+		sourceEntryId
+		sourceId
+		tags
+		updatedAt
+	}
+`;

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/collectionContent.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/collectionContent.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment CollectionContent_collectionContent on CollectionContent {
+		__typename
 		collectionEntryId
 		createdAt
 		description

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/content.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment Content_content on Content {
+		__typename
 		createdAt
 		fields
 		handle

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/product.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/product.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment Product_product on Product {
+		__typename
 		availableForSale
 		createdAt
 		indexedAt

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/productContent.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/productContent.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment ProductContent_productContent on ProductContent {
+		__typename
 		createdAt
 		description
 		featuredMedia {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/variant.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/variant.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment Variant_variant on Variant {
+		__typename
 		availableForSale
 		compareAtPrice
 		content {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/variantContent.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/fragments/variantContent.ts
@@ -1,5 +1,6 @@
 export default /* GraphQL */ `
 	fragment VariantContent_variantContent on VariantContent {
+		__typename
 		createdAt
 		description
 		featuredMedia {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/content.ts
@@ -9,6 +9,7 @@ export default /* GraphQL */ `
 			edges {
 				cursor
 				node {
+					__typename
 					...Content_content
 				}
 			}

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/productCollectionEntries.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/productCollectionEntries.ts
@@ -7,6 +7,7 @@ export default /* GraphQL */ `
 		allProductCollections(filter: $filter) {
 			edges {
 				node {
+					__typename
 					productConnection(first: $entriesFirst, after: $entriesAfter) {
 						pageInfo {
 							hasNextPage

--- a/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/productCollections.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/graphql/queries/productCollections.ts
@@ -11,31 +11,7 @@ export default /* GraphQL */ `
 			edges {
 				cursor
 				node {
-					content {
-						...CollectionContent_collectionContent
-					}
-					createdAt
-					indexedAt
-					metafields {
-						...Metafield_metafield
-					}
-					nacelleEntryId
-					productConnection(first: $maxReturnedEntriesPerCollection) {
-						totalCount
-						pageInfo {
-							hasNextPage
-							endCursor
-						}
-						edges {
-							node {
-								...Product_product
-							}
-						}
-					}
-					sourceEntryId
-					sourceId
-					tags
-					updatedAt
+					...ProductCollection_collection
 				}
 			}
 		}

--- a/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/index.test.ts
@@ -178,6 +178,7 @@ describe('content', () => {
 		expectTypeOf(defaultData).toMatchTypeOf<Content[]>();
 		expectTypeOf(explicitNodesData).toMatchTypeOf<Content[]>();
 		expectTypeOf(explicitEdgesData).toMatchTypeOf<ContentEdge[]>();
+		expect(defaultData[0].__typename).toBe('Content');
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
@@ -358,6 +359,7 @@ describe('products', () => {
 		expectTypeOf(defaultData).toMatchTypeOf<Product[]>();
 		expectTypeOf(explicitNodesData).toMatchTypeOf<Product[]>();
 		expectTypeOf(explicitEdgesData).toMatchTypeOf<ProductEdge[]>();
+		expect(defaultData[0].__typename).toBe('Product');
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {
@@ -540,6 +542,7 @@ describe('productCollections', () => {
 		expectTypeOf(defaultData).toMatchTypeOf<ProductCollection[]>();
 		expectTypeOf(explicitNodesData).toMatchTypeOf<ProductCollection[]>();
 		expectTypeOf(explicitEdgesData).toMatchTypeOf<ProductCollectionEdge[]>();
+		expect(defaultData[0].__typename).toBe('ProductCollection');
 	});
 
 	it('should pass parameters including the `nacelleEntryId` as variables', async () => {

--- a/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
@@ -9,82 +9,91 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
 	[SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+	T extends { [key: string]: unknown },
+	K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+	| T
+	| {
+			[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+	  };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-	ID: string;
-	String: string;
-	Boolean: boolean;
-	Int: number;
-	Float: number;
-	Decimal: any;
-	JSON: any;
+	ID: { input: string; output: string };
+	String: { input: string; output: string };
+	Boolean: { input: boolean; output: boolean };
+	Int: { input: number; output: number };
+	Float: { input: number; output: number };
+	Decimal: { input: any; output: any };
+	JSON: { input: any; output: any };
 };
 
 export type CollectionContent = Node & {
 	__typename?: 'CollectionContent';
 	/** [sys] Reference to collection by Nacelle ID. */
-	collectionEntryId: Scalars['ID'];
+	collectionEntryId: Scalars['ID']['output'];
 	/** [source] The Unix timestamp in seconds when the collection content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a collection. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a collection. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Reference to collection by handle. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of product collection to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of metafields associated with the product collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] Specifies if the collection content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] SEO fields for a collection */
 	seo?: Maybe<Seo>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The title for a collection. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the collection content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents master pieces of content like a page, article, employee, press-release, etc. */
 export type Content = Node & {
 	__typename?: 'Content';
 	/** [source] The Unix timestamp in seconds when the content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] Stringified JSON representing custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [source] A human-friendly unique string for the content. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of the content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] Specifies if the content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the content. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The title for the content. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The categorization for the content, often used for search and filter. */
-	type?: Maybe<Scalars['String']>;
+	type?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
@@ -95,38 +104,38 @@ export type ContentCollection = Node & {
 	/** [source] List of content entries with Relay-style pagination */
 	contentConnection: ContentConnection;
 	/** [source] The Unix timestamp in seconds when the content collection was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/**
 	 * [source] List of content entries for a given content collection.
 	 * @deprecated `contentConnection` should be used for paginated content queries.
 	 */
 	entries: Array<Content>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the content collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the collection. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the content collection was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
 export type ContentCollectionContentConnectionArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Represents a collection of content: articles for a blog, employees for an About Us page, press releases for a News page, etc. */
 export type ContentCollectionEntriesArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Result of a ContentCollection Query with pagination info */
@@ -139,24 +148,24 @@ export type ContentCollectionConnection = NodeConnection & {
 /** Implementation of an Edge type for ContentCollection entries */
 export type ContentCollectionEdge = NodeEdge & {
 	__typename?: 'ContentCollectionEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: ContentCollection;
 };
 
 /** Filter results for product collection */
 export type ContentCollectionFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n collections of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter content collection entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter content collection entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content collection entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -164,47 +173,47 @@ export type ContentConnection = NodeConnection & {
 	__typename?: 'ContentConnection';
 	edges: Array<ContentEdge>;
 	/** [source] Returns filtered number of entries for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of entries in a collection for collection queries, null for content queries */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Content entries */
 export type ContentEdge = NodeEdge & {
 	__typename?: 'ContentEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Content;
 };
 
 /** Filter results for content */
 export type ContentFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Determines how many levels of nested content entries should be returned */
-	entryDepth?: InputMaybe<Scalars['Int']>;
+	entryDepth?: InputMaybe<Scalars['Int']['input']>;
 	/** Returns the first n content entries of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter content entries by entry handle. Requires type filter or defaults to type of 'page'. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter content entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ContentSearchOptions>;
 	/** Filter content entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
-	type?: InputMaybe<Scalars['String']>;
+	type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** List of Content ids grouped for a specific purpose. */
 export type ContentList = {
 	__typename?: 'ContentList';
-	ids: Array<Scalars['ID']>;
-	listHandle?: Maybe<Scalars['String']>;
-	title?: Maybe<Scalars['String']>;
+	ids: Array<Scalars['ID']['output']>;
+	listHandle?: Maybe<Scalars['String']['output']>;
+	title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Searchable fields for content */
@@ -219,68 +228,68 @@ export type ContentSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** A piece of media that can represent an Image, 3dModel, or Video. */
 export type Media = {
 	__typename?: 'Media';
-	altText?: Maybe<Scalars['String']>;
-	id?: Maybe<Scalars['ID']>;
-	mimeType?: Maybe<Scalars['String']>;
-	src: Scalars['String'];
-	thumbnailSrc?: Maybe<Scalars['String']>;
-	type: Scalars['String'];
+	altText?: Maybe<Scalars['String']['output']>;
+	id?: Maybe<Scalars['ID']['output']>;
+	mimeType?: Maybe<Scalars['String']['output']>;
+	src: Scalars['String']['output'];
+	thumbnailSrc?: Maybe<Scalars['String']['output']>;
+	type: Scalars['String']['output'];
 };
 
 /** Metafields represent custom metadata attached to a resource. Metafields can be sorted into namespaces and are comprised of keys, values */
 export type Metafield = {
 	__typename?: 'Metafield';
-	id?: Maybe<Scalars['ID']>;
-	key: Scalars['String'];
-	namespace?: Maybe<Scalars['String']>;
-	value: Scalars['String'];
+	id?: Maybe<Scalars['ID']['output']>;
+	key: Scalars['String']['output'];
+	namespace?: Maybe<Scalars['String']['output']>;
+	value: Scalars['String']['output'];
 };
 
 /** Represents a single price */
 export type Money = {
 	__typename?: 'Money';
 	/** [source] An amount for the money */
-	amount: Scalars['Int'];
+	amount: Scalars['Int']['output'];
 	/** [source] A currencyCode identifier for the amount */
-	currencyCode: Scalars['String'];
+	currencyCode: Scalars['String']['output'];
 	/** [source] (optional) The precision to which the currency amount should be displayed */
-	precisionDigits?: Maybe<Scalars['Int']>;
+	precisionDigits?: Maybe<Scalars['Int']['output']>;
 };
 
 /** The mutation root. */
 export type Mutation = {
 	__typename?: 'Mutation';
-	root?: Maybe<Scalars['String']>;
+	root?: Maybe<Scalars['String']['output']>;
 };
 
 /** The filter to apply, when selecting navigation items. */
 export type NavigationFilterInput = {
 	/** The navigation group to filter by */
-	groupId?: InputMaybe<Scalars['String']>;
+	groupId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type NavigationGroup = {
 	__typename?: 'NavigationGroup';
 	/** Created-at timestamp */
-	createdAt?: Maybe<Scalars['String']>;
+	createdAt?: Maybe<Scalars['String']['output']>;
 	/** The unique identifier of the navigation group */
-	groupId: Scalars['String'];
+	groupId: Scalars['String']['output'];
 	/** Items within a navigation group */
 	items?: Maybe<Array<NavigationGroupItem>>;
 	/** Navigation properties */
 	properties?: Maybe<Array<NavigationPropertyItem>>;
 	/** Displayable title of a navigation group */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** Updated-at timestamp */
-	updatedAt?: Maybe<Scalars['String']>;
+	updatedAt?: Maybe<Scalars['String']['output']>;
 	/** Updated-by user ID */
-	updatedBy?: Maybe<Scalars['String']>;
+	updatedBy?: Maybe<Scalars['String']['output']>;
 };
 
 export type NavigationGroupItem = {
@@ -292,23 +301,23 @@ export type NavigationGroupItem = {
 	/** Navigation properties */
 	properties?: Maybe<Array<NavigationPropertyItem>>;
 	/** Displayable title of a navigation item */
-	title: Scalars['String'];
+	title: Scalars['String']['output'];
 	/** Item type */
 	type?: Maybe<NavigationPropertyType>;
 	/** Route to a navigation item */
-	url: Scalars['String'];
+	url: Scalars['String']['output'];
 };
 
 export type NavigationMediaItem = {
 	__typename?: 'NavigationMediaItem';
 	/** URL that links to the media item */
-	url?: Maybe<Scalars['String']>;
+	url?: Maybe<Scalars['String']['output']>;
 };
 
 export type NavigationPropertyItem = {
 	__typename?: 'NavigationPropertyItem';
-	key: Scalars['String'];
-	value: Scalars['String'];
+	key: Scalars['String']['output'];
+	value: Scalars['String']['output'];
 };
 
 export type NavigationPropertyType =
@@ -322,7 +331,7 @@ export type NavigationPropertyType =
 /** An entry with a Globally Unique ID */
 export type Node = {
 	/** The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 };
 
 /** An object containing an array of Node data and pagination information */
@@ -333,17 +342,17 @@ export type NodeConnection = {
 
 /** An object containing a node with Nacelle data and a cursor for pagination and filtering */
 export type NodeEdge = {
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Node;
 };
 
 /** Pagination object indicating if there are more pages of data and where the next page starts. */
 export type PageInfo = {
 	__typename?: 'PageInfo';
-	endCursor: Scalars['String'];
-	hasNextPage: Scalars['Boolean'];
-	hasPreviousPage: Scalars['Boolean'];
-	startCursor: Scalars['String'];
+	endCursor: Scalars['String']['output'];
+	hasNextPage: Scalars['Boolean']['output'];
+	hasPreviousPage: Scalars['Boolean']['output'];
+	startCursor: Scalars['String']['output'];
 };
 
 /** A price break definition. */
@@ -352,43 +361,43 @@ export type PriceBreak = {
 	/** [source] List of metafields associated with the price break. */
 	metafields: Array<Metafield>;
 	/** [source] The price associated with this price break. */
-	price?: Maybe<Scalars['Decimal']>;
+	price?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Maximum quantity of variant needed to apply price break. */
-	quantityMax?: Maybe<Scalars['Int']>;
+	quantityMax?: Maybe<Scalars['Int']['output']>;
 	/** [source] Minimum quantity of variant needed to apply price break. */
-	quantityMin?: Maybe<Scalars['Int']>;
+	quantityMin?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A price rule definition. */
 export type PriceRule = {
 	__typename?: 'PriceRule';
 	/** [source] Array of customer segment ids. Unused. */
-	availableTo: Array<Scalars['String']>;
+	availableTo: Array<Scalars['String']['output']>;
 	/** [source] The compare at price of the price rule. This can be used to mark a variant as on sale. */
-	comparedAtPrice?: Maybe<Scalars['Decimal']>;
+	comparedAtPrice?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Country code associated with this price rule. Distinct from currency code. */
-	country?: Maybe<Scalars['String']>;
+	country?: Maybe<Scalars['String']['output']>;
 	/** [source] Identifying handle of price rule if applicable. */
-	handle: Scalars['String'];
+	handle: Scalars['String']['output'];
 	/** [source] The id of the source price rule if applicable. */
-	id?: Maybe<Scalars['ID']>;
+	id?: Maybe<Scalars['ID']['output']>;
 	/** [source] List of metafields associated with the price rule. */
 	metafields: Array<Metafield>;
 	/** [source] The price associated with this price rule. */
-	price: Scalars['Decimal'];
+	price: Scalars['Decimal']['output'];
 	/** [source] Used for changing a variant's price based on quantity selected. */
 	priceBreaks: Array<PriceBreak>;
 	/** [source] The currency code for this price rule. */
-	priceCurrency: Scalars['String'];
+	priceCurrency: Scalars['String']['output'];
 	/** [source] The title of the price rule. */
-	title: Scalars['String'];
+	title: Scalars['String']['output'];
 };
 
 /** Fields available for standalone pricing */
 export type Pricing = {
 	__typename?: 'Pricing';
 	/** [source] List of metafields associated with the pricing */
-	metafields?: Maybe<Scalars['JSON']>;
+	metafields?: Maybe<Scalars['JSON']['output']>;
 	/** [source] The default price */
 	price?: Maybe<Money>;
 	/** [source] The shipping price */
@@ -398,38 +407,38 @@ export type Pricing = {
 	/** [source] The tax amount */
 	taxValue?: Maybe<Money>;
 	/** [sys] Reference to parent variant by Nacelle ID */
-	variantEntryId: Scalars['ID'];
+	variantEntryId: Scalars['ID']['output'];
 };
 
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
 export type Product = Node & {
 	__typename?: 'Product';
 	/** [source] Specifies if at least one product variant is available for sale. */
-	availableForSale?: Maybe<Scalars['Boolean']>;
+	availableForSale?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] Localized content for the product. */
 	content?: Maybe<ProductContent>;
 	/** [source] The Unix timestamp in seconds when the product was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the product. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The categorization for a product, often used for search and filter. */
-	productType?: Maybe<Scalars['String']>;
+	productType?: Maybe<Scalars['String']['output']>;
 	/** [source] The ID for the product from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the product. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of variants for the product. */
 	variants: Array<Variant>;
 	/** [source] Vendor name for product. */
-	vendor?: Maybe<Scalars['String']>;
+	vendor?: Maybe<Scalars['String']['output']>;
 };
 
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
@@ -443,13 +452,13 @@ export type ProductCollection = Node & {
 	/** [source] Localized content associated with the product collection. */
 	content?: Maybe<CollectionContent>;
 	/** [source] The Unix timestamp in seconds when the product collection was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the product collection. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] List of products entries with Relay-style pagination */
 	productConnection: ProductConnection;
 	/**
@@ -458,25 +467,25 @@ export type ProductCollection = Node & {
 	 */
 	products: Array<Product>;
 	/** [source] The ID for the content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] List of tags that have been associated to the collection. */
-	tags: Array<Scalars['String']>;
+	tags: Array<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product collection was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Represents a collection of products. */
 export type ProductCollectionProductConnectionArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Represents a collection of products. */
 export type ProductCollectionProductsArgs = {
-	after?: InputMaybe<Scalars['String']>;
-	first?: InputMaybe<Scalars['Int']>;
+	after?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -484,37 +493,37 @@ export type ProductCollectionConnection = NodeConnection & {
 	__typename?: 'ProductCollectionConnection';
 	edges: Array<ProductCollectionEdge>;
 	/** [source] Returns filtered number of collections for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of collections for backend search, defaults to null */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Content entries */
 export type ProductCollectionEdge = NodeEdge & {
 	__typename?: 'ProductCollectionEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: ProductCollection;
 };
 
 /** Filter results for product collection */
 export type ProductCollectionFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n collections of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter product collection entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter product collection entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductCollectionSearchOptions>;
 	/** Filter product collection entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
-	type?: InputMaybe<Scalars['String']>;
+	type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Searchable fields for product collection */
@@ -529,7 +538,7 @@ export type ProductCollectionSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Order by which to sort */
@@ -540,93 +549,93 @@ export type ProductConnection = NodeConnection & {
 	__typename?: 'ProductConnection';
 	edges: Array<ProductEdge>;
 	/** [source] Returns filtered number of products for backend search, defaults to null */
-	filteredCount?: Maybe<Scalars['Int']>;
+	filteredCount?: Maybe<Scalars['Int']['output']>;
 	pageInfo: PageInfo;
 	/** [source] Returns total number of products in a collection for collection queries, null for product queries */
-	totalCount?: Maybe<Scalars['Int']>;
+	totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A piece of product content represents the localized version of data points, with more flexibility. */
 export type ProductContent = Node & {
 	__typename?: 'ProductContent';
 	/** [source] The Unix timestamp in seconds when the product content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a product. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a product. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Reference to product by handle. */
-	handle?: Maybe<Scalars['String']>;
+	handle?: Maybe<Scalars['String']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of product content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of media for a product */
 	media: Array<Media>;
 	/** [source] List of metafields associated with the product content. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] List of product options. */
 	options: Array<ProductOption>;
 	/** [sys] Reference to product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [source] Specifies if the product content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] SEO fields for a product */
 	seo?: Maybe<Seo>;
 	/** [source] The ID for the product content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The title for a product. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the product content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Implementation of an Edge type for Product entries */
 export type ProductEdge = NodeEdge & {
 	__typename?: 'ProductEdge';
-	cursor: Scalars['String'];
+	cursor: Scalars['String']['output'];
 	node: Product;
 };
 
 /** Filter results for product */
 export type ProductFilterInput = {
 	/** Returns elements after a cursor nacelleEntryId */
-	after?: InputMaybe<Scalars['String']>;
+	after?: InputMaybe<Scalars['String']['input']>;
 	/** Returns the first n products of a query. Defaults to 100. Max value of 500 */
-	first?: InputMaybe<Scalars['Int']>;
+	first?: InputMaybe<Scalars['Int']['input']>;
 	/** Filter product entries by entry handle. */
-	handles?: InputMaybe<Array<Scalars['String']>>;
+	handles?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter items based on locale. [IETF language tag] (ie. en-US) */
-	locale?: InputMaybe<Scalars['String']>;
+	locale?: InputMaybe<Scalars['String']['input']>;
 	/** Filter product entries by Nacelle entry id. */
-	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	nacelleEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 	/** Filter product variant standalone pricing by country code */
-	pricingCountryCode?: InputMaybe<Scalars['String']>;
+	pricingCountryCode?: InputMaybe<Scalars['String']['input']>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductSearchOptions>;
 	/** Filter product entries by source entry id. */
-	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** List of Product ids grouped for a specific purpose. */
 export type ProductList = {
 	__typename?: 'ProductList';
-	ids: Array<Scalars['ID']>;
-	listHandle?: Maybe<Scalars['String']>;
-	title?: Maybe<Scalars['String']>;
+	ids: Array<Scalars['ID']['output']>;
+	listHandle?: Maybe<Scalars['String']['output']>;
+	title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Product property names like Size, Color, and Material that the customers can select. Variants are selected based on permutations of these options. */
 export type ProductOption = {
 	__typename?: 'ProductOption';
-	name: Scalars['String'];
-	values: Array<Scalars['String']>;
+	name: Scalars['String']['output'];
+	values: Array<Scalars['String']['output']>;
 };
 
 /** Searchable fields for product */
@@ -641,7 +650,7 @@ export type ProductSearchOptions = {
 	/** The order by which to sort */
 	sortOrder?: InputMaybe<ProductCollectionSortOrder>;
 	/** The search term of the entry to search */
-	term?: InputMaybe<Scalars['String']>;
+	term?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Query = {
@@ -680,7 +689,7 @@ export type Query = {
 	 * @deprecated `allProducts` should be used for paginated product queries.
 	 */
 	products: Array<Product>;
-	root?: Maybe<Scalars['String']>;
+	root?: Maybe<Scalars['String']['output']>;
 	/** Space properties data for a space */
 	spaceProperties: SpaceProperties;
 };
@@ -724,22 +733,22 @@ export type QueryProductsArgs = {
 /** A simple response indicating that an indexing event was received. Processing will occur in the background. */
 export type QueryResponse = {
 	__typename?: 'QueryResponse';
-	message: Scalars['String'];
+	message: Scalars['String']['output'];
 };
 
 /** A field used to provide SEO data for web crawlers */
 export type Seo = {
 	__typename?: 'SEO';
-	description: Scalars['String'];
-	title: Scalars['String'];
+	description: Scalars['String']['output'];
+	title: Scalars['String']['output'];
 };
 
 /** Properties used by customers to select a product variant. Products can have multiple options, like different sizes or colors. */
 export type SelectedOption = {
 	__typename?: 'SelectedOption';
-	label?: Maybe<Scalars['String']>;
-	name: Scalars['String'];
-	value: Scalars['String'];
+	label?: Maybe<Scalars['String']['output']>;
+	name: Scalars['String']['output'];
+	value: Scalars['String']['output'];
 };
 
 export type SpaceProperties = {
@@ -747,17 +756,17 @@ export type SpaceProperties = {
 	/** List of space properties grouped by namespace */
 	properties?: Maybe<Array<Maybe<SpacePropertyNamespace>>>;
 	/** Updated-at timestamp */
-	updatedAt?: Maybe<Scalars['String']>;
+	updatedAt?: Maybe<Scalars['String']['output']>;
 	/** Updated-by user ID */
-	updatedBy?: Maybe<Scalars['String']>;
+	updatedBy?: Maybe<Scalars['String']['output']>;
 };
 
 export type SpacePropertyItem = {
 	__typename?: 'SpacePropertyItem';
 	/** Property name */
-	key: Scalars['String'];
+	key: Scalars['String']['output'];
 	/** Property value */
-	value: Scalars['String'];
+	value: Scalars['String']['output'];
 };
 
 export type SpacePropertyNamespace = {
@@ -765,101 +774,101 @@ export type SpacePropertyNamespace = {
 	/** List of space properties items */
 	items?: Maybe<Array<Maybe<SpacePropertyItem>>>;
 	/** Namespace name */
-	namespace?: Maybe<Scalars['String']>;
+	namespace?: Maybe<Scalars['String']['output']>;
 };
 
 /** A product variant represents a different version of a product, such as differing sizes or differing colors. */
 export type Variant = Node & {
 	__typename?: 'Variant';
 	/** [source] Specifies if the variant is available for sale. */
-	availableForSale?: Maybe<Scalars['Boolean']>;
+	availableForSale?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] The compare at price of the variant. This can be used to mark a variant as on sale. */
-	compareAtPrice?: Maybe<Scalars['Decimal']>;
+	compareAtPrice?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] Localized content for the variant. */
 	content?: Maybe<VariantContent>;
 	/** [source] The Unix timestamp in seconds when the variant was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] List of metafields associated with the variant. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [source] The price of the variant. */
-	price?: Maybe<Scalars['Decimal']>;
+	price?: Maybe<Scalars['Decimal']['output']>;
 	/** [source] The currency of the variant price. */
-	priceCurrency?: Maybe<Scalars['String']>;
+	priceCurrency?: Maybe<Scalars['String']['output']>;
 	/** [source] List of pricing rules associated with the variant */
 	priceRules: Array<PriceRule>;
 	/** [source] standalone pricing */
 	pricing?: Maybe<Array<Maybe<Pricing>>>;
 	/** [sys] Reference to parent product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [sys] Reference to parent product by handle. */
-	productHandle?: Maybe<Scalars['String']>;
+	productHandle?: Maybe<Scalars['String']['output']>;
 	/** [source] The total sellable quantity of the variant for online sales channels. */
-	quantityAvailable?: Maybe<Scalars['Int']>;
+	quantityAvailable?: Maybe<Scalars['Int']['output']>;
 	/** [source] The SKU (stock keeping unit) associated with the variant. */
-	sku?: Maybe<Scalars['String']>;
+	sku?: Maybe<Scalars['String']['output']>;
 	/** [source] The ID for the product variant from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] The Unix timestamp in seconds when the variant was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The variant sort position. */
-	variantPosition?: Maybe<Scalars['Int']>;
+	variantPosition?: Maybe<Scalars['Int']['output']>;
 	/** [source] The weight of the variant in the unit specified with weightUnit. */
-	weight?: Maybe<Scalars['Float']>;
+	weight?: Maybe<Scalars['Float']['output']>;
 	/** [source] The unit of measurement for weight. */
-	weightUnit?: Maybe<Scalars['String']>;
+	weightUnit?: Maybe<Scalars['String']['output']>;
 };
 
 /** A piece of variant content represents the localized version of data points, with more flexibility. */
 export type VariantContent = Node & {
 	__typename?: 'VariantContent';
 	/** [source] The Unix timestamp in seconds when the variant content was created. */
-	createdAt?: Maybe<Scalars['Int']>;
+	createdAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The description for a variant. */
-	description?: Maybe<Scalars['String']>;
+	description?: Maybe<Scalars['String']['output']>;
 	/** [source] The primary media for a variant. */
 	featuredMedia?: Maybe<Media>;
 	/** [source] Custom fields from a dynamic CMS source. */
-	fields?: Maybe<Scalars['JSON']>;
+	fields?: Maybe<Scalars['JSON']['output']>;
 	/** [sys] Timestamp of when Nacelle last indexed this entry. */
-	indexedAt?: Maybe<Scalars['Int']>;
+	indexedAt?: Maybe<Scalars['Int']['output']>;
 	/** [source] The locale of variant content to be presented. [IETF language tag] (ie. en-US) */
-	locale?: Maybe<Scalars['String']>;
+	locale?: Maybe<Scalars['String']['output']>;
 	/** [source] List of media for a variant */
 	media: Array<Media>;
 	/** [source] List of metafields associated with the variant content. */
 	metafields: Array<Metafield>;
 	/** [sys] The Nacelle ID of the entry. */
-	nacelleEntryId: Scalars['ID'];
+	nacelleEntryId: Scalars['ID']['output'];
 	/** [sys] Reference to parent product by Nacelle ID. */
-	productEntryId?: Maybe<Scalars['ID']>;
+	productEntryId?: Maybe<Scalars['ID']['output']>;
 	/** [sys] Reference to parent product by handle. */
-	productHandle?: Maybe<Scalars['String']>;
+	productHandle?: Maybe<Scalars['String']['output']>;
 	/** [source] Specifies if the variant content has been published. */
-	published?: Maybe<Scalars['Boolean']>;
+	published?: Maybe<Scalars['Boolean']['output']>;
 	/** [source] List of product options applied to the variant. */
 	selectedOptions: Array<SelectedOption>;
 	/** [source] The ID for the variant content from its system of origin (i.e. Shopify). */
-	sourceEntryId: Scalars['ID'];
+	sourceEntryId: Scalars['ID']['output'];
 	/** [source] The ID for the system of origin. */
-	sourceId: Scalars['ID'];
+	sourceId: Scalars['ID']['output'];
 	/** [source] Source url of variant swatch. */
-	swatchSrc?: Maybe<Scalars['String']>;
+	swatchSrc?: Maybe<Scalars['String']['output']>;
 	/** [source] The title for a variant. */
-	title?: Maybe<Scalars['String']>;
+	title?: Maybe<Scalars['String']['output']>;
 	/** [source] The Unix timestamp in seconds when the variant content was last modified. */
-	updatedAt?: Maybe<Scalars['Int']>;
+	updatedAt?: Maybe<Scalars['Int']['output']>;
 	/** [sys] Reference to parent variant by Nacelle ID. */
-	variantEntryId?: Maybe<Scalars['ID']>;
+	variantEntryId?: Maybe<Scalars['ID']['output']>;
 };
 
 export type _Service = {
 	__typename?: '_Service';
 	/** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied */
-	sdl?: Maybe<Scalars['String']>;
+	sdl?: Maybe<Scalars['String']['output']>;
 };

--- a/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
+++ b/packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts
@@ -155,6 +155,8 @@ export type ContentCollectionFilterInput = {
 	locale?: InputMaybe<Scalars['String']>;
 	/** Filter content collection entries by Nacelle entry id. */
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	/** Filter content collection entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 };
 
 /** Result of a Content Query with pagination info */
@@ -191,6 +193,8 @@ export type ContentFilterInput = {
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ContentSearchOptions>;
+	/** Filter content entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
 	type?: InputMaybe<Scalars['String']>;
 };
@@ -238,6 +242,18 @@ export type Metafield = {
 	value: Scalars['String'];
 };
 
+/** Represents a single price */
+export type Money = {
+	__typename?: 'Money';
+	/** [source] An amount for the money */
+	amount: Scalars['Int'];
+	/** [source] A currencyCode identifier for the amount */
+	currencyCode: Scalars['String'];
+	/** [source] (optional) The precision to which the currency amount should be displayed */
+	precisionDigits?: Maybe<Scalars['Int']>;
+};
+
+/** The mutation root. */
 export type Mutation = {
 	__typename?: 'Mutation';
 	root?: Maybe<Scalars['String']>;
@@ -368,6 +384,23 @@ export type PriceRule = {
 	title: Scalars['String'];
 };
 
+/** Fields available for standalone pricing */
+export type Pricing = {
+	__typename?: 'Pricing';
+	/** [source] List of metafields associated with the pricing */
+	metafields?: Maybe<Scalars['JSON']>;
+	/** [source] The default price */
+	price?: Maybe<Money>;
+	/** [source] The shipping price */
+	shipping?: Maybe<Money>;
+	/** [source] The discounted price */
+	strikeThroughPrice?: Maybe<Money>;
+	/** [source] The tax amount */
+	taxValue?: Maybe<Money>;
+	/** [sys] Reference to parent variant by Nacelle ID */
+	variantEntryId: Scalars['ID'];
+};
+
 /** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
 export type Product = Node & {
 	__typename?: 'Product';
@@ -397,6 +430,11 @@ export type Product = Node & {
 	variants: Array<Variant>;
 	/** [source] Vendor name for product. */
 	vendor?: Maybe<Scalars['String']>;
+};
+
+/** A product represents an individual item for sale. Products are often physical, but they don't have to be. For example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty). */
+export type ProductVariantsArgs = {
+	filter?: InputMaybe<ProductFilterInput>;
 };
 
 /** Represents a collection of products. */
@@ -473,12 +511,14 @@ export type ProductCollectionFilterInput = {
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductCollectionSearchOptions>;
+	/** Filter product collection entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 	/** Filter content entries by content type (ie. 'article', 'page', etc.) */
 	type?: InputMaybe<Scalars['String']>;
 };
 
 /** Searchable fields for product collection */
-export type ProductCollectionSearchFields = 'HANDLE' | 'TITLE';
+export type ProductCollectionSearchFields = 'HANDLE' | 'TAGS' | 'TITLE';
 
 /** Search options for Product Collection */
 export type ProductCollectionSearchOptions = {
@@ -566,8 +606,12 @@ export type ProductFilterInput = {
 	locale?: InputMaybe<Scalars['String']>;
 	/** Filter product entries by Nacelle entry id. */
 	nacelleEntryIds?: InputMaybe<Array<Scalars['String']>>;
+	/** Filter product variant standalone pricing by country code */
+	pricingCountryCode?: InputMaybe<Scalars['String']>;
 	/** The backend search filter */
 	searchFilter?: InputMaybe<ProductSearchOptions>;
+	/** Filter product entries by source entry id. */
+	sourceEntryIds?: InputMaybe<Array<Scalars['String']>>;
 };
 
 /** List of Product ids grouped for a specific purpose. */
@@ -602,9 +646,13 @@ export type ProductSearchOptions = {
 
 export type Query = {
 	__typename?: 'Query';
+	_service: _Service;
 	/** Query a list of content entries with Relay-style pagination */
 	allContent: ContentConnection;
-	/** Query a list of content collection entries with Relay-style pagination */
+	/**
+	 * Query a list of content collection entries with Relay-style pagination
+	 * @deprecated `allContent` should be used for paginated content queries.
+	 */
 	allContentCollections: ContentCollectionConnection;
 	/** Query a list of ProductCollection entries with Relay-style pagination */
 	allProductCollections: ProductCollectionConnection;
@@ -617,7 +665,7 @@ export type Query = {
 	content: Array<Content>;
 	/**
 	 * Query a collection of contents
-	 * @deprecated `allContentCollections` should be used for paginated content collection queries.
+	 * @deprecated `allContent` should be used for paginated content queries.
 	 */
 	contentCollections: Array<ContentCollection>;
 	/** Get navigation groups for a space */
@@ -743,6 +791,8 @@ export type Variant = Node & {
 	priceCurrency?: Maybe<Scalars['String']>;
 	/** [source] List of pricing rules associated with the variant */
 	priceRules: Array<PriceRule>;
+	/** [source] standalone pricing */
+	pricing?: Maybe<Array<Maybe<Pricing>>>;
 	/** [sys] Reference to parent product by Nacelle ID. */
 	productEntryId?: Maybe<Scalars['ID']>;
 	/** [sys] Reference to parent product by handle. */
@@ -806,4 +856,10 @@ export type VariantContent = Node & {
 	updatedAt?: Maybe<Scalars['Int']>;
 	/** [sys] Reference to parent variant by Nacelle ID. */
 	variantEntryId?: Maybe<Scalars['ID']>;
+};
+
+export type _Service = {
+	__typename?: '_Service';
+	/** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied */
+	sdl?: Maybe<Scalars['String']>;
 };


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-9068](https://nacelle.atlassian.net/browse/ENG-9068) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

Add `__typename` to fragments

## How to Test

<!--
  Provide point-by-point instructions that PR reviewers can follow to successfully test your PR.
-->

In the Commerce Queries folder `packages/storefront-sdk-plugins/commerce-queries`:
- `npm run test`

## Notes

When running Codegen some strange things happened to the following files:
- packages/storefront-sdk-plugins/commerce-queries/src/graphql/documents.ts
- packages/storefront-sdk-plugins/commerce-queries/src/types/storefront.ts

With the inclusion of `Pricing` and `Money` types, let's discuss wether or not we want to include this in this PR

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Screenshots, videos, etc. in the PR description are free of brand names and sensitive details.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).
- [ ] Updated the `README.md` with documentation changes (if applicable).


[ENG-9068]: https://nacelle.atlassian.net/browse/ENG-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ