### PR TITLE
fix: retry on all network errors

### DIFF
--- a/.changeset/angry-apricots-jog.md
+++ b/.changeset/angry-apricots-jog.md
@@ -1,0 +1,5 @@
+---
+'@nacelle/storefront-sdk': patch
+---
+
+Updated the default request retry logic to retry in response to all network errors. To customize request retry logic, you can provide your own configured instance of `@urql/exchange-retry` to the Storefront SDK's [`exchanges`](https://docs.nacelle.com/docs/storefront-sdk-major-version-2#exchanges) parameter.

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -47,14 +47,6 @@ export interface QueryParams<
 	variables?: QVariables | string;
 }
 
-export const retryStatusCodes = [
-	429, // Too Many Requests
-	500, // Internal Server Error
-	502, // Bad Gateway
-	503, // Service Unavailable
-	504 // Gateway Timeout
-];
-
 export const retryExchange = urqlRetryExchange({
 	maxDelayMs: 5000,
 	maxNumberAttempts: 5,

--- a/packages/storefront-sdk/src/client/index.ts
+++ b/packages/storefront-sdk/src/client/index.ts
@@ -60,12 +60,9 @@ export const retryExchange = urqlRetryExchange({
 	maxNumberAttempts: 5,
 	initialDelayMs: 500,
 	retryIf: (error) => {
-		// if it's a network error, retry if specific error codes
 		if (error.networkError) {
-			const statusCode = (error.response as globalThis.Response)?.status;
-			return retryStatusCodes.includes(statusCode);
+			return true;
 		} else {
-			// only retry if graphQL error is related to internal error
 			return error.graphQLErrors.some((err) =>
 				err.message.includes('INTERNAL_SERVER_ERROR')
 			);


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-10894](https://nacelle.atlassian.net/browse/ENG-10894) <!-- link to Jira ticket if one exists -->

> SDK should retry on network errors

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

The Storefront SDK wasn't retrying on certain network errors like `ETIMEDOUT`.

## What is this pull request doing?

This PR updates the default [urql request retry](https://formidable.com/open-source/urql/docs/advanced/retry-operations) configuration so that retries happen in response to any network error. Previously, retries only happened in response to certain HTTP error statuses. This made it difficult to respond to transient network issues like `ETIMEDOUT`.

This PR also adds a couple of new unit tests to achieve 100% coverage.

## How to Test

### End to end

This is a tough PR to test end-to-end. Instead of asking reviewers to follow steps, I'll provide my own testing results.

In a fresh project, I used [`nock`](https://github.com/nock/nock) to simulate an `ETIMEDOUT` error. I then added some logging to the `retryIf` configuration in `node_modules/@nacelle/storefront-sdk/dist/nacelle-storefront-sdk.js`. I made a content request and saw that the `ETIMEDOUT` led to the expected number of retries (5):

<img width="943" alt="storefront sdk demo retry" src="https://github.com/getnacelle/nacelle-js/assets/5732000/21b1c6ce-a31e-4120-a792-1e0373490c4f">

### Unit tests

1. Check out the `ENG-10894/storefront-sdk-retry-on-all-network-errors` branch
2. Navigate to `packages/storefront-sdk`
3. `npm run build` - it should build without errors
4. `npm run coverage` - all tests should pass with 100% coverage

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
- [x] You can follow your own "How to Test" instructions and get the expected result.
- [x] Created a [changeset](https://github.com/changesets/changesets) (if the change should appear in a changelog).

[ENG-10894]: https://nacelle.atlassian.net/browse/ENG-10894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ