### PR TITLE
feat: cache installed dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
           registry-url: 'https://npm.pkg.github.com/'
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,14 +11,21 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
+          repository: getnacelle/shared-code
+          path: shared-code
+          token: ${{ secrets.PACKAGES_TOKEN }}
+          fetch-depth: 0 # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-          registry-url: 'https://npm.pkg.github.com/'
+
+      - name: Cache dependencies
+        uses: ./shared-code/actions/common/cache
+        with:
+          runtime: 'nodejs'
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,7 @@ jobs:
         with:
           repository: getnacelle/shared-code
           path: shared-code
-          token: ${{ secrets.PACKAGES_TOKEN }}
-          fetch-depth: 0 # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,22 +8,18 @@ jobs:
   PR:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          repository: getnacelle/shared-code
-          path: shared-code
-          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
 
-      - name: Cache dependencies
-        uses: ./shared-code/actions/common/cache
+      - name: Cache NPM packages
+        uses: actions/cache@v2
         with:
-          runtime: 'nodejs'
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
 
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,20 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
+          repository: getnacelle/shared-code
+          path: shared-code
+          token: ${{ secrets.PACKAGES_TOKEN }}
+          fetch-depth: 0 # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          node-version: '18.x'
+
+      - name: Cache dependencies
+        uses: ./shared-code/actions/common/cache
+        with:
+          runtime: 'nodejs'
 
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          repository: getnacelle/shared-code
-          path: shared-code
-          ref: main
-          
+    
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
 
-      - name: Cache dependencies
-        uses: ./shared-code/actions/common/cache
+      - name: Cache NPM packages
+        uses: actions/cache@v2
         with:
-          runtime: 'nodejs'
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
 
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           repository: getnacelle/shared-code
           path: shared-code
-          token: ${{ secrets.PACKAGES_TOKEN }}
-          fetch-depth: 0 # This makes Actions fetch all git history to prevent issues with SonarCloud analysis
-
+          ref: main
+          
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
       - uses: dorny/paths-filter@v2
         id: changes

--- a/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package-lock.json
@@ -14,6 +14,7 @@
 				"@graphql-codegen/typescript": "^4.0.1",
 				"@graphql-codegen/typescript-operations": "^4.0.1",
 				"@graphql-typed-document-node/core": "^3.2.0",
+				"@nacelle/storefront-sdk": ">=2.0.3",
 				"@typescript-eslint/eslint-plugin": "^5.47.0",
 				"@typescript-eslint/parser": "^5.47.0",
 				"@vitest/coverage-c8": "^0.26.0",
@@ -32,14 +33,14 @@
 				"npm": ">=7"
 			},
 			"peerDependencies": {
-				"@nacelle/storefront-sdk": ">=2.0.3"
+				"@nacelle/storefront-sdk": "^2.0.3"
 			}
 		},
 		"node_modules/@0no-co/graphql.web": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
 			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
-			"peer": true,
+			"dev": true,
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
 			},
@@ -2538,7 +2539,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.3.tgz",
 			"integrity": "sha512-d8W+EEvEs1jDtSjD/YhQBPWcXxoR1T+QTzl29+DV6u4KiE5L8t8HbIj6pr8tussCgTFx/ngi+WqYIMmrawHi1g==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@urql/core": "^4.0.6",
 				"@urql/exchange-persisted": "^4.0.0",
@@ -3005,7 +3006,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
 			"integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@0no-co/graphql.web": "^1.0.1",
 				"wonka": "^6.3.2"
@@ -3015,7 +3016,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-4.1.0.tgz",
 			"integrity": "sha512-zB6RcAF1z1TVFOvU8lOv02iUCHpzYVwp5G0aX3PlW3MVE2eueezw9XMzvYsEjXE78Rzz04Irf450YV0dkxKAaQ==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@urql/core": ">=4.1.0",
 				"wonka": "^6.3.2"
@@ -3025,7 +3026,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
 			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -5114,7 +5115,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-			"devOptional": true,
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -8156,7 +8157,7 @@
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
 			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
-			"peer": true
+			"dev": true
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -8295,7 +8296,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz",
 			"integrity": "sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {}
 		},
 		"@ampproject/remapping": {
@@ -10021,7 +10022,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nacelle/storefront-sdk/-/storefront-sdk-2.0.3.tgz",
 			"integrity": "sha512-d8W+EEvEs1jDtSjD/YhQBPWcXxoR1T+QTzl29+DV6u4KiE5L8t8HbIj6pr8tussCgTFx/ngi+WqYIMmrawHi1g==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": "^4.0.6",
 				"@urql/exchange-persisted": "^4.0.0",
@@ -10353,7 +10354,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
 			"integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@0no-co/graphql.web": "^1.0.1",
 				"wonka": "^6.3.2"
@@ -10363,7 +10364,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-persisted/-/exchange-persisted-4.1.0.tgz",
 			"integrity": "sha512-zB6RcAF1z1TVFOvU8lOv02iUCHpzYVwp5G0aX3PlW3MVE2eueezw9XMzvYsEjXE78Rzz04Irf450YV0dkxKAaQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": ">=4.1.0",
 				"wonka": "^6.3.2"
@@ -10373,7 +10374,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.1.1.tgz",
 			"integrity": "sha512-+YX8c4J/nW/V7MZeNAAKzV7S79CVspLJ3vmJQXCUjBGuL0NtQE7PlXtOGWXE+ogySE1pHslPc1PIbdd7uml7NQ==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@urql/core": ">=4.0.0",
 				"wonka": "^6.3.2"
@@ -11961,7 +11962,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-			"devOptional": true,
+			"dev": true,
 			"peer": true
 		},
 		"graphql-config": {
@@ -14136,7 +14137,7 @@
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.2.tgz",
 			"integrity": "sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==",
-			"peer": true
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/storefront-sdk-plugins/commerce-queries/package.json
+++ b/packages/storefront-sdk-plugins/commerce-queries/package.json
@@ -56,7 +56,7 @@
 		"@graphql-codegen/typescript": "^4.0.1",
 		"@graphql-codegen/typescript-operations": "^4.0.1",
 		"@graphql-typed-document-node/core": "^3.2.0",
-		"@nacelle/storefront-sdk": ">=2.0.3",
+		"@nacelle/storefront-sdk": "^2.0.3",
 		"@typescript-eslint/eslint-plugin": "^5.47.0",
 		"@typescript-eslint/parser": "^5.47.0",
 		"@vitest/coverage-c8": "^0.26.0",
@@ -71,7 +71,7 @@
 		"vitest": "^0.26.3"
 	},
 	"peerDependencies": {
-		"@nacelle/storefront-sdk": ">=2.0.3"
+		"@nacelle/storefront-sdk": "^2.0.3"
 	},
 	"volta": {
 		"node": "18.12.1"


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the appropriate Conventional Commit type, (feat!:, docs:, refactor:, etc.).
  - After the prefix, start with a verb.
  - Give as much context as necessary and as little as possible.
-->

## Why are these changes introduced?

Addresses [ENG-11299](https://nacelle.atlassian.net/browse/ENG-11299) <!-- link to Jira ticket if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

> Cache nacelle-js package dependencies in workflows

## What is this pull request doing?

<!--
  Summary of the changes committed. Use examples or visual media (with alt text) to convey meaning.
-->

### CI/CD changes

This PR updates the `setup-node` action to version 4, which supports [dependency caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows). It also adds the necessary config settings (`cache` and `cache-dependency-path`).

Docs related to this change:
- https://github.com/actions/setup-node#caching-global-packages-data
- https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data (see **Using wildcard patterns to cache dependencies**)

### Dependency version range changes

In `@nacelle/commerce-queries-plugin`'s `package.json`, the dependency version operator (both peerDep and devDep) for `@nacelle/storefront-sdk` has been changed from `>=` to `^`. In contrast to the [`>=` comparator](https://github.com/npm/node-semver#ranges), [carat ranges](https://github.com/npm/node-semver#caret-ranges-123-025-004) allow an existing installation of a lesser minor or patch version to be considered valid.

With dependency caching enabled, this should allow us to publish changes to `@nacelle/storefront-sdk` and `@nacelle/commerce-queries-plugin` in the same changeset, because we circumvent `npm install` issues related to the not-yet-released minor/patch version of `@nacelle/storefront-sdk` (on which `@nacelle/commerce-queries-plugin` depends).

## Expected side-effects

We should expect the PR and Release workflows to run much faster in the future, because they won't be installing and bootstrapping the monorepo's dependencies on each run.

## How to test

There's no good way to test this locally. We'll need to evaluate the performance of this (in the context of fixing the aforementioned `@nacelle/storefront-sdk` x `@nacelle/commerce-queries-plugin` publishing issue) in production, the next time that these packages are both changed in the same changeset.

## Checklist

- [x] This Pull Request aligns with `nacelle-js`' [Code of Conduct](https://github.com/getnacelle/nacelle-js/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).


[ENG-11299]: https://nacelle.atlassian.net/browse/ENG-11299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ